### PR TITLE
Update to the last rust-nightly.

### DIFF
--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -16,7 +16,7 @@ macro_rules! bench_binop(
                 i = (i + 1) & (LEN - 1);
 
                 unsafe {
-                    test::black_box(elems1.unsafe_get(i).$binop(elems2.unsafe_get(i)))
+                    test::black_box(elems1.unsafe_get(i).$binop(*elems2.unsafe_get(i)))
                 }
             })
         }

--- a/benches/dmat.rs
+++ b/benches/dmat.rs
@@ -9,12 +9,13 @@ use na::{DVec, DMat};
 macro_rules! bench_mul_dmat(
     ($bh: expr, $nrows: expr, $ncols: expr) => {
         {
-            let a:     DMat<f64> = DMat::new_random($nrows, $ncols);
-            let mut b: DMat<f64> = DMat::new_random($nrows, $ncols);
-
             $bh.iter(|| {
+                let a:     DMat<f64> = DMat::new_random($nrows, $ncols);
+                let mut b: DMat<f64> = DMat::new_random($nrows, $ncols);
+
                 for _ in range(0u, 1000) {
-                    b = a * b;
+                    // XXX: the clone here is highly undesirable!
+                    b = a.clone() * b;
                 }
             })
         }
@@ -49,12 +50,14 @@ fn bench_mul_dmat6(bh: &mut Bencher) {
 macro_rules! bench_mul_dmat_dvec(
     ($bh: expr, $nrows: expr, $ncols: expr) => {
         {
-            let m : DMat<f64>     = DMat::new_random($nrows, $ncols);
-            let mut v : DVec<f64> = DVec::new_random($ncols);
 
             $bh.iter(|| {
+                let m : DMat<f64>     = DMat::new_random($nrows, $ncols);
+                let mut v : DVec<f64> = DVec::new_random($ncols);
+
                 for _ in range(0u, 1000) {
-                    v = m * v
+                    // XXX: the clone here is highly undesirable!
+                    v = m.clone() * v
                 }
             })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ pub fn orig<P: Orig>() -> P {
 
 /// Returns the center of two points.
 #[inline]
-pub fn center<N: BaseFloat, P: FloatPnt<N, V>, V>(a: &P, b: &P) -> P {
+pub fn center<N: BaseFloat, P: FloatPnt<N, V>, V: Copy>(a: &P, b: &P) -> P {
     let _2 = one::<N>() + one();
     (*a + *b.as_vec()) / _2
 }

--- a/src/linalg/decompositions.rs
+++ b/src/linalg/decompositions.rs
@@ -40,11 +40,11 @@ pub fn householder_matrix<N, V, M>(dim: uint, start: uint, vec: V) -> M
 pub fn qr<N, V, M>(m: &M) -> (M, M)
     where N: BaseFloat,
           V: Indexable<uint, N> + Norm<N>,
-          M: Clone + Eye + ColSlice<V> + Transpose + Indexable<(uint, uint), N> + Mul<M, M> {
+          M: Copy + Eye + ColSlice<V> + Transpose + Indexable<(uint, uint), N> + Mul<M, M> {
     let (rows, cols) = m.shape();
     assert!(rows >= cols);
     let mut q : M = Eye::new_identity(rows);
-    let mut r = m.clone();
+    let mut r = *m;
 
     let iterations = min(rows - 1, cols);
 
@@ -76,9 +76,9 @@ pub fn eigen_qr<N, V, VS, M>(m: &M, eps: &N, niter: uint) -> (M, V)
     where N:  BaseFloat,
           VS: Indexable<uint, N> + Norm<N>,
           M:  Indexable<(uint, uint), N> + SquareMat<N, V> + Add<M, M> + Sub<M, M> + ColSlice<VS> +
-              ApproxEq<N> + Clone {
+              ApproxEq<N> + Copy {
     let mut eigenvectors: M = ::one::<M>();
-    let mut eigenvalues = m.clone();
+    let mut eigenvalues = *m;
     // let mut shifter: M = Eye::new_identity(rows);
 
     let mut iter = 0u;

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -5,8 +5,8 @@
 use std::rand::Rand;
 use std::rand;
 use std::slice::{Items, MutItems};
-use traits::operations::ApproxEq;
 use std::iter::FromIterator;
+use traits::operations::{ApproxEq, Axpy};
 use traits::geometry::{Dot, Norm};
 use traits::structure::{Iterable, IterableMut, Indexable, Shape, BaseFloat, BaseNum, Zero, One};
 

--- a/src/structs/pnt_macros.rs
+++ b/src/structs/pnt_macros.rs
@@ -21,9 +21,9 @@ macro_rules! orig_impl(
 
 macro_rules! pnt_sub_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: Sub<N, N>> Sub<$t<N>, $tv<N>> for $t<N> {
+        impl<N: Copy + Sub<N, N>> Sub<$t<N>, $tv<N>> for $t<N> {
             #[inline]
-            fn sub(&self, right: &$t<N>) -> $tv<N> {
+            fn sub(self, right: $t<N>) -> $tv<N> {
                 *self.as_vec() - *right.as_vec()
             }
         }
@@ -32,9 +32,9 @@ macro_rules! pnt_sub_impl(
 
 macro_rules! pnt_add_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Add<N, N>> Add<$tv<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Add<N, N>> Add<$tv<N>, $t<N>> for $t<N> {
             #[inline]
-            fn add(&self, right: &$tv<N>) -> $t<N> {
+            fn add(self, right: $tv<N>) -> $t<N> {
                 $t::new(self.$comp0 + right.$comp0 $(, self.$compN + right.$compN)*)
             }
         }
@@ -43,9 +43,9 @@ macro_rules! pnt_add_vec_impl(
 
 macro_rules! pnt_sub_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Sub<N, N>> Sub<$tv<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Sub<N, N>> Sub<$tv<N>, $t<N>> for $t<N> {
             #[inline]
-            fn sub(&self, right: &$tv<N>) -> $t<N> {
+            fn sub(self, right: $tv<N>) -> $t<N> {
                 $t::new(self.$comp0 - right.$comp0 $(, self.$compN - right.$compN)*)
             }
         }
@@ -100,12 +100,12 @@ macro_rules! pnt_as_vec_impl(
 
 macro_rules! pnt_to_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Clone + One + Zero> ToHomogeneous<$t2<N>> for $t<N> {
+        impl<N: Copy + One + Zero> ToHomogeneous<$t2<N>> for $t<N> {
             fn to_homogeneous(&self) -> $t2<N> {
                 let mut res: $t2<N> = Orig::orig();
 
-                res.$comp0    = self.$comp0.clone();
-                $( res.$compN = self.$compN.clone(); )*
+                res.$comp0    = self.$comp0;
+                $( res.$compN = self.$compN; )*
                 res.$extra    = ::one();
 
                 res
@@ -116,12 +116,12 @@ macro_rules! pnt_to_homogeneous_impl(
 
 macro_rules! pnt_from_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Clone + Div<N, N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
+        impl<N: Copy + Div<N, N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
             fn from(v: &$t2<N>) -> $t<N> {
                 let mut res: $t<N> = Orig::orig();
 
-                res.$comp0    = v.$comp0.clone() / v.$extra;
-                $( res.$compN = v.$compN.clone() / v.$extra; )*
+                res.$comp0    = v.$comp0 / v.$extra;
+                $( res.$compN = v.$compN / v.$extra; )*
 
                 res
             }

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -13,7 +13,7 @@ macro_rules! submat_impl(
 
 macro_rules! rotate_impl(
     ($t: ident, $tv: ident, $tp: ident) => (
-        impl<N: BaseNum + Clone> Rotate<$tv<N>> for $t<N> {
+        impl<N: BaseNum> Rotate<$tv<N>> for $t<N> {
             #[inline]
             fn rotate(&self, v: &$tv<N>) -> $tv<N> {
                 *self * *v
@@ -25,7 +25,7 @@ macro_rules! rotate_impl(
             }
         }
 
-        impl<N: BaseNum + Clone> Rotate<$tp<N>> for $t<N> {
+        impl<N: BaseNum> Rotate<$tp<N>> for $t<N> {
             #[inline]
             fn rotate(&self, p: &$tp<N>) -> $tp<N> {
                 *self * *p
@@ -41,7 +41,7 @@ macro_rules! rotate_impl(
 
 macro_rules! transform_impl(
     ($t: ident, $tv: ident, $tp: ident) => (
-        impl<N: BaseNum + Clone> Transform<$tv<N>> for $t<N> {
+        impl<N: BaseNum> Transform<$tv<N>> for $t<N> {
             #[inline]
             fn transform(&self, v: &$tv<N>) -> $tv<N> {
                 self.rotate(v)
@@ -53,7 +53,7 @@ macro_rules! transform_impl(
             }
         }
 
-        impl<N: BaseNum + Clone> Transform<$tp<N>> for $t<N> {
+        impl<N: BaseNum> Transform<$tp<N>> for $t<N> {
             #[inline]
             fn transform(&self, p: &$tp<N>) -> $tp<N> {
                 self.rotate(p)
@@ -91,7 +91,7 @@ macro_rules! rotation_matrix_impl(
 
 macro_rules! one_impl(
     ($t: ident) => (
-        impl<N: BaseNum + Clone> One for $t<N> {
+        impl<N: BaseNum> One for $t<N> {
             #[inline]
             fn one() -> $t<N> {
                 $t { submat: ::one() }
@@ -102,9 +102,9 @@ macro_rules! one_impl(
 
 macro_rules! rot_mul_rot_impl(
     ($t: ident) => (
-        impl<N: BaseNum + Clone> Mul<$t<N>, $t<N>> for $t<N> {
+        impl<N: BaseNum> Mul<$t<N>, $t<N>> for $t<N> {
             #[inline]
-            fn mul(&self, right: &$t<N>) -> $t<N> {
+            fn mul(self, right: $t<N>) -> $t<N> {
                 $t { submat: self.submat * right.submat }
             }
         }
@@ -113,10 +113,10 @@ macro_rules! rot_mul_rot_impl(
 
 macro_rules! rot_mul_vec_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum + Clone> Mul<$tv<N>, $tv<N>> for $t<N> {
+        impl<N: BaseNum> Mul<$tv<N>, $tv<N>> for $t<N> {
             #[inline]
-            fn mul(&self, right: &$tv<N>) -> $tv<N> {
-                self.submat * *right
+            fn mul(self, right: $tv<N>) -> $tv<N> {
+                self.submat * right
             }
         }
     )
@@ -130,10 +130,10 @@ macro_rules! rot_mul_pnt_impl(
 
 macro_rules! vec_mul_rot_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum + Clone> Mul<$t<N>, $tv<N>> for $tv<N> {
+        impl<N: BaseNum> Mul<$t<N>, $tv<N>> for $tv<N> {
             #[inline]
-            fn mul(&self, right: &$t<N>) -> $tv<N> {
-                *self * right.submat
+            fn mul(self, right: $t<N>) -> $tv<N> {
+                self * right.submat
             }
         }
     )
@@ -147,7 +147,7 @@ macro_rules! pnt_mul_rot_impl(
 
 macro_rules! inv_impl(
     ($t: ident) => (
-        impl<N: Clone> Inv for $t<N> {
+        impl<N: Copy> Inv for $t<N> {
             #[inline]
             fn inv(&mut self) -> bool {
                 self.transpose();
@@ -167,7 +167,7 @@ macro_rules! inv_impl(
 
 macro_rules! transpose_impl(
     ($t: ident) => (
-        impl<N: Clone> Transpose for $t<N> {
+        impl<N: Copy> Transpose for $t<N> {
             #[inline]
             fn transpose_cpy(&self) -> $t<N> {
                 $t { submat: Transpose::transpose_cpy(&self.submat) }
@@ -183,7 +183,7 @@ macro_rules! transpose_impl(
 
 macro_rules! row_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: Clone + Zero> Row<$tv<N>> for $t<N> {
+        impl<N: Copy + Zero> Row<$tv<N>> for $t<N> {
             #[inline]
             fn nrows(&self) -> uint {
                 self.submat.nrows()
@@ -203,7 +203,7 @@ macro_rules! row_impl(
 
 macro_rules! col_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: Clone + Zero> Col<$tv<N>> for $t<N> {
+        impl<N: Copy + Zero> Col<$tv<N>> for $t<N> {
             #[inline]
             fn ncols(&self) -> uint {
                 self.submat.ncols()
@@ -239,7 +239,7 @@ macro_rules! index_impl(
 
 macro_rules! to_homogeneous_impl(
     ($t: ident, $tm: ident) => (
-        impl<N: BaseNum + Clone> ToHomogeneous<$tm<N>> for $t<N> {
+        impl<N: BaseNum> ToHomogeneous<$tm<N>> for $t<N> {
             #[inline]
             fn to_homogeneous(&self) -> $tm<N> {
                 self.submat.to_homogeneous()

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -23,8 +23,8 @@ impl Inv for mat::Identity {
 
 impl<T: Clone> Mul<T, T> for mat::Identity {
     #[inline]
-    fn mul(&self, other: &T) -> T {
-        other.clone()
+    fn mul(self, other: T) -> T {
+        other
     }
 }
 

--- a/src/structs/spec/mat.rs
+++ b/src/structs/spec/mat.rs
@@ -5,10 +5,10 @@ use traits::operations::{Inv, Det, ApproxEq};
 use traits::structure::{Row, Col, BaseNum};
 
 // some specializations:
-impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat1<N> {
+impl<N: BaseNum + ApproxEq<N>> Inv for Mat1<N> {
     #[inline]
     fn inv_cpy(&self) -> Option<Mat1<N>> {
-        let mut res = self.clone();
+        let mut res = *self;
         if res.inv() {
             Some(res)
         }
@@ -31,10 +31,10 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat1<N> {
     }
 }
 
-impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat2<N> {
+impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
     #[inline]
     fn inv_cpy(&self) -> Option<Mat2<N>> {
-        let mut res = self.clone();
+        let mut res = *self;
         if res.inv() {
             Some(res)
         }
@@ -60,10 +60,11 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat2<N> {
     }
 }
 
-impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat3<N> {
+impl<N: BaseNum + ApproxEq<N>> Inv for Mat3<N> {
     #[inline]
     fn inv_cpy(&self) -> Option<Mat3<N>> {
-        let mut res = self.clone();
+        let mut res = *self;
+
         if res.inv() {
             Some(res)
         }
@@ -103,10 +104,10 @@ impl<N: BaseNum + ApproxEq<N> + Clone> Inv for Mat3<N> {
     }
 }
 
-impl<N: BaseNum + Clone> Det<N> for Mat1<N> {
+impl<N: BaseNum> Det<N> for Mat1<N> {
     #[inline]
     fn det(&self) -> N {
-        self.m11.clone()
+        self.m11
     }
 }
 
@@ -128,7 +129,7 @@ impl<N: BaseNum> Det<N> for Mat3<N> {
     }
 }
 
-impl<N: Clone> Row<Vec3<N>> for Mat3<N> {
+impl<N: Copy> Row<Vec3<N>> for Mat3<N> {
     #[inline]
     fn nrows(&self) -> uint {
         3
@@ -137,9 +138,9 @@ impl<N: Clone> Row<Vec3<N>> for Mat3<N> {
     #[inline]
     fn row(&self, i: uint) -> Vec3<N> {
         match i {
-            0 => Vec3::new(self.m11.clone(), self.m12.clone(), self.m13.clone()),
-            1 => Vec3::new(self.m21.clone(), self.m22.clone(), self.m23.clone()),
-            2 => Vec3::new(self.m31.clone(), self.m32.clone(), self.m33.clone()),
+            0 => Vec3::new(self.m11, self.m12, self.m13),
+            1 => Vec3::new(self.m21, self.m22, self.m23),
+            2 => Vec3::new(self.m31, self.m32, self.m33),
             _ => panic!(format!("Index out of range: 3d matrices do not have {} rows.",  i))
         }
     }
@@ -148,18 +149,18 @@ impl<N: Clone> Row<Vec3<N>> for Mat3<N> {
     fn set_row(&mut self, i: uint, r: Vec3<N>) {
         match i {
             0 => {
-                self.m11 = r.x.clone();
-                self.m12 = r.y.clone();
+                self.m11 = r.x;
+                self.m12 = r.y;
                 self.m13 = r.z;
             },
             1 => {
-                self.m21 = r.x.clone();
-                self.m22 = r.y.clone();
+                self.m21 = r.x;
+                self.m22 = r.y;
                 self.m23 = r.z;
             },
             2 => {
-                self.m31 = r.x.clone();
-                self.m32 = r.y.clone();
+                self.m31 = r.x;
+                self.m32 = r.y;
                 self.m33 = r.z;
             },
             _ => panic!(format!("Index out of range: 3d matrices do not have {} rows.",  i))
@@ -168,7 +169,7 @@ impl<N: Clone> Row<Vec3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Clone> Col<Vec3<N>> for Mat3<N> {
+impl<N: Copy> Col<Vec3<N>> for Mat3<N> {
     #[inline]
     fn ncols(&self) -> uint {
         3
@@ -177,9 +178,9 @@ impl<N: Clone> Col<Vec3<N>> for Mat3<N> {
     #[inline]
     fn col(&self, i: uint) -> Vec3<N> {
         match i {
-            0 => Vec3::new(self.m11.clone(), self.m21.clone(), self.m31.clone()),
-            1 => Vec3::new(self.m12.clone(), self.m22.clone(), self.m32.clone()),
-            2 => Vec3::new(self.m13.clone(), self.m23.clone(), self.m33.clone()),
+            0 => Vec3::new(self.m11, self.m21, self.m31),
+            1 => Vec3::new(self.m12, self.m22, self.m32),
+            2 => Vec3::new(self.m13, self.m23, self.m33),
             _ => panic!(format!("Index out of range: 3d matrices do not have {} cols.", i))
         }
     }
@@ -188,18 +189,18 @@ impl<N: Clone> Col<Vec3<N>> for Mat3<N> {
     fn set_col(&mut self, i: uint, r: Vec3<N>) {
         match i {
             0 => {
-                self.m11 = r.x.clone();
-                self.m21 = r.y.clone();
+                self.m11 = r.x;
+                self.m21 = r.y;
                 self.m31 = r.z;
             },
             1 => {
-                self.m12 = r.x.clone();
-                self.m22 = r.y.clone();
+                self.m12 = r.x;
+                self.m22 = r.y;
                 self.m32 = r.z;
             },
             2 => {
-                self.m13 = r.x.clone();
-                self.m23 = r.y.clone();
+                self.m13 = r.x;
+                self.m23 = r.y;
                 self.m33 = r.z;
             },
             _ => panic!(format!("Index out of range: 3d matrices do not have {} cols.", i))
@@ -208,9 +209,9 @@ impl<N: Clone> Col<Vec3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Mat3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Mat3<N>> for Mat3<N> {
     #[inline]
-    fn mul(&self, right: &Mat3<N>) -> Mat3<N> {
+    fn mul(self, right: Mat3<N>) -> Mat3<N> {
         Mat3::new(
             self.m11 * right.m11 + self.m12 * right.m21 + self.m13 * right.m31,
             self.m11 * right.m12 + self.m12 * right.m22 + self.m13 * right.m32,
@@ -227,9 +228,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Mat3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Mat2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Mat2<N>> for Mat2<N> {
     #[inline(always)]
-    fn mul(&self, right: &Mat2<N>) -> Mat2<N> {
+    fn mul(self, right: Mat2<N>) -> Mat2<N> {
         Mat2::new(
             self.m11 * right.m11 + self.m12 * right.m21,
             self.m11 * right.m12 + self.m12 * right.m22,
@@ -240,9 +241,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Mat2<N>> for Mat2<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Vec3<N>, Vec3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec3<N>, Vec3<N>> for Mat3<N> {
     #[inline(always)]
-    fn mul(&self, right: &Vec3<N>) -> Vec3<N> {
+    fn mul(self, right: Vec3<N>) -> Vec3<N> {
         Vec3::new(
             self.m11 * right.x + self.m12 * right.y + self.m13 * right.z,
             self.m21 * right.x + self.m22 * right.y + self.m23 * right.z,
@@ -251,9 +252,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Vec3<N>, Vec3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Vec3<N>> for Vec3<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Vec3<N>> for Vec3<N> {
     #[inline(always)]
-    fn mul(&self, right: &Mat3<N>) -> Vec3<N> {
+    fn mul(self, right: Mat3<N>) -> Vec3<N> {
         Vec3::new(
             self.x * right.m11 + self.y * right.m21 + self.z * right.m31,
             self.x * right.m12 + self.y * right.m22 + self.z * right.m32,
@@ -262,9 +263,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Vec3<N>> for Vec3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Vec2<N>> for Vec2<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Vec2<N>> for Vec2<N> {
     #[inline(always)]
-    fn mul(&self, right: &Mat2<N>) -> Vec2<N> {
+    fn mul(self, right: Mat2<N>) -> Vec2<N> {
         Vec2::new(
             self.x * right.m11 + self.y * right.m21,
             self.x * right.m12 + self.y * right.m22
@@ -272,9 +273,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Vec2<N>> for Vec2<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Vec2<N>, Vec2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec2<N>, Vec2<N>> for Mat2<N> {
     #[inline(always)]
-    fn mul(&self, right: &Vec2<N>) -> Vec2<N> {
+    fn mul(self, right: Vec2<N>) -> Vec2<N> {
         Vec2::new(
             self.m11 * right.x + self.m12 * right.y,
             self.m21 * right.x + self.m22 * right.y
@@ -282,9 +283,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Vec2<N>, Vec2<N>> for Mat2<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Pnt3<N>, Pnt3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Pnt3<N>, Pnt3<N>> for Mat3<N> {
     #[inline(always)]
-    fn mul(&self, right: &Pnt3<N>) -> Pnt3<N> {
+    fn mul(self, right: Pnt3<N>) -> Pnt3<N> {
         Pnt3::new(
             self.m11 * right.x + self.m12 * right.y + self.m13 * right.z,
             self.m21 * right.x + self.m22 * right.y + self.m23 * right.z,
@@ -293,9 +294,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Pnt3<N>, Pnt3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Pnt3<N>> for Pnt3<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Pnt3<N>> for Pnt3<N> {
     #[inline(always)]
-    fn mul(&self, right: &Mat3<N>) -> Pnt3<N> {
+    fn mul(self, right: Mat3<N>) -> Pnt3<N> {
         Pnt3::new(
             self.x * right.m11 + self.y * right.m21 + self.z * right.m31,
             self.x * right.m12 + self.y * right.m22 + self.z * right.m32,
@@ -304,9 +305,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Pnt3<N>> for Pnt3<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Pnt2<N>> for Pnt2<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Pnt2<N>> for Pnt2<N> {
     #[inline(always)]
-    fn mul(&self, right: &Mat2<N>) -> Pnt2<N> {
+    fn mul(self, right: Mat2<N>) -> Pnt2<N> {
         Pnt2::new(
             self.x * right.m11 + self.y * right.m21,
             self.x * right.m12 + self.y * right.m22
@@ -314,9 +315,9 @@ impl<N: Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Pnt2<N>> for Pnt2<N> {
     }
 }
 
-impl<N: Mul<N, N> + Add<N, N>> Mul<Pnt2<N>, Pnt2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Pnt2<N>, Pnt2<N>> for Mat2<N> {
     #[inline(always)]
-    fn mul(&self, right: &Pnt2<N>) -> Pnt2<N> {
+    fn mul(self, right: Pnt2<N>) -> Pnt2<N> {
         Pnt2::new(
             self.m11 * right.x + self.m12 * right.y,
             self.m21 * right.x + self.m22 * right.y

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -100,14 +100,14 @@ impl<N> Basis for vec::Vec0<N> {
 
 impl<N, T> Add<T, vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
-    fn add(&self, _: &T) -> vec::Vec0<N> {
+    fn add(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
 impl<N, T> Sub<T, vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
-    fn sub(&self, _: &T) -> vec::Vec0<N> {
+    fn sub(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
@@ -128,22 +128,22 @@ impl<N: BaseNum> Dot<N> for vec::Vec0<N> {
 
 impl<N, T> Mul<T, vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
-    fn mul(&self, _: &T) -> vec::Vec0<N> {
+    fn mul(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
 impl<N, T> Div<T, vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
-    fn div(&self, _: &T) -> vec::Vec0<N> {
+    fn div(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
-impl<N: Clone + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
+impl<N: Copy + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
     fn translation(&self) -> vec::Vec0<N> {
-        self.clone()
+        *self
     }
 
     #[inline]

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -270,7 +270,7 @@ pub trait RMul<V> {
     fn rmul(&self, v: &V) -> V;
 }
 
-impl<M: Mul<T, T>, T> RMul<T> for M {
+impl<M: Copy + Mul<T, T>, T: Copy> RMul<T> for M {
     fn rmul(&self, v: &T) -> T {
         *self * *v
     }
@@ -282,7 +282,7 @@ pub trait LMul<V> {
     fn lmul(&self, &V) -> V;
 }
 
-impl<T: Mul<M, T>, M> LMul<T> for M {
+impl<T: Copy + Mul<M, T>, M: Copy> LMul<T> for M {
     fn lmul(&self, v: &T) -> T {
         *v * *self
     }
@@ -366,3 +366,27 @@ impl_absolute_id!(u16)
 impl_absolute_id!(u32)
 impl_absolute_id!(u64)
 impl_absolute_id!(uint)
+
+macro_rules! impl_axpy(
+    ($n: ty) => {
+        impl Axpy<$n> for $n {
+            #[inline]
+            fn axpy(&mut self, a: &$n, x: &$n) {
+                *self = *self + *a * *x
+            }
+        }
+    }
+)
+
+impl_axpy!(f32)
+impl_axpy!(f64)
+impl_axpy!(i8)
+impl_axpy!(i16)
+impl_axpy!(i32)
+impl_axpy!(i64)
+impl_axpy!(int)
+impl_axpy!(u8)
+impl_axpy!(u16)
+impl_axpy!(u32)
+impl_axpy!(u64)
+impl_axpy!(uint)

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -8,8 +8,9 @@ use traits::operations::{RMul, LMul, Axpy, Transpose, Inv, Absolute};
 use traits::geometry::{Dot, Norm, Orig};
 
 /// Basic integral numeric trait.
-pub trait BaseNum: Zero + One + Add<Self, Self> + Sub<Self, Self> + Mul<Self, Self> +
-                   Div<Self, Self> + Rem<Self, Self> + Neg<Self> + PartialEq + Absolute<Self> {
+pub trait BaseNum: Copy + Zero + One + Add<Self, Self> + Sub<Self, Self> + Mul<Self, Self> +
+                   Div<Self, Self> + Rem<Self, Self> + Neg<Self> + PartialEq + Absolute<Self> +
+                   Axpy<Self> {
 }
 
 /// Basic floating-point number numeric trait.
@@ -262,7 +263,7 @@ pub trait PntAsVec<V> {
 // XXX: the vector space element `V` should be an associated type. Though this would prevent V from
 // having bounds (they are not supported yet). So, for now, we will just use a type parameter.
 pub trait NumPnt<N, V>:
-          PntAsVec<V> + Dim + Sub<Self, V> + Orig + Neg<Self> + PartialEq + Mul<N, Self> +
+          Copy + PntAsVec<V> + Dim + Sub<Self, V> + Orig + Neg<Self> + PartialEq + Mul<N, Self> +
           Div<N, Self> + Add<V, Self> + Axpy<N> + Index<uint, N> { // FIXME: + Sub<V, Self>
 }
 

--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -3,7 +3,6 @@
 extern crate "nalgebra" as na;
 
 use std::rand::random;
-use std::cmp::{min, max};
 use na::{Vec1, Vec3, Mat1, Mat2, Mat3, Mat4, Mat5, Mat6, Rot3, Persp3, PerspMat3, Ortho3, OrthoMat3,
          DMat, DVec, Row, Col, BaseFloat};
 
@@ -250,6 +249,7 @@ fn test_dmat_from_vec() {
     assert!(mat1 == mat2);
 }
 
+/* FIXME: review qr decomposition to make it work with DMat.
 #[test]
 fn test_qr() {
     for _ in range(0u, 10) {
@@ -264,6 +264,7 @@ fn test_qr() {
         assert!(na::approx_eq(&randmat,  &recomp));
     }
 }
+*/
 
 #[test]
 fn test_qr_mat1() {


### PR DESCRIPTION
Version of rustc: 0.13.0-nightly (42deaa5e4 2014-12-16 17:51:23 +0000).

This is a quick fix that introduces some backward incompatibilities: it assumes that `N` is always `Copy` (and `Clone`). If we do not make this assumption, we have to be careful and restrict the amount of cloning to a minimum as it may induce some costly memory operations (e.g. allocation). This patch is not that careful because doing so requires a lot more work (perhaps introducing new traits for in-place operations like: `mul_to(left: &Vec3<N>, right: &Vec3<N>, out: &Vec3<N>)`. I will create an issue about this as soon as I have the time to develop this.

The two salient backward incompatibilities brought by this patch are:
1. operator overloading will not work any more if the scalar type is not `Copy` (e.g. you won't be able to add two `Vec3<DVec<f32>>`).
2. QR decomposition (and the QR method for eigenvector extraction) won't work for `DMat` any more.
