### PR TITLE
std::cast::transmute -> std::mem::transmute

### DIFF
--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -2,7 +2,7 @@
 
 #![allow(missing_doc)] // we allow missing to avoid having to document the mij components.
 
-use std::cast;
+use std::mem;
 use std::num::{One, Zero};
 use traits::operations::ApproxEq;
 use std::slice::{Items, MutItems};

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -19,13 +19,13 @@ macro_rules! at_fast_impl(
         impl<N: Clone> $t<N> {
             #[inline]
             pub unsafe fn at_fast(&self, (i, j): (uint, uint)) -> N {
-                (*cast::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)
+                (*mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)
                  .unsafe_ref(i + j * $dim)).clone()
             }
 
             #[inline]
             pub unsafe fn set_fast(&mut self, (i, j): (uint, uint), val: N) {
-                (*cast::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
+                (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
                  .unsafe_mut_ref(i + j * $dim)) = val
             }
         }
@@ -126,7 +126,7 @@ macro_rules! iterable_impl(
         #[inline]
         fn iter<'l>(&'l self) -> Items<'l, N> {
             unsafe {
-                cast::transmute::<&'l $t<N>, &'l [N, ..$dim * $dim]>(self).iter()
+                mem::transmute::<&'l $t<N>, &'l [N, ..$dim * $dim]>(self).iter()
             }
         }
     }
@@ -139,7 +139,7 @@ macro_rules! iterable_mut_impl(
         #[inline]
         fn mut_iter<'l>(&'l mut self) -> MutItems<'l, N> {
             unsafe {
-                cast::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim * $dim]>(self).mut_iter()
+                mem::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim * $dim]>(self).mut_iter()
             }
         }
     }
@@ -174,33 +174,33 @@ macro_rules! indexable_impl(
         #[inline]
         fn at(&self, (i, j): (uint, uint)) -> N {
             unsafe {
-                cast::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)[i + j * $dim].clone()
+                mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)[i + j * $dim].clone()
             }
         }
 
         #[inline]
         fn set(&mut self, (i, j): (uint, uint), val: N) {
             unsafe {
-                cast::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)[i + j * $dim] = val
+                mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)[i + j * $dim] = val
             }
         }
 
         #[inline]
         fn swap(&mut self, (i1, j1): (uint, uint), (i2, j2): (uint, uint)) {
             unsafe {
-              cast::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
+              mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
                 .swap(i1 + j1 * $dim, i2 + j2 * $dim)
             }
         }
 
         #[inline]
         unsafe fn unsafe_at(&self, (i, j): (uint, uint)) -> N {
-            (*cast::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self).unsafe_ref(i + j * $dim)).clone()
+            (*mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self).unsafe_ref(i + j * $dim)).clone()
         }
 
         #[inline]
         unsafe fn unsafe_set(&mut self, (i, j): (uint, uint), val: N) {
-            (*cast::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self).unsafe_mut_ref(i + j * $dim)) = val
+            (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self).unsafe_mut_ref(i + j * $dim)) = val
         }
     }
   )

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -1,4 +1,4 @@
-use std::cast;
+use std::mem;
 use std::num::{Zero, One, Float, Bounded};
 use std::slice::{Items, MutItems};
 use std::iter::{Iterator, FromIterator};
@@ -50,14 +50,14 @@ impl<N> vec::Vec0<N> {
 impl<N> Iterable<N> for vec::Vec0<N> {
     #[inline]
     fn iter<'l>(&'l self) -> Items<'l, N> {
-        unsafe { cast::transmute::<&'l vec::Vec0<N>, &'l [N, ..0]>(self).iter() }
+        unsafe { mem::transmute::<&'l vec::Vec0<N>, &'l [N, ..0]>(self).iter() }
     }
 }
 
 impl<N> IterableMut<N> for vec::Vec0<N> {
     #[inline]
     fn mut_iter<'l>(&'l mut self) -> MutItems<'l, N> {
-        unsafe { cast::transmute::<&'l mut vec::Vec0<N>, &'l mut [N, ..0]>(self).mut_iter() }
+        unsafe { mem::transmute::<&'l mut vec::Vec0<N>, &'l mut [N, ..0]>(self).mut_iter() }
     }
 }
 

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -2,7 +2,7 @@
 
 #![allow(missing_doc)] // we allow missing to avoid having to document the vector components.
 
-use std::cast;
+use std::mem;
 use std::num::{Zero, One, Float, Bounded};
 use std::slice::{Items, MutItems};
 use std::iter::{Iterator, FromIterator};

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -21,14 +21,14 @@ macro_rules! at_fast_impl(
             /// Unsafe read access to a vector element by index.
             #[inline]
             pub unsafe fn at_fast(&self, i: uint) -> N {
-                (*cast::transmute::<&$t<N>, &[N, ..$dim]>(self)
+                (*mem::transmute::<&$t<N>, &[N, ..$dim]>(self)
                  .unsafe_ref(i)).clone()
             }
 
             /// Unsafe write access to a vector element by index.
             #[inline]
             pub unsafe fn set_fast(&mut self, i: uint, val: N) {
-                (*cast::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).unsafe_mut_ref(i)) = val
+                (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).unsafe_mut_ref(i)) = val
             }
         }
     )
@@ -154,32 +154,32 @@ macro_rules! indexable_impl(
             #[inline]
             fn at(&self, i: uint) -> N {
                 unsafe {
-                    cast::transmute::<&$t<N>, &[N, ..$dim]>(self)[i].clone()
+                    mem::transmute::<&$t<N>, &[N, ..$dim]>(self)[i].clone()
                 }
             }
 
             #[inline]
             fn set(&mut self, i: uint, val: N) {
                 unsafe {
-                    cast::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self)[i] = val
+                    mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self)[i] = val
                 }
             }
 
             #[inline]
             fn swap(&mut self, i1: uint, i2: uint) {
                 unsafe {
-                    cast::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).swap(i1, i2)
+                    mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).swap(i1, i2)
                 }
             }
 
             #[inline]
             unsafe fn unsafe_at(&self, i: uint) -> N {
-                (*cast::transmute::<&$t<N>, &[N, ..$dim]>(self).unsafe_ref(i)).clone()
+                (*mem::transmute::<&$t<N>, &[N, ..$dim]>(self).unsafe_ref(i)).clone()
             }
 
             #[inline]
             unsafe fn unsafe_set(&mut self, i: uint, val: N) {
-                (*cast::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).unsafe_mut_ref(i)) = val
+                (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).unsafe_mut_ref(i)) = val
             }
         }
     )
@@ -206,7 +206,7 @@ macro_rules! iterable_impl(
             #[inline]
             fn iter<'l>(&'l self) -> Items<'l, N> {
                 unsafe {
-                    cast::transmute::<&'l $t<N>, &'l [N, ..$dim]>(self).iter()
+                    mem::transmute::<&'l $t<N>, &'l [N, ..$dim]>(self).iter()
                 }
             }
         }
@@ -219,7 +219,7 @@ macro_rules! iterable_mut_impl(
             #[inline]
             fn mut_iter<'l>(&'l mut self) -> MutItems<'l, N> {
                 unsafe {
-                    cast::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim]>(self).mut_iter()
+                    mem::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim]>(self).mut_iter()
                 }
             }
         }


### PR DESCRIPTION
The module std::cast has been renamed std::mem

mozilla/rust@f94d671
