### PR TITLE
Fix coordinate calculation in DMat::from_fn().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 doc
 lib
 TODO
+target/

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -139,7 +139,7 @@ impl<N> DMat<N> {
         DMat {
             nrows: nrows,
             ncols: ncols,
-            mij:   Vec::from_fn(nrows * ncols, |i| { let m = i % ncols; f(m, m - i * ncols) })
+            mij:   Vec::from_fn(nrows * ncols, |i| f(i % nrows, i / nrows))
         }
     }
 

--- a/src/tests/mat.rs
+++ b/src/tests/mat.rs
@@ -266,3 +266,16 @@ fn test_decomp_qr_mat5() {
 fn test_decomp_qr_mat6() {
     test_decomp_qr_impl!(Mat6<f64>);
 }
+
+
+#[test]
+fn test_from_fn() {
+    let actual: DMat<uint> = DMat::from_fn( 3, 4, 
+                                           |i,j| 10*i + j);
+    let expected: DMat<uint> = DMat::from_row_vec(3, 4, 
+                                                  [0_0, 0_1, 0_2, 0_3,
+                                                   1_0, 1_1, 1_2, 1_3,
+                                                   2_0, 2_1, 2_2, 2_3 ]);
+
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Hello, I was playing with your library and noticed that I was getting incorrect coordinates to my `DMat::from_fn` builder fn on the order of 2^64, and suspected a uint underflow.  

I changed the coordinate calculations in `DMat::from_fn` to `(i % nrows, i / nrows)`.  There's probably some slick way to avoid the integer division, but this at least works.

I also added a unit test to verify the new behavior.
