### PR TITLE
Use object-oriented style for trait methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,13 +326,13 @@ pub fn center<N: BaseFloat, P: FloatPnt<N, V>, V>(a: &P, b: &P) -> P {
 /// Returns the distance between two points.
 #[inline(always)]
 pub fn dist<N: BaseFloat, P: FloatPnt<N, V>, V: Norm<N>>(a: &P, b: &P) -> N {
-    FloatPnt::<N, V>::dist(a, b)
+    a.dist(b)
 }
 
 /// Returns the squared distance between two points.
 #[inline(always)]
 pub fn sqdist<N: BaseFloat, P: FloatPnt<N, V>, V: Norm<N>>(a: &P, b: &P) -> N {
-    FloatPnt::<N, V>::sqdist(a, b)
+    a.sqdist(b)
 }
 
 /*

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -217,36 +217,26 @@ macro_rules! dvec_impl(
 
         impl<N: BaseNum + Clone> Dot<N> for $dvec<N> {
             #[inline]
-            fn dot(a: &$dvec<N>, b: &$dvec<N>) -> N {
-                assert!(a.len() == b.len());
-
+            fn dot(&self, other: &$dvec<N>) -> N {
+                assert!(self.len() == other.len());
                 let mut res: N = ::zero();
-
-                for i in range(0u, a.len()) {
-                    res = res + unsafe { a.unsafe_at(i) * b.unsafe_at(i) };
+                for i in range(0u, self.len()) {
+                    res = res + unsafe { self.unsafe_at(i) * other.unsafe_at(i) };
                 }
-
                 res
             }
         }
 
         impl<N: BaseFloat + Clone> Norm<N> for $dvec<N> {
             #[inline]
-            fn sqnorm(v: &$dvec<N>) -> N {
-                Dot::dot(v, v)
+            fn sqnorm(&self) -> N {
+                Dot::dot(self, self)
             }
 
             #[inline]
-            fn norm(v: &$dvec<N>) -> N {
-                Norm::sqnorm(v).sqrt()
-            }
-
-            #[inline]
-            fn normalize_cpy(v: &$dvec<N>) -> $dvec<N> {
-                let mut res : $dvec<N> = v.clone();
-
+            fn normalize_cpy(&self) -> $dvec<N> {
+                let mut res : $dvec<N> = self.clone();
                 let _ = res.normalize();
-
                 res
             }
 
@@ -269,16 +259,8 @@ macro_rules! dvec_impl(
             }
 
             #[inline]
-            fn approx_eq(a: &$dvec<N>, b: &$dvec<N>) -> bool {
-                let zip = a.as_slice().iter().zip(b.as_slice().iter());
-
-                zip.all(|(a, b)| ApproxEq::approx_eq(a, b))
-            }
-
-            #[inline]
-            fn approx_eq_eps(a: &$dvec<N>, b: &$dvec<N>, epsilon: &N) -> bool {
-                let zip = a.as_slice().iter().zip(b.as_slice().iter());
-
+            fn approx_eq_eps(&self, other: &$dvec<N>, epsilon: &N) -> bool {
+                let zip = self.as_slice().iter().zip(other.as_slice().iter());
                 zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
             }
         }

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -113,8 +113,8 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn append_translation_cpy(iso: &$t<N>, t: &$tv<N>) -> $t<N> {
-                $t::new_with_rotmat(*t + iso.translation, iso.rotation.clone())
+            fn append_translation_cpy(&self, t: &$tv<N>) -> $t<N> {
+                $t::new_with_rotmat(*t + self.translation, self.rotation.clone())
             }
 
             #[inline]
@@ -123,8 +123,8 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn prepend_translation_cpy(iso: &$t<N>, t: &$tv<N>) -> $t<N> {
-                $t::new_with_rotmat(iso.translation + iso.rotation * *t, iso.rotation.clone())
+            fn prepend_translation_cpy(&self, t: &$tv<N>) -> $t<N> {
+                $t::new_with_rotmat(self.translation + self.rotation * *t, self.rotation.clone())
             }
 
             #[inline]
@@ -173,10 +173,10 @@ macro_rules! rotation_impl(
             }
 
             #[inline]
-            fn append_rotation_cpy(t: &$t<N>, rot: &$tav<N>) -> $t<N> {
+            fn append_rotation_cpy(&self, rot: &$tav<N>) -> $t<N> {
                 let delta = $trot::new(rot.clone());
 
-                $t::new_with_rotmat(delta * t.translation, delta * t.rotation)
+                $t::new_with_rotmat(delta * self.translation, delta * self.rotation)
             }
 
             #[inline]
@@ -187,10 +187,10 @@ macro_rules! rotation_impl(
             }
 
             #[inline]
-            fn prepend_rotation_cpy(t: &$t<N>, rot: &$tav<N>) -> $t<N> {
+            fn prepend_rotation_cpy(&self, rot: &$tav<N>) -> $t<N> {
                 let delta = $trot::new(rot.clone());
 
-                $t::new_with_rotmat(t.translation.clone(), t.rotation * delta)
+                $t::new_with_rotmat(self.translation.clone(), self.rotation * delta)
             }
 
             #[inline]
@@ -234,16 +234,16 @@ macro_rules! transformation_impl(
                 *self = *t * *self
             }
 
-            fn append_transformation_cpy(iso: &$t<N>, t: &$t<N>) -> $t<N> {
-                *t * *iso
+            fn append_transformation_cpy(&self, t: &$t<N>) -> $t<N> {
+                *t * *self
             }
 
             fn prepend_transformation(&mut self, t: &$t<N>) {
                 *self = *self * *t
             }
 
-            fn prepend_transformation_cpy(iso: &$t<N>, t: &$t<N>) -> $t<N> {
-                *iso * *t
+            fn prepend_transformation_cpy(&self, t: &$t<N>) -> $t<N> {
+                *self * *t
             }
 
             fn set_transformation(&mut self, t: $t<N>) {
@@ -276,17 +276,14 @@ macro_rules! inv_impl(
             fn inv(&mut self) -> bool {
                 self.rotation.inv();
                 self.translation = self.rotation * -self.translation;
-
                 // always succeed
                 true
             }
 
             #[inline]
-            fn inv_cpy(m: &$t<N>) -> Option<$t<N>> {
-                let mut res = m.clone();
-
+            fn inv_cpy(&self) -> Option<$t<N>> {
+                let mut res = self.clone();
                 res.inv();
-
                 // always succeed
                 Some(res)
             }
@@ -320,15 +317,9 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
-            fn approx_eq(a: &$t<N>, b: &$t<N>) -> bool {
-                ApproxEq::approx_eq(&a.rotation, &b.rotation) &&
-                    ApproxEq::approx_eq(&a.translation, &b.translation)
-            }
-
-            #[inline]
-            fn approx_eq_eps(a: &$t<N>, b: &$t<N>, epsilon: &N) -> bool {
-                ApproxEq::approx_eq_eps(&a.rotation, &b.rotation, epsilon) &&
-                    ApproxEq::approx_eq_eps(&a.translation, &b.translation, epsilon)
+            fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
+                ApproxEq::approx_eq_eps(&self.rotation, &other.rotation, epsilon) &&
+                    ApproxEq::approx_eq_eps(&self.translation, &other.translation, epsilon)
             }
         }
     )

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -513,9 +513,8 @@ macro_rules! inv_impl(
     impl<N: Clone + BaseNum>
     Inv for $t<N> {
         #[inline]
-        fn inv_cpy(m: &$t<N>) -> Option<$t<N>> {
-            let mut res : $t<N> = m.clone();
-
+        fn inv_cpy(&self) -> Option<$t<N>> {
+            let mut res : $t<N> = self.clone();
             if res.inv() {
                 Some(res)
             }
@@ -596,11 +595,9 @@ macro_rules! transpose_impl(
   ($t: ident, $dim: expr) => (
     impl<N: Clone> Transpose for $t<N> {
         #[inline]
-        fn transpose_cpy(m: &$t<N>) -> $t<N> {
-            let mut res = m.clone();
-
+        fn transpose_cpy(&self) -> $t<N> {
+            let mut res = self.clone();
             res.transpose();
-
             res
         }
 
@@ -625,16 +622,8 @@ macro_rules! approx_eq_impl(
         }
 
         #[inline]
-        fn approx_eq(a: &$t<N>, b: &$t<N>) -> bool {
-            let zip = a.iter().zip(b.iter());
-
-            zip.all(|(a, b)| ApproxEq::approx_eq(a, b))
-        }
-
-        #[inline]
-        fn approx_eq_eps(a: &$t<N>, b: &$t<N>, epsilon: &N) -> bool {
-            let zip = a.iter().zip(b.iter());
-
+        fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
+            let zip = self.iter().zip(other.iter());
             zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
         }
     }
@@ -686,15 +675,13 @@ macro_rules! outer_impl(
     ($t: ident, $m: ident) => (
         impl<N: Clone + Mul<N, N> + Zero> Outer<$m<N>> for $t<N> {
             #[inline]
-            fn outer(a: &$t<N>, b: &$t<N>) -> $m<N> {
+            fn outer(&self, other: &$t<N>) -> $m<N> {
                 let mut res: $m<N> = ::zero();
-
                 for i in range(0u, Dim::dim(None::<$t<N>>)) {
                     for j in range(0u, Dim::dim(None::<$t<N>>)) {
-                        res.set((i, j), a.at(i) * b.at(j))
+                        res.set((i, j), self.at(i) * other.at(j))
                     }
                 }
-
                 res
             }
         }
@@ -705,8 +692,8 @@ macro_rules! eigen_qr_impl(
     ($t: ident, $v: ident) => (
         impl<N> EigenQR<N, $v<N>> for $t<N>
             where N: BaseNum + One + Zero + BaseFloat + ApproxEq<N> + Clone {
-            fn eigen_qr(m: &$t<N>, eps: &N, niter: uint) -> ($t<N>, $v<N>) {
-                linalg::eigen_qr(m, eps, niter)
+            fn eigen_qr(&self, eps: &N, niter: uint) -> ($t<N>, $v<N>) {
+                linalg::eigen_qr(self, eps, niter)
             }
         }
     )

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -66,9 +66,8 @@ impl<N: Neg<N>> Quat<N> {
 
 impl<N: BaseFloat + ApproxEq<N> + Clone> Inv for Quat<N> {
     #[inline]
-    fn inv_cpy(m: &Quat<N>) -> Option<Quat<N>> {
-        let mut res = m.clone();
-
+    fn inv_cpy(&self) -> Option<Quat<N>> {
+        let mut res = self.clone();
         if res.inv() {
             Some(res)
         }
@@ -98,14 +97,14 @@ impl<N: BaseFloat + ApproxEq<N> + Clone> Inv for Quat<N> {
 
 impl<N: BaseFloat> Norm<N> for Quat<N> {
     #[inline]
-    fn sqnorm(q: &Quat<N>) -> N {
-        q.w * q.w + q.i * q.i + q.j * q.j + q.k * q.k
+    fn sqnorm(&self) -> N {
+        self.w * self.w + self.i * self.i + self.j * self.j + self.k * self.k
     }
 
     #[inline]
-    fn normalize_cpy(v: &Quat<N>) -> Quat<N> {
-        let n = Norm::norm(v);
-        Quat::new(v.w / n, v.i / n, v.j / n, v.k / n)
+    fn normalize_cpy(&self) -> Quat<N> {
+        let n = self.norm();
+        Quat::new(self.w / n, self.i / n, self.j / n, self.k / n)
     }
 
     #[inline]
@@ -261,9 +260,8 @@ impl<N: BaseNum + Clone> One for UnitQuat<N> {
 
 impl<N: Clone + Neg<N>> Inv for UnitQuat<N> {
     #[inline]
-    fn inv_cpy(m: &UnitQuat<N>) -> Option<UnitQuat<N>> {
-        let mut cpy = m.clone();
-
+    fn inv_cpy(&self) -> Option<UnitQuat<N>> {
+        let mut cpy = self.clone();
         cpy.inv();
         Some(cpy)
     }
@@ -290,13 +288,8 @@ impl<N: ApproxEq<N>> ApproxEq<N> for UnitQuat<N> {
     }
 
     #[inline]
-    fn approx_eq(a: &UnitQuat<N>, b: &UnitQuat<N>) -> bool {
-        ApproxEq::approx_eq(&a.q, &b.q)
-    }
-
-    #[inline]
-    fn approx_eq_eps(a: &UnitQuat<N>, b: &UnitQuat<N>, eps: &N) -> bool {
-        ApproxEq::approx_eq_eps(&a.q, &b.q, eps)
+    fn approx_eq_eps(&self, other: &UnitQuat<N>, eps: &N) -> bool {
+        ApproxEq::approx_eq_eps(&self.q, &other.q, eps)
     }
 }
 
@@ -379,8 +372,8 @@ impl<N: BaseFloat + Clone> Rotation<Vec3<N>> for UnitQuat<N> {
     }
 
     #[inline]
-    fn append_rotation_cpy(t: &UnitQuat<N>, amount: &Vec3<N>) -> UnitQuat<N> {
-        *t * UnitQuat::new(amount.clone())
+    fn append_rotation_cpy(&self, amount: &Vec3<N>) -> UnitQuat<N> {
+        *self * UnitQuat::new(amount.clone())
     }
 
     #[inline]
@@ -389,8 +382,8 @@ impl<N: BaseFloat + Clone> Rotation<Vec3<N>> for UnitQuat<N> {
     }
 
     #[inline]
-    fn prepend_rotation_cpy(t: &UnitQuat<N>, amount: &Vec3<N>) -> UnitQuat<N> {
-        UnitQuat::new(amount.clone()) * *t
+    fn prepend_rotation_cpy(&self, amount: &Vec3<N>) -> UnitQuat<N> {
+        UnitQuat::new(amount.clone()) * *self
     }
 
     #[inline]

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -46,8 +46,8 @@ impl<N: BaseFloat + Clone> Rotation<Vec1<N>> for Rot2<N> {
     }
 
     #[inline]
-    fn append_rotation_cpy(t: &Rot2<N>, rot: &Vec1<N>) -> Rot2<N> {
-        Rot2::new(rot.clone()) * *t
+    fn append_rotation_cpy(&self, rot: &Vec1<N>) -> Rot2<N> {
+        Rot2::new(rot.clone()) * *self
     }
 
     #[inline]
@@ -56,8 +56,8 @@ impl<N: BaseFloat + Clone> Rotation<Vec1<N>> for Rot2<N> {
     }
 
     #[inline]
-    fn prepend_rotation_cpy(t: &Rot2<N>, rot: &Vec1<N>) -> Rot2<N> {
-        *t * Rot2::new(rot.clone())
+    fn prepend_rotation_cpy(&self, rot: &Vec1<N>) -> Rot2<N> {
+        *self * Rot2::new(rot.clone())
     }
 
     #[inline]
@@ -249,8 +249,8 @@ Rotation<Vec3<N>> for Rot3<N> {
     }
 
     #[inline]
-    fn append_rotation_cpy(t: &Rot3<N>, axisangle: &Vec3<N>) -> Rot3<N> {
-        Rot3::new(axisangle.clone()) * *t
+    fn append_rotation_cpy(&self, axisangle: &Vec3<N>) -> Rot3<N> {
+        Rot3::new(axisangle.clone()) * *self
     }
 
     #[inline]
@@ -259,8 +259,8 @@ Rotation<Vec3<N>> for Rot3<N> {
     }
 
     #[inline]
-    fn prepend_rotation_cpy(t: &Rot3<N>, axisangle: &Vec3<N>) -> Rot3<N> {
-        *t * Rot3::new(axisangle.clone())
+    fn prepend_rotation_cpy(&self, axisangle: &Vec3<N>) -> Rot3<N> {
+        *self * Rot3::new(axisangle.clone())
     }
 
     #[inline]
@@ -351,7 +351,7 @@ Rotation<Vec4<N>> for Rot4<N> {
     }
 
     #[inline]
-    fn append_rotation_cpy(_: &Rot4<N>, _: &Vec4<N>) -> Rot4<N> {
+    fn append_rotation_cpy(&self, _: &Vec4<N>) -> Rot4<N> {
         panic!("Not yet implemented")
     }
 
@@ -361,7 +361,7 @@ Rotation<Vec4<N>> for Rot4<N> {
     }
 
     #[inline]
-    fn prepend_rotation_cpy(_: &Rot4<N>, _: &Vec4<N>) -> Rot4<N> {
+    fn prepend_rotation_cpy(&self, _: &Vec4<N>) -> Rot4<N> {
         panic!("Not yet implemented")
     }
 

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -157,9 +157,9 @@ macro_rules! inv_impl(
             }
 
             #[inline]
-            fn inv_cpy(m: &$t<N>) -> Option<$t<N>> {
+            fn inv_cpy(&self) -> Option<$t<N>> {
                 // always succeed
-                Some(Transpose::transpose_cpy(m))
+                Some(self.transpose_cpy())
             }
         }
     )
@@ -169,8 +169,8 @@ macro_rules! transpose_impl(
     ($t: ident) => (
         impl<N: Clone> Transpose for $t<N> {
             #[inline]
-            fn transpose_cpy(m: &$t<N>) -> $t<N> {
-                $t { submat: Transpose::transpose_cpy(&m.submat) }
+            fn transpose_cpy(&self) -> $t<N> {
+                $t { submat: Transpose::transpose_cpy(&self.submat) }
             }
 
             #[inline]
@@ -257,13 +257,13 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
-            fn approx_eq(a: &$t<N>, b: &$t<N>) -> bool {
-                ApproxEq::approx_eq(&a.submat, &b.submat)
+            fn approx_eq(&self, other: &$t<N>) -> bool {
+                ApproxEq::approx_eq(&self.submat, &other.submat)
             }
 
             #[inline]
-            fn approx_eq_eps(a: &$t<N>, b: &$t<N>, epsilon: &N) -> bool {
-                ApproxEq::approx_eq_eps(&a.submat, &b.submat, epsilon)
+            fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
+                ApproxEq::approx_eq_eps(&self.submat, &other.submat, epsilon)
             }
         }
     )

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -12,7 +12,7 @@ impl One for mat::Identity {
 }
 
 impl Inv for mat::Identity {
-    fn inv_cpy(_: &mat::Identity) -> Option<mat::Identity> {
+    fn inv_cpy(&self) -> Option<mat::Identity> {
         Some(mat::Identity::new())
     }
 
@@ -30,7 +30,7 @@ impl<T: Clone> Mul<T, T> for mat::Identity {
 
 impl Transpose for mat::Identity {
     #[inline]
-    fn transpose_cpy(_: &mat::Identity) -> mat::Identity {
+    fn transpose_cpy(&self) -> mat::Identity {
         mat::Identity::new()
     }
 
@@ -56,7 +56,7 @@ impl<V: Zero> Translation<V> for mat::Identity {
     }
 
     #[inline]
-    fn append_translation_cpy(_: &mat::Identity, _: &V) -> mat::Identity {
+    fn append_translation_cpy(&self, _: &V) -> mat::Identity {
         panic!("Attempted to translate the identity matrix.")
     }
 
@@ -66,7 +66,7 @@ impl<V: Zero> Translation<V> for mat::Identity {
     }
 
     #[inline]
-    fn prepend_translation_cpy(_: &mat::Identity, _: &V) -> mat::Identity {
+    fn prepend_translation_cpy(&self, _: &V) -> mat::Identity {
         panic!("Attempted to translate the identity matrix.")
     }
 
@@ -105,7 +105,7 @@ impl<V: Zero> Rotation<V> for mat::Identity {
     }
 
     #[inline]
-    fn append_rotation_cpy(_: &mat::Identity, _: &V) -> mat::Identity {
+    fn append_rotation_cpy(&self, _: &V) -> mat::Identity {
         panic!("Attempted to rotate the identity matrix.")
     }
 
@@ -115,7 +115,7 @@ impl<V: Zero> Rotation<V> for mat::Identity {
     }
 
     #[inline]
-    fn prepend_rotation_cpy(_: &mat::Identity, _: &V) -> mat::Identity {
+    fn prepend_rotation_cpy(&self, _: &V) -> mat::Identity {
         panic!("Attempted to rotate the identity matrix.")
     }
 
@@ -161,7 +161,7 @@ impl<M: One> Transformation<M> for mat::Identity {
     }
 
     #[inline]
-    fn append_transformation_cpy(_: &mat::Identity, _: &M) -> mat::Identity {
+    fn append_transformation_cpy(&self, _: &M) -> mat::Identity {
         panic!("Attempted to transform the identity matrix.")
     }
 
@@ -171,7 +171,7 @@ impl<M: One> Transformation<M> for mat::Identity {
     }
 
     #[inline]
-    fn prepend_transformation_cpy(_: &mat::Identity, _: &M) -> mat::Identity {
+    fn prepend_transformation_cpy(&self, _: &M) -> mat::Identity {
         panic!("Attempted to transform the identity matrix.")
     }
 

--- a/src/structs/spec/mat.rs
+++ b/src/structs/spec/mat.rs
@@ -7,9 +7,8 @@ use traits::structure::{Row, Col, BaseNum};
 // some specializations:
 impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat1<N> {
     #[inline]
-    fn inv_cpy(m: &Mat1<N>) -> Option<Mat1<N>> {
-        let mut res = m.clone();
-
+    fn inv_cpy(&self) -> Option<Mat1<N>> {
+        let mut res = self.clone();
         if res.inv() {
             Some(res)
         }
@@ -34,9 +33,8 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat1<N> {
 
 impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat2<N> {
     #[inline]
-    fn inv_cpy(m: &Mat2<N>) -> Option<Mat2<N>> {
-        let mut res = m.clone();
-
+    fn inv_cpy(&self) -> Option<Mat2<N>> {
+        let mut res = self.clone();
         if res.inv() {
             Some(res)
         }
@@ -64,9 +62,8 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat2<N> {
 
 impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat3<N> {
     #[inline]
-    fn inv_cpy(m: &Mat3<N>) -> Option<Mat3<N>> {
-        let mut res = m.clone();
-
+    fn inv_cpy(&self) -> Option<Mat3<N>> {
+        let mut res = self.clone();
         if res.inv() {
             Some(res)
         }
@@ -108,26 +105,26 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat3<N> {
 
 impl<N: BaseNum + Clone> Det<N> for Mat1<N> {
     #[inline]
-    fn det(m: &Mat1<N>) -> N {
-        m.m11.clone()
+    fn det(&self) -> N {
+        self.m11.clone()
     }
 }
 
 impl<N: BaseNum> Det<N> for Mat2<N> {
     #[inline]
-    fn det(m: &Mat2<N>) -> N {
-        m.m11 * m.m22 - m.m21 * m.m12
+    fn det(&self) -> N {
+        self.m11 * self.m22 - self.m21 * self.m12
     }
 }
 
 impl<N: BaseNum> Det<N> for Mat3<N> {
     #[inline]
-    fn det(m: &Mat3<N>) -> N {
-        let minor_m12_m23 = m.m22 * m.m33 - m.m32 * m.m23;
-        let minor_m11_m23 = m.m21 * m.m33 - m.m31 * m.m23;
-        let minor_m11_m22 = m.m21 * m.m32 - m.m31 * m.m22;
+    fn det(&self) -> N {
+        let minor_m12_m23 = self.m22 * self.m33 - self.m32 * self.m23;
+        let minor_m11_m23 = self.m21 * self.m33 - self.m31 * self.m23;
+        let minor_m11_m22 = self.m21 * self.m32 - self.m31 * self.m22;
 
-        m.m11 * minor_m12_m23 - m.m12 * minor_m11_m23 + m.m13 * minor_m11_m22
+        self.m11 * minor_m12_m23 - self.m12 * minor_m11_m23 + self.m13 * minor_m11_m22
     }
 }
 

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -5,37 +5,37 @@ use structs::mat::Mat3;
 
 impl<N: Mul<N, N> + Sub<N, N>> Cross<Vec1<N>> for Vec2<N> {
     #[inline]
-    fn cross(a: &Vec2<N>, b: &Vec2<N>) -> Vec1<N> {
-        Vec1::new(a.x * b.y - a.y * b.x)
+    fn cross(&self, other: &Vec2<N>) -> Vec1<N> {
+        Vec1::new(self.x * other.y - self.y * other.x)
     }
 }
 
 // FIXME: instead of returning a Vec2, define a Mat2x1 matrix?
 impl<N: Neg<N> + Clone> CrossMatrix<Vec2<N>> for Vec2<N> {
     #[inline]
-    fn cross_matrix(v: &Vec2<N>) -> Vec2<N> {
-        Vec2::new(-v.y, v.x.clone())
+    fn cross_matrix(&self) -> Vec2<N> {
+        Vec2::new(-self.y, self.x.clone())
     }
 }
 
 impl<N: Mul<N, N> + Sub<N, N>> Cross<Vec3<N>> for Vec3<N> {
     #[inline]
-    fn cross(a: &Vec3<N>, b: &Vec3<N>) -> Vec3<N> {
+    fn cross(&self, other: &Vec3<N>) -> Vec3<N> {
         Vec3::new(
-            a.y * b.z - a.z * b.y,
-            a.z * b.x - a.x * b.z,
-            a.x * b.y - a.y * b.x
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x
         )
     }
 }
 
 impl<N: Neg<N> + Zero + Clone> CrossMatrix<Mat3<N>> for Vec3<N> {
     #[inline]
-    fn cross_matrix(v: &Vec3<N>) -> Mat3<N> {
+    fn cross_matrix(&self) -> Mat3<N> {
         Mat3::new(
-            ::zero(), -v.z        , v.y.clone(),
-            v.z.clone() , ::zero(), -v.x,
-            -v.y        , v.x.clone() , ::zero()
+            ::zero(),       -self.z,          self.y.clone(),
+            self.z.clone(),  ::zero(),       -self.x,
+            -self.y,         self.x.clone(),  ::zero()
         )
     }
 }

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -121,7 +121,7 @@ impl<N: Neg<N>> Neg<vec::Vec0<N>> for vec::Vec0<N> {
 
 impl<N: BaseNum> Dot<N> for vec::Vec0<N> {
     #[inline]
-    fn dot(_: &vec::Vec0<N>, _: &vec::Vec0<N>) -> N {
+    fn dot(&self, _: &vec::Vec0<N>) -> N {
         ::zero()
     }
 }
@@ -157,8 +157,8 @@ impl<N: Clone + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
     }
 
     #[inline]
-    fn append_translation_cpy(vec: &vec::Vec0<N>, t: &vec::Vec0<N>) -> vec::Vec0<N> {
-        *t + vec
+    fn append_translation_cpy(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
+        *t + self
     }
 
     #[inline]
@@ -167,8 +167,8 @@ impl<N: Clone + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
     }
 
     #[inline]
-    fn prepend_translation_cpy(vec: &vec::Vec0<N>, t: &vec::Vec0<N>) -> vec::Vec0<N> {
-        *vec + *t
+    fn prepend_translation_cpy(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
+        *self + *t
     }
 
     #[inline]
@@ -178,17 +178,17 @@ impl<N: Clone + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
 
 impl<N: BaseFloat> Norm<N> for vec::Vec0<N> {
     #[inline]
-    fn sqnorm(_: &vec::Vec0<N>) -> N {
+    fn sqnorm(&self) -> N {
         ::zero()
     }
 
     #[inline]
-    fn norm(_: &vec::Vec0<N>) -> N {
+    fn norm(&self) -> N {
         ::zero()
     }
 
     #[inline]
-    fn normalize_cpy(_: &vec::Vec0<N>) -> vec::Vec0<N> {
+    fn normalize_cpy(&self) -> vec::Vec0<N> {
         ::zero()
     }
 
@@ -205,12 +205,7 @@ impl<N: ApproxEq<N>> ApproxEq<N> for vec::Vec0<N> {
     }
 
     #[inline]
-    fn approx_eq(_: &vec::Vec0<N>, _: &vec::Vec0<N>) -> bool {
-        true
-    }
-
-    #[inline]
-    fn approx_eq_eps(_: &vec::Vec0<N>, _: &vec::Vec0<N>, _: &N) -> bool {
+    fn approx_eq_eps(&self, _: &vec::Vec0<N>, _: &N) -> bool {
         true
     }
 }

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -82,26 +82,26 @@ macro_rules! ord_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
         impl<N: BaseFloat + Clone> POrd for $t<N> {
             #[inline]
-            fn inf(a: &$t<N>, b: &$t<N>) -> $t<N> {
-                $t::new(a.$comp0.min(b.$comp0.clone())
-                        $(, a.$compN.min(b.$compN))*)
+            fn inf(&self, other: &$t<N>) -> $t<N> {
+                $t::new(self.$comp0.min(other.$comp0.clone())
+                        $(, self.$compN.min(other.$compN))*)
             }
 
             #[inline]
-            fn sup(a: &$t<N>, b: &$t<N>) -> $t<N> {
-                $t::new(a.$comp0.max(b.$comp0.clone())
-                        $(, a.$compN.max(b.$compN.clone()))*)
+            fn sup(&self, other: &$t<N>) -> $t<N> {
+                $t::new(self.$comp0.max(other.$comp0.clone())
+                        $(, self.$compN.max(other.$compN.clone()))*)
             }
 
             #[inline]
             #[allow(unused_mut)] // otherwise there will be a warning for is_eq or Vec1.
-            fn partial_cmp(a: &$t<N>, b: &$t<N>) -> POrdering {
-                let is_lt     = a.$comp0 <  b.$comp0;
-                let mut is_eq = a.$comp0 == b.$comp0;
+            fn partial_cmp(&self, other: &$t<N>) -> POrdering {
+                let is_lt     = self.$comp0 <  other.$comp0;
+                let mut is_eq = self.$comp0 == other.$comp0;
 
                 if is_lt { // <
                     $(
-                        if a.$compN > b.$compN {
+                        if self.$compN > other.$compN {
                             return POrdering::NotComparable
                         }
                      )*
@@ -110,10 +110,10 @@ macro_rules! ord_impl(
                 }
                 else { // >=
                     $(
-                        if a.$compN < b.$compN {
+                        if self.$compN < other.$compN {
                             return POrdering::NotComparable
                         }
-                        else if a.$compN > b.$compN {
+                        else if self.$compN > other.$compN {
                             is_eq = false;
                         }
 
@@ -129,23 +129,23 @@ macro_rules! ord_impl(
             }
 
             #[inline]
-            fn partial_lt(a: &$t<N>, b: &$t<N>) -> bool {
-                a.$comp0 < b.$comp0 $(&& a.$compN < b.$compN)*
+            fn partial_lt(&self, other: &$t<N>) -> bool {
+                self.$comp0 < other.$comp0 $(&& self.$compN < other.$compN)*
             }
 
             #[inline]
-            fn partial_le(a: &$t<N>, b: &$t<N>) -> bool {
-                a.$comp0 <= b.$comp0 $(&& a.$compN <= b.$compN)*
+            fn partial_le(&self, other: &$t<N>) -> bool {
+                self.$comp0 <= other.$comp0 $(&& self.$compN <= other.$compN)*
             }
 
             #[inline]
-            fn partial_gt(a: &$t<N>, b: &$t<N>) -> bool {
-                a.$comp0 > b.$comp0 $(&& a.$compN > b.$compN)*
+            fn partial_gt(&self, other: &$t<N>) -> bool {
+                self.$comp0 > other.$comp0 $(&& self.$compN > other.$compN)*
             }
 
             #[inline]
-            fn partial_ge(a: &$t<N>, b: &$t<N>) -> bool {
-                a.$comp0 >= b.$comp0 $(&& a.$compN >= b.$compN)*
+            fn partial_ge(&self, other: &$t<N>) -> bool {
+                self.$comp0 >= other.$comp0 $(&& self.$compN >= other.$compN)*
             }
         }
     )
@@ -493,8 +493,8 @@ macro_rules! dot_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
         impl<N: BaseNum> Dot<N> for $t<N> {
             #[inline]
-            fn dot(a: &$t<N>, b: &$t<N>) -> N {
-                a.$comp0 * b.$comp0 $(+ a.$compN * b.$compN )*
+            fn dot(&self, other: &$t<N>) -> N {
+                self.$comp0 * other.$comp0 $(+ self.$compN * other.$compN )*
             }
         }
     )
@@ -595,8 +595,8 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn append_translation_cpy(transform: &$t<N>, t: &$t<N>) -> $t<N> {
-                *t + *transform
+            fn append_translation_cpy(&self, t: &$t<N>) -> $t<N> {
+                *t + *self
             }
 
             #[inline]
@@ -605,8 +605,8 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn prepend_translation_cpy(transform: &$t<N>, t: &$t<N>) -> $t<N> {
-                *transform + *t
+            fn prepend_translation_cpy(&self, t: &$t<N>) -> $t<N> {
+                *self + *t
             }
 
             #[inline]
@@ -621,21 +621,14 @@ macro_rules! norm_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
         impl<N: Clone + BaseFloat> Norm<N> for $t<N> {
             #[inline]
-            fn sqnorm(v: &$t<N>) -> N {
-                Dot::dot(v, v)
+            fn sqnorm(&self) -> N {
+                Dot::dot(self, self)
             }
 
             #[inline]
-            fn norm(v: &$t<N>) -> N {
-                Norm::sqnorm(v).sqrt()
-            }
-
-            #[inline]
-            fn normalize_cpy(v: &$t<N>) -> $t<N> {
-                let mut res : $t<N> = v.clone();
-
+            fn normalize_cpy(&self) -> $t<N> {
+                let mut res : $t<N> = self.clone();
                 let _ = res.normalize();
-
                 res
             }
 
@@ -661,15 +654,15 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
-            fn approx_eq(a: &$t<N>, b: &$t<N>) -> bool {
-                ApproxEq::approx_eq(&a.$comp0, &b.$comp0)
-                $(&& ApproxEq::approx_eq(&a.$compN, &b.$compN))*
+            fn approx_eq(&self, other: &$t<N>) -> bool {
+                ApproxEq::approx_eq(&self.$comp0, &other.$comp0)
+                $(&& ApproxEq::approx_eq(&self.$compN, &other.$compN))*
             }
 
             #[inline]
-            fn approx_eq_eps(a: &$t<N>, b: &$t<N>, eps: &N) -> bool {
-                ApproxEq::approx_eq_eps(&a.$comp0, &b.$comp0, eps)
-                $(&& ApproxEq::approx_eq_eps(&a.$compN, &b.$compN, eps))*
+            fn approx_eq_eps(&self, other: &$t<N>, eps: &N) -> bool {
+                ApproxEq::approx_eq_eps(&self.$comp0, &other.$comp0, eps)
+                $(&& ApproxEq::approx_eq_eps(&self.$compN, &other.$compN, eps))*
             }
         }
     )

--- a/src/traits/geometry.rs
+++ b/src/traits/geometry.rs
@@ -17,13 +17,13 @@ pub trait Translation<V> {
     fn append_translation(&mut self, &V);
 
     /// Appends the translation `amount` to a copy of `t`.
-    fn append_translation_cpy(t: &Self, amount: &V) -> Self;
+    fn append_translation_cpy(&self, amount: &V) -> Self;
 
     /// Prepends a translation to this object.
     fn prepend_translation(&mut self, &V);
 
     /// Prepends the translation `amount` to a copy of `t`.
-    fn prepend_translation_cpy(t: &Self, amount: &V) -> Self;
+    fn prepend_translation_cpy(&self, amount: &V) -> Self;
 
     /// Sets the translation.
     fn set_translation(&mut self, V);
@@ -52,13 +52,13 @@ pub trait Rotation<V> {
     fn append_rotation(&mut self, &V);
 
     /// Appends the rotation `amount` to a copy of `t`.
-    fn append_rotation_cpy(t: &Self, amount: &V) -> Self;
+    fn append_rotation_cpy(&self, amount: &V) -> Self;
 
     /// Prepends a rotation to this object.
     fn prepend_rotation(&mut self, &V);
 
     /// Prepends the rotation `amount` to a copy of `t`.
-    fn prepend_rotation_cpy(t: &Self, amount: &V) -> Self;
+    fn prepend_rotation_cpy(&self, amount: &V) -> Self;
 
     /// Sets the rotation of `self`.
     fn set_rotation(&mut self, V);
@@ -90,8 +90,8 @@ pub trait RotationWithTranslation<LV: Neg<LV>, AV>: Rotation<AV> + Translation<L
     ///   * `amount` - the rotation to apply.
     ///   * `point` - the center of rotation.
     #[inline]
-    fn append_rotation_wrt_point_cpy(t: &Self, amount: &AV, center: &LV) -> Self {
-        let mut res = Translation::append_translation_cpy(t, &-*center);
+    fn append_rotation_wrt_point_cpy(&self, amount: &AV, center: &LV) -> Self {
+        let mut res = Translation::append_translation_cpy(self, &-*center);
 
         res.append_rotation(amount);
         res.append_translation(center);
@@ -119,8 +119,8 @@ pub trait RotationWithTranslation<LV: Neg<LV>, AV>: Rotation<AV> + Translation<L
     ///   * `t` - the object to be rotated.
     ///   * `amount` - the rotation to apply.
     #[inline]
-    fn append_rotation_wrt_center_cpy(t: &Self, amount: &AV) -> Self {
-        RotationWithTranslation::append_rotation_wrt_point_cpy(t, amount, &t.translation())
+    fn append_rotation_wrt_center_cpy(&self, amount: &AV) -> Self {
+        RotationWithTranslation::append_rotation_wrt_point_cpy(self, amount, &self.translation())
     }
 
     /// Applies a rotation centered on the translation of `m`.
@@ -174,13 +174,13 @@ pub trait Transformation<M> {
     fn append_transformation(&mut self, &M);
 
     /// Appends the transformation `amount` to a copy of `t`.
-    fn append_transformation_cpy(t: &Self, amount: &M) -> Self;
+    fn append_transformation_cpy(&self, amount: &M) -> Self;
 
     /// Prepends a transformation to this object.
     fn prepend_transformation(&mut self, &M);
 
     /// Prepends the transformation `amount` to a copy of `t`.
-    fn prepend_transformation_cpy(t: &Self, amount: &M) -> Self;
+    fn prepend_transformation_cpy(&self, amount: &M) -> Self;
 
     /// Sets the transformation of `self`.
     fn set_transformation(&mut self, M);
@@ -201,24 +201,24 @@ pub trait Transform<V> {
 pub trait Dot<N> {
     /// Computes the dot (inner) product of two vectors.
     #[inline]
-    fn dot(&Self, &Self) -> N;
+    fn dot(&self, other: &Self) -> N;
 }
 
 /// Traits of objects having an euclidian norm.
 pub trait Norm<N: BaseFloat> {
     /// Computes the norm of `self`.
     #[inline]
-    fn norm(v: &Self) -> N {
-        Norm::sqnorm(v).sqrt()
+    fn norm(&self) -> N {
+        self.sqnorm().sqrt()
     }
 
     /// Computes the squared norm of `self`.
     ///
     /// This is usually faster than computing the norm itself.
-    fn sqnorm(&Self) -> N;
+    fn sqnorm(&self) -> N;
 
     /// Gets the normalized version of a copy of `v`.
-    fn normalize_cpy(v: &Self) -> Self;
+    fn normalize_cpy(&self) -> Self;
 
     /// Normalizes `self`.
     fn normalize(&mut self) -> N;
@@ -229,7 +229,7 @@ pub trait Norm<N: BaseFloat> {
  */
 pub trait Cross<V> {
     /// Computes the cross product between two elements (usually vectors).
-    fn cross(&Self, other: &Self) -> V;
+    fn cross(&self, other: &Self) -> V;
 }
 
 /**
@@ -238,7 +238,7 @@ pub trait Cross<V> {
 pub trait CrossMatrix<M> {
     /// The matrix associated to any cross product with this vector. I.e. `v.cross(anything)` =
     /// `v.cross_matrix().rmul(anything)`.
-    fn cross_matrix(&Self) -> M;
+    fn cross_matrix(&self) -> M;
 }
 
 /// Traits of objects which can be put in homogeneous coordinates form.

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -71,55 +71,55 @@ impl POrdering {
 
 /// Pointwise ordering operations.
 pub trait POrd {
-    /// Returns the infimum of `a` and `b`.
-    fn inf(a: &Self, b: &Self) -> Self;
+    /// Returns the infimum of this value and another
+    fn inf(&self, other: &Self) -> Self;
 
-    /// Returns the supremum of `a` and `b`.
-    fn sup(a: &Self, b: &Self) -> Self;
+    /// Returns the supremum of this value and another
+    fn sup(&self, other: &Self) -> Self;
 
-    /// Compare `a` and `b` using a partial ordering relation.
-    fn partial_cmp(a: &Self, b: &Self) -> POrdering;
+    /// Compare `self` and `other` using a partial ordering relation.
+    fn partial_cmp(&self, other: &Self) -> POrdering;
 
-    /// Returns `true` iff `a` and `b` are comparable and `a <= b`.
+    /// Returns `true` iff `self` and `other` are comparable and `self <= other`.
     #[inline]
-    fn partial_le(a: &Self, b: &Self) -> bool {
-        POrd::partial_cmp(a, b).is_le()
+    fn partial_le(&self, other: &Self) -> bool {
+        POrd::partial_cmp(self, other).is_le()
     }
 
-    /// Returns `true` iff `a` and `b` are comparable and `a < b`.
+    /// Returns `true` iff `self` and `other` are comparable and `self < other`.
     #[inline]
-    fn partial_lt(a: &Self, b: &Self) -> bool {
-        POrd::partial_cmp(a, b).is_lt()
+    fn partial_lt(&self, other: &Self) -> bool {
+        POrd::partial_cmp(self, other).is_lt()
     }
 
-    /// Returns `true` iff `a` and `b` are comparable and `a >= b`.
+    /// Returns `true` iff `self` and `other` are comparable and `self >= other`.
     #[inline]
-    fn partial_ge(a: &Self, b: &Self) -> bool {
-        POrd::partial_cmp(a, b).is_ge()
+    fn partial_ge(&self, other: &Self) -> bool {
+        POrd::partial_cmp(self, other).is_ge()
     }
 
-    /// Returns `true` iff `a` and `b` are comparable and `a > b`.
+    /// Returns `true` iff `self` and `other` are comparable and `self > other`.
     #[inline]
-    fn partial_gt(a: &Self, b: &Self) -> bool {
-        POrd::partial_cmp(a, b).is_gt()
+    fn partial_gt(&self, other: &Self) -> bool {
+        POrd::partial_cmp(self, other).is_gt()
     }
 
-    /// Return the minimum of `a` and `b` if they are comparable.
+    /// Return the minimum of `self` and `other` if they are comparable.
     #[inline]
-    fn partial_min<'a>(a: &'a Self, b: &'a Self) -> Option<&'a Self> {
-        match POrd::partial_cmp(a, b) {
-            POrdering::PartialLess | POrdering::PartialEqual => Some(a),
-            POrdering::PartialGreater             => Some(b),
+    fn partial_min<'a>(&'a self, other: &'a Self) -> Option<&'a Self> {
+        match POrd::partial_cmp(self, other) {
+            POrdering::PartialLess | POrdering::PartialEqual => Some(self),
+            POrdering::PartialGreater             => Some(other),
             POrdering::NotComparable              => None
         }
     }
 
-    /// Return the maximum of `a` and `b` if they are comparable.
+    /// Return the maximum of `self` and `other` if they are comparable.
     #[inline]
-    fn partial_max<'a>(a: &'a Self, b: &'a Self) -> Option<&'a Self> {
-        match POrd::partial_cmp(a, b) {
-            POrdering::PartialGreater | POrdering::PartialEqual => Some(a),
-            POrdering::PartialLess   => Some(b),
+    fn partial_max<'a>(&'a self, other: &'a Self) -> Option<&'a Self> {
+        match POrd::partial_cmp(self, other) {
+            POrdering::PartialGreater | POrdering::PartialEqual => Some(self),
+            POrdering::PartialLess   => Some(other),
             POrdering::NotComparable => None
         }
     }
@@ -127,9 +127,9 @@ pub trait POrd {
     /// Clamp `value` between `min` and `max`. Returns `None` if `value` is not comparable to
     /// `min` or `max`.
     #[inline]
-    fn partial_clamp<'a>(value: &'a Self, min: &'a Self, max: &'a Self) -> Option<&'a Self> {
-        let v_min = POrd::partial_cmp(value, min);
-        let v_max = POrd::partial_cmp(value, max);
+    fn partial_clamp<'a>(&'a self, min: &'a Self, max: &'a Self) -> Option<&'a Self> {
+        let v_min = self.partial_cmp(min);
+        let v_max = self.partial_cmp(max);
 
         if v_min.is_not_comparable() || v_max.is_not_comparable() {
             None
@@ -142,7 +142,7 @@ pub trait POrd {
                 Some(max)
             }
             else {
-                Some(value)
+                Some(self)
             }
         }
     }
@@ -154,12 +154,12 @@ pub trait ApproxEq<Eps> {
     fn approx_epsilon(unused_self: Option<Self>) -> Eps;
 
     /// Tests approximate equality using a custom epsilon.
-    fn approx_eq_eps(a: &Self, other: &Self, epsilon: &Eps) -> bool;
+    fn approx_eq_eps(&self, other: &Self, epsilon: &Eps) -> bool;
 
     /// Tests approximate equality.
     #[inline]
-    fn approx_eq(a: &Self, b: &Self) -> bool {
-        ApproxEq::approx_eq_eps(a, b, &ApproxEq::approx_epsilon(None::<Self>))
+    fn approx_eq(&self, other: &Self) -> bool {
+        self.approx_eq_eps(other, &ApproxEq::approx_epsilon(None::<Self>))
     }
 }
 
@@ -170,8 +170,8 @@ impl ApproxEq<f32> for f32 {
     }
 
     #[inline]
-    fn approx_eq_eps(a: &f32, b: &f32, epsilon: &f32) -> bool {
-        ::abs(&(*a - *b)) < *epsilon
+    fn approx_eq_eps(&self, other: &f32, epsilon: &f32) -> bool {
+        ::abs(&(*self - *other)) < *epsilon
     }
 }
 
@@ -182,8 +182,8 @@ impl ApproxEq<f64> for f64 {
     }
 
     #[inline]
-    fn approx_eq_eps(a: &f64, b: &f64, approx_epsilon: &f64) -> bool {
-        ::abs(&(*a - *b)) < *approx_epsilon
+    fn approx_eq_eps(&self, other: &f64, approx_epsilon: &f64) -> bool {
+        ::abs(&(*self - *other)) < *approx_epsilon
     }
 }
 
@@ -198,7 +198,7 @@ pub trait Absolute<A> {
 /// Trait of objects having an inverse. Typically used to implement matrix inverse.
 pub trait Inv {
     /// Returns the inverse of `m`.
-    fn inv_cpy(m: &Self) -> Option<Self>;
+    fn inv_cpy(&self) -> Option<Self>;
 
     /// In-place version of `inverse`.
     fn inv(&mut self) -> bool;
@@ -207,13 +207,13 @@ pub trait Inv {
 /// Trait of objects having a determinant. Typically used by square matrices.
 pub trait Det<N> {
     /// Returns the determinant of `m`.
-    fn det(m: &Self) -> N;
+    fn det(&self) -> N;
 }
 
 /// Trait of objects which can be transposed.
 pub trait Transpose {
     /// Computes the transpose of a matrix.
-    fn transpose_cpy(m: &Self) -> Self;
+    fn transpose_cpy(&self) -> Self;
 
     /// In-place version of `transposed`.
     fn transpose(&mut self);
@@ -222,7 +222,7 @@ pub trait Transpose {
 /// Traits of objects having an outer product.
 pub trait Outer<M> {
     /// Computes the outer product: `a * b`
-    fn outer(a: &Self, b: &Self) -> M;
+    fn outer(&self, other: &Self) -> M;
 }
 
 /// Trait for computing the covariance of a set of data.
@@ -231,14 +231,14 @@ pub trait Cov<M> {
     ///
     ///   * For matrices, observations are stored in its rows.
     ///   * For vectors, observations are stored in its components (thus are 1-dimensional).
-    fn cov(m: &Self) -> M;
+    fn cov(&self) -> M;
 
     /// Computes the covariance of the obsevations stored by `m`:
     ///
     ///   * For matrices, observations are stored in its rows.
     ///   * For vectors, observations are stored in its components (thus are 1-dimensional).
-    fn cov_to(m: &Self, out: &mut M) {
-        *out = Cov::cov(m)
+    fn cov_to(&self, out: &mut M) {
+        *out = self.cov()
     }
 }
 
@@ -248,13 +248,13 @@ pub trait Mean<N> {
     /// 
     ///   * For matrices, observations are stored in its rows.
     ///   * For vectors, observations are stored in its components (thus are 1-dimensional).
-    fn mean(v: &Self) -> N;
+    fn mean(&self) -> N;
 }
 
 /// Trait for computing the eigenvector and eigenvalues of a square matrix usin the QR algorithm.
 pub trait EigenQR<N, V>: SquareMat<N, V> {
     /// Computes the eigenvectors and eigenvalues of this matrix.
-    fn eigen_qr(m: &Self, eps: &N, niter: uint) -> (Self, V);
+    fn eigen_qr(&self, eps: &N, niter: uint) -> (Self, V);
 }
 
 // XXX: those two traits should not exist since there is generalized operator overloading of Add

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -270,14 +270,14 @@ pub trait NumPnt<N, V>:
 pub trait FloatPnt<N: BaseFloat, V: Norm<N>>: NumPnt<N, V> {
     /// Computes the square distance between two points.
     #[inline]
-    fn sqdist(a: &Self, b: &Self) -> N {
-        Norm::sqnorm(&(*a - *b))
+    fn sqdist(&self, other: &Self) -> N {
+        (*self - *other).sqnorm()
     }
 
     /// Computes the distance between two points.
     #[inline]
-    fn dist(a: &Self, b: &Self) -> N {
-        Norm::norm(&(*a - *b))
+    fn dist(&self, other: &Self) -> N {
+        (*self - *other).norm()
     }
 }
 


### PR DESCRIPTION
Wherever sensible the geometric traits now take `&self` arguments, so that implementations can be invoked as instance methods instead of static methods. This makes some idioms easier to express and generally allows for greater flexibility as the restructured methods can still be invoked like static methods.

Fixes #39.
