### PR TITLE
Use new std::vec functions

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -38,7 +38,7 @@ impl<N> DMat<N> {
     #[inline]
     pub unsafe fn new_uninitialized(nrows: uint, ncols: uint) -> DMat<N> {
         let mut vec = vec::with_capacity(nrows * ncols);
-        vec::raw::set_len(&mut vec, nrows * ncols);
+        vec.set_len(nrows * ncols);
 
         DMat {
             nrows: nrows,
@@ -244,7 +244,7 @@ impl<N: Clone> DMat<N> {
     /// Just like `at` without bounds checking.
     #[inline]
     pub unsafe fn at_fast(&self, row: uint, col: uint) -> N {
-        vec::raw::get(self.mij, self.offset(row, col))
+        (*self.mij.unsafe_ref(self.offset(row, col))).clone()
     }
 }
 

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -52,7 +52,7 @@ impl<N: Zero + Clone> DVec<N> {
 impl<N: Clone> DVec<N> {
     /// Indexing without bounds checking.
     pub unsafe fn at_fast(&self, i: uint) -> N {
-        vec::raw::get(self.at, i)
+        (*self.at.unsafe_ref(i)).clone()
     }
 }
 
@@ -80,7 +80,7 @@ impl<N> DVec<N> {
     #[inline]
     pub unsafe fn new_uninitialized(dim: uint) -> DVec<N> {
         let mut vec = vec::with_capacity(dim);
-        vec::raw::set_len(&mut vec, dim);
+        vec.set_len(dim);
 
         DVec {
             at: vec


### PR DESCRIPTION
Rust changed the std::vec syntax. I'm new to Rust, so I'm not sure if this is correct. When running `make test` 2 tests failed on my system (don't know if they were failing before though).
