### PR TITLE
Compile with nightlies

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -12,8 +12,6 @@ use traits::operations::{Inv, Transpose, Mean, Cov};
 use traits::structure::{Cast, ColSlice, RowSlice, Eye, Indexable};
 use std::fmt::{Show, Formatter, Result};
 
-#[doc(hidden)]
-mod metal;
 
 /// Matrix with dimensions unknown at compile-time.
 #[deriving(TotalEq, Eq, Clone)]
@@ -50,7 +48,7 @@ impl<N> DMat<N> {
 
 impl<N: Zero + Clone> DMat<N> {
     /// Builds a matrix filled with zeros.
-    /// 
+    ///
     /// # Arguments
     ///   * `dim` - The dimension of the matrix. A `dim`-dimensional matrix contains `dim * dim`
     ///   components.
@@ -183,7 +181,7 @@ impl<N> DMat<N> {
 
 impl<N: One + Zero + Clone> Eye for DMat<N> {
     /// Builds an identity matrix.
-    /// 
+    ///
     /// # Arguments
     /// * `dim` - The dimension of the matrix. A `dim`-dimensional matrix contains `dim * dim`
     /// components.
@@ -377,7 +375,7 @@ Inv for DMat<N> {
                 n0 = n0 + 1;
             }
 
-            if n0 == dim { 
+            if n0 == dim {
                 return false
             }
 

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -11,9 +11,6 @@ use std::iter::FromIterator;
 use traits::geometry::{Dot, Norm};
 use traits::structure::{Iterable, IterableMut, Indexable};
 
-#[doc(hidden)]
-mod metal;
-
 /// Vector with a dimension unknown at compile-time.
 #[deriving(TotalEq, Eq, Show, Clone)]
 pub struct DVec<N> {
@@ -33,7 +30,7 @@ sub_redispatch_impl!(DVec, DVecSubRhs)
 
 impl<N: Zero + Clone> DVec<N> {
     /// Builds a vector filled with zeros.
-    /// 
+    ///
     /// # Arguments
     /// * `dim` - The dimension of the vector.
     #[inline]
@@ -88,7 +85,7 @@ impl<N: Clone> Indexable<uint, N> for DVec<N> {
 
 impl<N: One + Clone> DVec<N> {
     /// Builds a vector filled with ones.
-    /// 
+    ///
     /// # Arguments
     /// * `dim` - The dimension of the vector.
     #[inline]
@@ -291,7 +288,7 @@ impl<N: Num + Clone> Dot<N> for DVec<N> {
         }
 
         res
-    } 
+    }
 
     #[inline]
     fn sub_dot(a: &DVec<N>, b: &DVec<N>, c: &DVec<N>) -> N {
@@ -302,7 +299,7 @@ impl<N: Num + Clone> Dot<N> for DVec<N> {
         }
 
         res
-    } 
+    }
 }
 
 impl<N: Float + Clone> Norm<N> for DVec<N> {

--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -13,8 +13,6 @@ use traits::geometry::{RotationMatrix, Rotation, Rotate, AbsoluteRotate, Transfo
 use structs::vec::{Vec1, Vec2, Vec3, Vec4, Vec2MulRhs, Vec3MulRhs, Vec4MulRhs};
 use structs::rot::{Rot2, Rot3, Rot4};
 
-mod metal;
-mod iso_macros;
 
 /// Two dimensional isometry.
 ///
@@ -68,7 +66,7 @@ impl<N: Clone + Float> Iso3<N> {
     }
 
     /// Reorient and translate this transformation such that its local `z` axis points to a given
-    /// direction. 
+    /// direction.
     ///
     /// # Arguments
     ///   * eye - The new translation of the transformation.

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -15,8 +15,6 @@ use traits::structure::{Cast, Row, Col, Iterable, IterableMut, Dim, Indexable,
 use traits::operations::{Absolute, Transpose, Inv, Outer};
 use traits::geometry::{ToHomogeneous, FromHomogeneous};
 
-mod metal;
-mod mat_macros;
 
 /// Special identity matrix. All its operation are no-ops.
 #[deriving(TotalEq, Eq, Decodable, Clone, Rand, Show)]

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -16,11 +16,16 @@ pub use self::mat::{Mat1MulRhs, Mat2MulRhs, Mat3MulRhs, Mat4MulRhs, Mat5MulRhs, 
                     Mat1AddRhs, Mat2AddRhs, Mat3AddRhs, Mat4AddRhs, Mat5AddRhs, Mat6AddRhs,
                     Mat1SubRhs, Mat2SubRhs, Mat3SubRhs, Mat4SubRhs, Mat5SubRhs, Mat6SubRhs};
 
+mod metal;
 mod dmat;
 mod dvec;
+mod vec_macros;
 mod vec;
+mod mat_macros;
 mod mat;
+mod rot_macros;
 mod rot;
+mod iso_macros;
 mod iso;
 
 // specialization for some 1d, 2d and 3d operations

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -11,8 +11,6 @@ use traits::operations::{Absolute, Inv, Transpose, ApproxEq};
 use structs::vec::{Vec1, Vec2, Vec3, Vec4, Vec2MulRhs, Vec3MulRhs, Vec4MulRhs};
 use structs::mat::{Mat2, Mat3, Mat4, Mat5};
 
-mod metal;
-mod rot_macros;
 
 /// Two dimensional rotation matrix.
 #[deriving(TotalEq, Eq, Encodable, Decodable, Clone, Show, Hash)]
@@ -161,7 +159,7 @@ impl<N: Clone + Float> Rot3<N> {
             xaxis.z        , yaxis.z        , zaxis.z)
     }
 
-    /// Reorient this matrix such that its local `z` axis points to a given point. 
+    /// Reorient this matrix such that its local `z` axis points to a given point.
     ///
     /// # Arguments
     ///   * at - The point to look at. It is also the direction the matrix `y` axis will be aligned
@@ -273,7 +271,7 @@ pub struct Rot4<N> {
 //     pub fn new(left_iso: Quat<N>, right_iso: Quat<N>) -> Rot4<N> {
 //         assert!(left_iso.is_unit());
 //         assert!(right_iso.is_unright);
-// 
+//
 //         let mat_left_iso = Mat4::new(
 //             left_iso.x, -left_iso.y, -left_iso.z, -left_iso.w,
 //             left_iso.y,  left_iso.x, -left_iso.w,  left_iso.z,
@@ -284,7 +282,7 @@ pub struct Rot4<N> {
 //             right_iso.y,  right_iso.x,  right_iso.w, -right_iso.z,
 //             right_iso.z, -right_iso.w,  right_iso.x,  right_iso.y,
 //             right_iso.w,  right_iso.z, -right_iso.y,  right_iso.x);
-// 
+//
 //         Rot4 {
 //             submat: mat_left_iso * mat_right_iso
 //         }

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -12,8 +12,6 @@ use traits::geometry::{Transform, Rotate, FromHomogeneous, ToHomogeneous, Dot, N
                        Translation, Translate};
 use traits::structure::{Basis, Cast, Dim, Indexable, Iterable, IterableMut};
 
-mod metal;
-mod vec_macros;
 
 /// Vector of dimension 0.
 #[deriving(TotalEq, Eq, Decodable, Clone, Rand, Zero, Show)]


### PR DESCRIPTION
Hello,

Here is a patch to fix issue #10 I opened this morning (at least it was the morning in France ^^)

It's not really idiomatic rust, but at least does it compile.

I think one problem is the overlapping of the operator-overloading macros. Maybe would it be better to `include!` them directly in the related file? I'm a Rust newb, so maybe it's plain stupid, but at least it wouldn't pollute the global namespace.
