### PR TITLE
Implement assertion macros for ApproxEq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ pub use linalg::{
 mod structs;
 mod traits;
 mod linalg;
+mod macros;
 
 // mod lower_triangular;
 // mod chol;

--- a/src/macros/assert.rs
+++ b/src/macros/assert.rs
@@ -1,0 +1,28 @@
+/// Asserts approximate equality within a given tolerance of two values with the
+/// `ApproxEq` trait.
+#[macro_export]
+macro_rules! assert_approx_eq_eps(
+    ($given: expr, $expected: expr, $eps: expr) => ({
+        let eps = &($eps);
+        let (given_val, expected_val) = (&($given), &($expected));
+        if !ApproxEq::approx_eq_eps(given_val, expected_val, eps) {
+            panic!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
+                *given_val, *expected_val, *eps
+            )
+        }
+    })
+)
+
+/// Asserts approximate equality of two values with the `ApproxEq` trait.
+#[macro_export]
+macro_rules! assert_approx_eq(
+    ($given: expr, $expected: expr) => ({
+        let (given_val, expected_val) = (&($given), &($expected));
+        if !ApproxEq::approx_eq(given_val, expected_val) {
+            panic!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
+                *given_val, *expected_val,
+                ApproxEq::approx_epsilon(Some(*given_val))
+            )
+        }
+    })
+)

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,1 @@
+mod assert;

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -1,0 +1,35 @@
+//! Assertion macro tests
+
+#![feature(phase)]
+
+#[phase(plugin)]
+extern crate nalgebra;
+extern crate nalgebra;
+
+use nalgebra::{ApproxEq, Vec2};
+
+#[test]
+fn assert_approx_eq_f64() {
+    let a = 1.0f64;
+    let b = 1.0f64 + 1.0e-12f64;
+    assert_approx_eq!(a, b);
+}
+
+#[test]
+#[should_fail]
+fn assert_approx_eq_vec2_f32_fail() {
+    let a = Vec2::new(1.0f32, 0.0);
+    let b = Vec2::new(1.1f32, 0.1);
+    assert_approx_eq!(a, b);
+}
+
+#[test]
+fn assert_approx_eq_eps_f32() {
+    assert_approx_eq_eps!(1.0f32, 1.1, 0.2);
+}
+
+#[test]
+#[should_fail]
+fn assert_approx_eq_eps_f64_fail() {
+    assert_approx_eq_eps!(1.0f64, 1.1, 0.05);
+}


### PR DESCRIPTION
These macros yield readable error messages as test assertions for ApproxEq
types. They can be invoked as:

```
assert_approx_eq!(a, b);
assert_approx_eq_eps!(a, b, eps);
```

Fixes #40.
