### PR TITLE
Add trailing ';' to all item macros

### DIFF
--- a/src/macros/assert.rs
+++ b/src/macros/assert.rs
@@ -11,7 +11,7 @@ macro_rules! assert_approx_eq_eps(
             )
         }
     })
-)
+);
 
 /// Asserts approximate equality of two values with the `ApproxEq` trait.
 #[macro_export]
@@ -25,4 +25,4 @@ macro_rules! assert_approx_eq(
             )
         }
     })
-)
+);

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -77,7 +77,7 @@ impl<N> FromIterator<N> for DVec<N> {
 }
 
 
-dvec_impl!(DVec)
+dvec_impl!(DVec);
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 1.
 pub struct DVec1<N> {
@@ -85,8 +85,8 @@ pub struct DVec1<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec1, 1, 0)
-small_dvec_from_impl!(DVec1, 1, ::zero())
+small_dvec_impl!(DVec1, 1, 0);
+small_dvec_from_impl!(DVec1, 1, ::zero());
 
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 2.
@@ -95,8 +95,8 @@ pub struct DVec2<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec2, 2, 0, 1)
-small_dvec_from_impl!(DVec2, 2, ::zero(), ::zero())
+small_dvec_impl!(DVec2, 2, 0, 1);
+small_dvec_from_impl!(DVec2, 2, ::zero(), ::zero());
 
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 3.
@@ -105,8 +105,8 @@ pub struct DVec3<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec3, 3, 0, 1, 2)
-small_dvec_from_impl!(DVec3, 3, ::zero(), ::zero(), ::zero())
+small_dvec_impl!(DVec3, 3, 0, 1, 2);
+small_dvec_from_impl!(DVec3, 3, ::zero(), ::zero(), ::zero());
 
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 4.
@@ -115,8 +115,8 @@ pub struct DVec4<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec4, 4, 0, 1, 2, 3)
-small_dvec_from_impl!(DVec4, 4, ::zero(), ::zero(), ::zero(), ::zero())
+small_dvec_impl!(DVec4, 4, 0, 1, 2, 3);
+small_dvec_from_impl!(DVec4, 4, ::zero(), ::zero(), ::zero(), ::zero());
 
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 5.
@@ -125,8 +125,8 @@ pub struct DVec5<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec5, 5, 0, 1, 2, 3, 4)
-small_dvec_from_impl!(DVec5, 5, ::zero(), ::zero(), ::zero(), ::zero(), ::zero())
+small_dvec_impl!(DVec5, 5, 0, 1, 2, 3, 4);
+small_dvec_from_impl!(DVec5, 5, ::zero(), ::zero(), ::zero(), ::zero(), ::zero());
 
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 6.
@@ -135,5 +135,5 @@ pub struct DVec6<N> {
     dim: uint
 }
 
-small_dvec_impl!(DVec6, 6, 0, 1, 2, 3, 4, 5)
-small_dvec_from_impl!(DVec6, 6, ::zero(), ::zero(), ::zero(), ::zero(), ::zero(), ::zero())
+small_dvec_impl!(DVec6, 6, 0, 1, 2, 3, 4, 5);
+small_dvec_from_impl!(DVec6, 6, ::zero(), ::zero(), ::zero(), ::zero(), ::zero(), ::zero());

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -359,7 +359,7 @@ macro_rules! dvec_impl(
             }
         }
     )
-)
+);
 
 macro_rules! small_dvec_impl (
     ($dvec: ident, $dim: expr $(,$idx: expr)*) => (
@@ -398,9 +398,9 @@ macro_rules! small_dvec_impl (
             }
         }
 
-        dvec_impl!($dvec)
+        dvec_impl!($dvec);
     )
-)
+);
 
 macro_rules! small_dvec_from_impl (
     ($dvec: ident, $dim: expr $(,$zeros: expr)*) => (
@@ -488,4 +488,4 @@ macro_rules! small_dvec_from_impl (
             }
         }
     )
-)
+);

--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -92,59 +92,59 @@ impl<N> Iso4<N> {
     }
 }
 
-iso_impl!(Iso2, Rot2, Vec2, Vec1)
-rotation_matrix_impl!(Iso2, Rot2, Vec2, Vec1)
-rotation_impl!(Iso2, Rot2, Vec1)
-dim_impl!(Iso2, 2)
-one_impl!(Iso2)
-absolute_rotate_impl!(Iso2, Vec2)
-rand_impl!(Iso2)
-approx_eq_impl!(Iso2)
-to_homogeneous_impl!(Iso2, Mat3)
-inv_impl!(Iso2)
-transform_impl!(Iso2, Pnt2)
-transformation_impl!(Iso2)
-rotate_impl!(Iso2, Vec2)
-translation_impl!(Iso2, Vec2)
-translate_impl!(Iso2, Pnt2)
-iso_mul_iso_impl!(Iso2)
-iso_mul_pnt_impl!(Iso2, Pnt2)
-pnt_mul_iso_impl!(Iso2, Pnt2)
+iso_impl!(Iso2, Rot2, Vec2, Vec1);
+rotation_matrix_impl!(Iso2, Rot2, Vec2, Vec1);
+rotation_impl!(Iso2, Rot2, Vec1);
+dim_impl!(Iso2, 2);
+one_impl!(Iso2);
+absolute_rotate_impl!(Iso2, Vec2);
+rand_impl!(Iso2);
+approx_eq_impl!(Iso2);
+to_homogeneous_impl!(Iso2, Mat3);
+inv_impl!(Iso2);
+transform_impl!(Iso2, Pnt2);
+transformation_impl!(Iso2);
+rotate_impl!(Iso2, Vec2);
+translation_impl!(Iso2, Vec2);
+translate_impl!(Iso2, Pnt2);
+iso_mul_iso_impl!(Iso2);
+iso_mul_pnt_impl!(Iso2, Pnt2);
+pnt_mul_iso_impl!(Iso2, Pnt2);
 
-iso_impl!(Iso3, Rot3, Vec3, Vec3)
-rotation_matrix_impl!(Iso3, Rot3, Vec3, Vec3)
-rotation_impl!(Iso3, Rot3, Vec3)
-dim_impl!(Iso3, 3)
-one_impl!(Iso3)
-absolute_rotate_impl!(Iso3, Vec3)
-rand_impl!(Iso3)
-approx_eq_impl!(Iso3)
-to_homogeneous_impl!(Iso3, Mat4)
-inv_impl!(Iso3)
-transform_impl!(Iso3, Pnt3)
-transformation_impl!(Iso3)
-rotate_impl!(Iso3, Vec3)
-translation_impl!(Iso3, Vec3)
-translate_impl!(Iso3, Pnt3)
-iso_mul_iso_impl!(Iso3)
-iso_mul_pnt_impl!(Iso3, Pnt3)
-pnt_mul_iso_impl!(Iso3, Pnt3)
+iso_impl!(Iso3, Rot3, Vec3, Vec3);
+rotation_matrix_impl!(Iso3, Rot3, Vec3, Vec3);
+rotation_impl!(Iso3, Rot3, Vec3);
+dim_impl!(Iso3, 3);
+one_impl!(Iso3);
+absolute_rotate_impl!(Iso3, Vec3);
+rand_impl!(Iso3);
+approx_eq_impl!(Iso3);
+to_homogeneous_impl!(Iso3, Mat4);
+inv_impl!(Iso3);
+transform_impl!(Iso3, Pnt3);
+transformation_impl!(Iso3);
+rotate_impl!(Iso3, Vec3);
+translation_impl!(Iso3, Vec3);
+translate_impl!(Iso3, Pnt3);
+iso_mul_iso_impl!(Iso3);
+iso_mul_pnt_impl!(Iso3, Pnt3);
+pnt_mul_iso_impl!(Iso3, Pnt3);
 
-// iso_impl!(Iso4, Rot4, Vec4, Vec4)
-// rotation_matrix_impl!(Iso4, Rot4, Vec4, Vec4)
-// rotation_impl!(Iso4, Rot4, Vec4)
-dim_impl!(Iso4, 4)
-one_impl!(Iso4)
-absolute_rotate_impl!(Iso4, Vec4)
-// rand_impl!(Iso4)
-approx_eq_impl!(Iso4)
-to_homogeneous_impl!(Iso4, Mat5)
-inv_impl!(Iso4)
-transform_impl!(Iso4, Pnt4)
-transformation_impl!(Iso4)
-rotate_impl!(Iso4, Vec4)
-translation_impl!(Iso4, Vec4)
-translate_impl!(Iso4, Pnt4)
-iso_mul_iso_impl!(Iso4)
-iso_mul_pnt_impl!(Iso4, Pnt4)
-pnt_mul_iso_impl!(Iso4, Pnt4)
+// iso_impl!(Iso4, Rot4, Vec4, Vec4);
+// rotation_matrix_impl!(Iso4, Rot4, Vec4, Vec4);
+// rotation_impl!(Iso4, Rot4, Vec4);
+dim_impl!(Iso4, 4);
+one_impl!(Iso4);
+absolute_rotate_impl!(Iso4, Vec4);
+// rand_impl!(Iso4);
+approx_eq_impl!(Iso4);
+to_homogeneous_impl!(Iso4, Mat5);
+inv_impl!(Iso4);
+transform_impl!(Iso4, Pnt4);
+transformation_impl!(Iso4);
+rotate_impl!(Iso4, Vec4);
+translation_impl!(Iso4, Vec4);
+translate_impl!(Iso4, Pnt4);
+iso_mul_iso_impl!(Iso4);
+iso_mul_pnt_impl!(Iso4, Pnt4);
+pnt_mul_iso_impl!(Iso4, Pnt4);

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -22,7 +22,7 @@ macro_rules! iso_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotation_matrix_impl(
     ($t: ident, $trot: ident, $tlv: ident, $tav: ident) => (
@@ -34,7 +34,7 @@ macro_rules! rotation_matrix_impl(
             }
         }
     )
-)
+);
 
 
 macro_rules! dim_impl(
@@ -46,7 +46,7 @@ macro_rules! dim_impl(
             }
         }
     )
-)
+);
 
 macro_rules! one_impl(
     ($t: ident) => (
@@ -57,7 +57,7 @@ macro_rules! one_impl(
             }
         }
     )
-)
+);
 
 macro_rules! iso_mul_iso_impl(
     ($t: ident) => (
@@ -70,7 +70,7 @@ macro_rules! iso_mul_iso_impl(
             }
         }
     )
-)
+);
 
 macro_rules! iso_mul_pnt_impl(
     ($t: ident, $tv: ident) => (
@@ -81,7 +81,7 @@ macro_rules! iso_mul_pnt_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_mul_iso_impl(
     ($t: ident, $tv: ident) => (
@@ -92,7 +92,7 @@ macro_rules! pnt_mul_iso_impl(
             }
         }
     )
-)
+);
 
 macro_rules! translation_impl(
     ($t: ident, $tv: ident) => (
@@ -133,7 +133,7 @@ macro_rules! translation_impl(
             }
         }
     )
-)
+);
 
 macro_rules! translate_impl(
     ($t: ident, $tv: ident) => (
@@ -149,7 +149,7 @@ macro_rules! translate_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotation_impl(
     ($t: ident, $trot: ident, $tav: ident) => (
@@ -200,7 +200,7 @@ macro_rules! rotation_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotate_impl(
     ($t: ident, $tv: ident) => (
@@ -216,7 +216,7 @@ macro_rules! rotate_impl(
             }
         }
     )
-)
+);
 
 macro_rules! transformation_impl(
     ($t: ident) => (
@@ -251,7 +251,7 @@ macro_rules! transformation_impl(
             }
         }
     )
-)
+);
 
 macro_rules! transform_impl(
     ($t: ident, $tp: ident) => (
@@ -267,7 +267,7 @@ macro_rules! transform_impl(
             }
         }
     )
-)
+);
 
 macro_rules! inv_impl(
     ($t: ident) => (
@@ -289,7 +289,7 @@ macro_rules! inv_impl(
             }
         }
     )
-)
+);
 
 macro_rules! to_homogeneous_impl(
     ($t: ident, $th: ident) => (
@@ -306,7 +306,7 @@ macro_rules! to_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! approx_eq_impl(
     ($t: ident) => (
@@ -323,7 +323,7 @@ macro_rules! approx_eq_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rand_impl(
     ($t: ident) => (
@@ -334,7 +334,7 @@ macro_rules! rand_impl(
             }
         }
     )
-)
+);
 
 macro_rules! absolute_rotate_impl(
     ($t: ident, $tv: ident) => (
@@ -345,4 +345,4 @@ macro_rules! absolute_rotate_impl(
             }
         }
     )
-)
+);

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -34,43 +34,43 @@ pub struct Mat1<N> {
     pub m11: N
 }
 
-eye_impl!(Mat1, 1, m11)
+eye_impl!(Mat1, 1, m11);
 
-mat_impl!(Mat1, m11)
-as_array_impl!(Mat1, 1)
-mat_cast_impl!(Mat1, m11)
-add_impl!(Mat1, m11)
-sub_impl!(Mat1, m11)
-scalar_add_impl!(Mat1, m11)
-scalar_sub_impl!(Mat1, m11)
-scalar_mul_impl!(Mat1, m11)
-scalar_div_impl!(Mat1, m11)
-absolute_impl!(Mat1, m11)
-zero_impl!(Mat1, m11)
-one_impl!(Mat1, ::one)
-iterable_impl!(Mat1, 1)
-iterable_mut_impl!(Mat1, 1)
-at_fast_impl!(Mat1, 1)
-dim_impl!(Mat1, 1)
-indexable_impl!(Mat1, 1)
-index_impl!(Mat1, 1)
-mat_mul_mat_impl!(Mat1, 1)
-mat_mul_vec_impl!(Mat1, Vec1, 1, ::zero)
-vec_mul_mat_impl!(Mat1, Vec1, 1, ::zero)
-mat_mul_pnt_impl!(Mat1, Pnt1, 1, Orig::orig)
-pnt_mul_mat_impl!(Mat1, Pnt1, 1, Orig::orig)
-// (specialized) inv_impl!(Mat1, 1)
-transpose_impl!(Mat1, 1)
-approx_eq_impl!(Mat1)
-row_impl!(Mat1, Vec1, 1)
-col_impl!(Mat1, Vec1, 1)
-col_slice_impl!(Mat1, Vec1, DVec1, 1)
-row_slice_impl!(Mat1, Vec1, DVec1, 1)
-diag_impl!(Mat1, Vec1, 1)
-to_homogeneous_impl!(Mat1, Mat2, 1, 2)
-from_homogeneous_impl!(Mat1, Mat2, 1, 2)
-outer_impl!(Vec1, Mat1)
-eigen_qr_impl!(Mat1, Vec1)
+mat_impl!(Mat1, m11);
+as_array_impl!(Mat1, 1);
+mat_cast_impl!(Mat1, m11);
+add_impl!(Mat1, m11);
+sub_impl!(Mat1, m11);
+scalar_add_impl!(Mat1, m11);
+scalar_sub_impl!(Mat1, m11);
+scalar_mul_impl!(Mat1, m11);
+scalar_div_impl!(Mat1, m11);
+absolute_impl!(Mat1, m11);
+zero_impl!(Mat1, m11);
+one_impl!(Mat1, ::one);
+iterable_impl!(Mat1, 1);
+iterable_mut_impl!(Mat1, 1);
+at_fast_impl!(Mat1, 1);
+dim_impl!(Mat1, 1);
+indexable_impl!(Mat1, 1);
+index_impl!(Mat1, 1);
+mat_mul_mat_impl!(Mat1, 1);
+mat_mul_vec_impl!(Mat1, Vec1, 1, ::zero);
+vec_mul_mat_impl!(Mat1, Vec1, 1, ::zero);
+mat_mul_pnt_impl!(Mat1, Pnt1, 1, Orig::orig);
+pnt_mul_mat_impl!(Mat1, Pnt1, 1, Orig::orig);
+// (specialized); inv_impl!(Mat1, 1);
+transpose_impl!(Mat1, 1);
+approx_eq_impl!(Mat1);
+row_impl!(Mat1, Vec1, 1);
+col_impl!(Mat1, Vec1, 1);
+col_slice_impl!(Mat1, Vec1, DVec1, 1);
+row_slice_impl!(Mat1, Vec1, DVec1, 1);
+diag_impl!(Mat1, Vec1, 1);
+to_homogeneous_impl!(Mat1, Mat2, 1, 2);
+from_homogeneous_impl!(Mat1, Mat2, 1, 2);
+outer_impl!(Vec1, Mat1);
+eigen_qr_impl!(Mat1, Vec1);
 
 /// Square matrix of dimension 2.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -79,46 +79,46 @@ pub struct Mat2<N> {
     pub m12: N, pub m22: N
 }
 
-eye_impl!(Mat2, 2, m11, m22)
+eye_impl!(Mat2, 2, m11, m22);
 
 mat_impl!(Mat2, m11, m12,
-                m21, m22)
-as_array_impl!(Mat2, 2)
+                m21, m22);
+as_array_impl!(Mat2, 2);
 mat_cast_impl!(Mat2, m11, m12,
-                     m21, m22)
-add_impl!(Mat2, m11, m12, m21, m22)
-sub_impl!(Mat2, m11, m12, m21, m22)
-scalar_add_impl!(Mat2, m11, m12, m21, m22)
-scalar_sub_impl!(Mat2, m11, m12, m21, m22)
-scalar_mul_impl!(Mat2, m11, m12, m21, m22)
-scalar_div_impl!(Mat2, m11, m12, m21, m22)
+                     m21, m22);
+add_impl!(Mat2, m11, m12, m21, m22);
+sub_impl!(Mat2, m11, m12, m21, m22);
+scalar_add_impl!(Mat2, m11, m12, m21, m22);
+scalar_sub_impl!(Mat2, m11, m12, m21, m22);
+scalar_mul_impl!(Mat2, m11, m12, m21, m22);
+scalar_div_impl!(Mat2, m11, m12, m21, m22);
 absolute_impl!(Mat2, m11, m12,
-                     m21, m22)
+                     m21, m22);
 zero_impl!(Mat2, m11, m12,
-                 m21, m22)
+                 m21, m22);
 one_impl!(Mat2, ::one,  ::zero,
-                ::zero, ::one)
-iterable_impl!(Mat2, 2)
-iterable_mut_impl!(Mat2, 2)
-dim_impl!(Mat2, 2)
-indexable_impl!(Mat2, 2)
-index_impl!(Mat2, 2)
-at_fast_impl!(Mat2, 2)
-// (specialized) mul_impl!(Mat2, 2)
-// (specialized) rmul_impl!(Mat2, Vec2, 2)
-// (specialized) lmul_impl!(Mat2, Vec2, 2)
-// (specialized) inv_impl!(Mat2, 2)
-transpose_impl!(Mat2, 2)
-approx_eq_impl!(Mat2)
-row_impl!(Mat2, Vec2, 2)
-col_impl!(Mat2, Vec2, 2)
-col_slice_impl!(Mat2, Vec2, DVec2, 2)
-row_slice_impl!(Mat2, Vec2, DVec2, 2)
-diag_impl!(Mat2, Vec2, 2)
-to_homogeneous_impl!(Mat2, Mat3, 2, 3)
-from_homogeneous_impl!(Mat2, Mat3, 2, 3)
-outer_impl!(Vec2, Mat2)
-eigen_qr_impl!(Mat2, Vec2)
+                ::zero, ::one);
+iterable_impl!(Mat2, 2);
+iterable_mut_impl!(Mat2, 2);
+dim_impl!(Mat2, 2);
+indexable_impl!(Mat2, 2);
+index_impl!(Mat2, 2);
+at_fast_impl!(Mat2, 2);
+// (specialized); mul_impl!(Mat2, 2);
+// (specialized); rmul_impl!(Mat2, Vec2, 2);
+// (specialized); lmul_impl!(Mat2, Vec2, 2);
+// (specialized); inv_impl!(Mat2, 2);
+transpose_impl!(Mat2, 2);
+approx_eq_impl!(Mat2);
+row_impl!(Mat2, Vec2, 2);
+col_impl!(Mat2, Vec2, 2);
+col_slice_impl!(Mat2, Vec2, DVec2, 2);
+row_slice_impl!(Mat2, Vec2, DVec2, 2);
+diag_impl!(Mat2, Vec2, 2);
+to_homogeneous_impl!(Mat2, Mat3, 2, 3);
+from_homogeneous_impl!(Mat2, Mat3, 2, 3);
+outer_impl!(Vec2, Mat2);
+eigen_qr_impl!(Mat2, Vec2);
 
 /// Square matrix of dimension 3.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -128,79 +128,79 @@ pub struct Mat3<N> {
     pub m13: N, pub m23: N, pub m33: N
 }
 
-eye_impl!(Mat3, 3, m11, m22, m33)
+eye_impl!(Mat3, 3, m11, m22, m33);
 
 mat_impl!(Mat3, m11, m12, m13,
                 m21, m22, m23,
-                m31, m32, m33)
-as_array_impl!(Mat3, 3)
+                m31, m32, m33);
+as_array_impl!(Mat3, 3);
 mat_cast_impl!(Mat3, m11, m12, m13,
                      m21, m22, m23,
-                     m31, m32, m33)
+                     m31, m32, m33);
 add_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 sub_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 scalar_add_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 scalar_sub_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 scalar_mul_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 scalar_div_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 absolute_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 zero_impl!(Mat3,
     m11, m12, m13,
     m21, m22, m23,
     m31, m32, m33
-)
+);
 one_impl!(Mat3, ::one , ::zero, ::zero,
                 ::zero, ::one , ::zero,
-                ::zero, ::zero, ::one)
-iterable_impl!(Mat3, 3)
-iterable_mut_impl!(Mat3, 3)
-dim_impl!(Mat3, 3)
-indexable_impl!(Mat3, 3)
-index_impl!(Mat3, 3)
-at_fast_impl!(Mat3, 3)
-// (specialized) mul_impl!(Mat3, 3)
-// (specialized) rmul_impl!(Mat3, Vec3, 3)
-// (specialized) lmul_impl!(Mat3, Vec3, 3)
-// (specialized) inv_impl!(Mat3, 3)
-transpose_impl!(Mat3, 3)
-approx_eq_impl!(Mat3)
-// (specialized) row_impl!(Mat3, Vec3, 3)
-// (specialized) col_impl!(Mat3, Vec3, 3)
-col_slice_impl!(Mat3, Vec3, DVec3, 3)
-row_slice_impl!(Mat3, Vec3, DVec3, 3)
-diag_impl!(Mat3, Vec3, 3)
-to_homogeneous_impl!(Mat3, Mat4, 3, 4)
-from_homogeneous_impl!(Mat3, Mat4, 3, 4)
-outer_impl!(Vec3, Mat3)
-eigen_qr_impl!(Mat3, Vec3)
+                ::zero, ::zero, ::one);
+iterable_impl!(Mat3, 3);
+iterable_mut_impl!(Mat3, 3);
+dim_impl!(Mat3, 3);
+indexable_impl!(Mat3, 3);
+index_impl!(Mat3, 3);
+at_fast_impl!(Mat3, 3);
+// (specialized); mul_impl!(Mat3, 3);
+// (specialized); rmul_impl!(Mat3, Vec3, 3);
+// (specialized); lmul_impl!(Mat3, Vec3, 3);
+// (specialized); inv_impl!(Mat3, 3);
+transpose_impl!(Mat3, 3);
+approx_eq_impl!(Mat3);
+// (specialized); row_impl!(Mat3, Vec3, 3);
+// (specialized); col_impl!(Mat3, Vec3, 3);
+col_slice_impl!(Mat3, Vec3, DVec3, 3);
+row_slice_impl!(Mat3, Vec3, DVec3, 3);
+diag_impl!(Mat3, Vec3, 3);
+to_homogeneous_impl!(Mat3, Mat4, 3, 4);
+from_homogeneous_impl!(Mat3, Mat4, 3, 4);
+outer_impl!(Vec3, Mat3);
+eigen_qr_impl!(Mat3, Vec3);
 
 /// Square matrix of dimension 4.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -211,96 +211,96 @@ pub struct Mat4<N> {
     pub m14: N, pub m24: N, pub m34: N, pub m44: N
 }
 
-eye_impl!(Mat4, 4, m11, m22, m33, m44)
+eye_impl!(Mat4, 4, m11, m22, m33, m44);
 
 mat_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
-as_array_impl!(Mat4, 4)
+);
+as_array_impl!(Mat4, 4);
 mat_cast_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 add_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 sub_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 scalar_add_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 scalar_sub_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 scalar_mul_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 scalar_div_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 absolute_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 zero_impl!(Mat4,
   m11, m12, m13, m14,
   m21, m22, m23, m24,
   m31, m32, m33, m34,
   m41, m42, m43, m44
-)
+);
 one_impl!(Mat4, ::one  , ::zero, ::zero, ::zero,
                 ::zero, ::one  , ::zero, ::zero,
                 ::zero, ::zero, ::one  , ::zero,
-                ::zero, ::zero, ::zero, ::one)
-iterable_impl!(Mat4, 4)
-iterable_mut_impl!(Mat4, 4)
-dim_impl!(Mat4, 4)
-indexable_impl!(Mat4, 4)
-index_impl!(Mat4, 4)
-at_fast_impl!(Mat4, 4)
-mat_mul_mat_impl!(Mat4, 4)
-mat_mul_vec_impl!(Mat4, Vec4, 4, ::zero)
-vec_mul_mat_impl!(Mat4, Vec4, 4, ::zero)
-mat_mul_pnt_impl!(Mat4, Pnt4, 4, Orig::orig)
-pnt_mul_mat_impl!(Mat4, Pnt4, 4, Orig::orig)
-inv_impl!(Mat4, 4)
-transpose_impl!(Mat4, 4)
-approx_eq_impl!(Mat4)
-row_impl!(Mat4, Vec4, 4)
-col_impl!(Mat4, Vec4, 4)
-col_slice_impl!(Mat4, Vec4, DVec4, 4)
-row_slice_impl!(Mat4, Vec4, DVec4, 4)
-diag_impl!(Mat4, Vec4, 4)
-to_homogeneous_impl!(Mat4, Mat5, 4, 5)
-from_homogeneous_impl!(Mat4, Mat5, 4, 5)
-outer_impl!(Vec4, Mat4)
-eigen_qr_impl!(Mat4, Vec4)
+                ::zero, ::zero, ::zero, ::one);
+iterable_impl!(Mat4, 4);
+iterable_mut_impl!(Mat4, 4);
+dim_impl!(Mat4, 4);
+indexable_impl!(Mat4, 4);
+index_impl!(Mat4, 4);
+at_fast_impl!(Mat4, 4);
+mat_mul_mat_impl!(Mat4, 4);
+mat_mul_vec_impl!(Mat4, Vec4, 4, ::zero);
+vec_mul_mat_impl!(Mat4, Vec4, 4, ::zero);
+mat_mul_pnt_impl!(Mat4, Pnt4, 4, Orig::orig);
+pnt_mul_mat_impl!(Mat4, Pnt4, 4, Orig::orig);
+inv_impl!(Mat4, 4);
+transpose_impl!(Mat4, 4);
+approx_eq_impl!(Mat4);
+row_impl!(Mat4, Vec4, 4);
+col_impl!(Mat4, Vec4, 4);
+col_slice_impl!(Mat4, Vec4, DVec4, 4);
+row_slice_impl!(Mat4, Vec4, DVec4, 4);
+diag_impl!(Mat4, Vec4, 4);
+to_homogeneous_impl!(Mat4, Mat5, 4, 5);
+from_homogeneous_impl!(Mat4, Mat5, 4, 5);
+outer_impl!(Vec4, Mat4);
+eigen_qr_impl!(Mat4, Vec4);
 
 /// Square matrix of dimension 5.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -312,7 +312,7 @@ pub struct Mat5<N> {
     pub m15: N, pub m25: N, pub m35: N, pub m45: N, pub m55: N
 }
 
-eye_impl!(Mat5, 5, m11, m22, m33, m44, m55)
+eye_impl!(Mat5, 5, m11, m22, m33, m44, m55);
 
 mat_impl!(Mat5,
   m11, m12, m13, m14, m15,
@@ -320,101 +320,101 @@ mat_impl!(Mat5,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
-as_array_impl!(Mat5, 5)
+);
+as_array_impl!(Mat5, 5);
 mat_cast_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 absolute_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 zero_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 one_impl!(Mat5,
   ::one  , ::zero, ::zero, ::zero, ::zero,
   ::zero, ::one  , ::zero, ::zero, ::zero,
   ::zero, ::zero, ::one  , ::zero, ::zero,
   ::zero, ::zero, ::zero, ::one  , ::zero,
   ::zero, ::zero, ::zero, ::zero, ::one
-)
+);
 add_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 sub_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 scalar_add_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 scalar_sub_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 scalar_mul_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
+);
 scalar_div_impl!(Mat5,
   m11, m12, m13, m14, m15,
   m21, m22, m23, m24, m25,
   m31, m32, m33, m34, m35,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
-)
-iterable_impl!(Mat5, 5)
-iterable_mut_impl!(Mat5, 5)
-dim_impl!(Mat5, 5)
-indexable_impl!(Mat5, 5)
-index_impl!(Mat5, 5)
-at_fast_impl!(Mat5, 5)
-mat_mul_mat_impl!(Mat5, 5)
-mat_mul_vec_impl!(Mat5, Vec5, 5, ::zero)
-vec_mul_mat_impl!(Mat5, Vec5, 5, ::zero)
-mat_mul_pnt_impl!(Mat5, Pnt5, 5, Orig::orig)
-pnt_mul_mat_impl!(Mat5, Pnt5, 5, Orig::orig)
-inv_impl!(Mat5, 5)
-transpose_impl!(Mat5, 5)
-approx_eq_impl!(Mat5)
-row_impl!(Mat5, Vec5, 5)
-col_impl!(Mat5, Vec5, 5)
-col_slice_impl!(Mat5, Vec5, DVec5, 5)
-row_slice_impl!(Mat5, Vec5, DVec5, 5)
-diag_impl!(Mat5, Vec5, 5)
-to_homogeneous_impl!(Mat5, Mat6, 5, 6)
-from_homogeneous_impl!(Mat5, Mat6, 5, 6)
-outer_impl!(Vec5, Mat5)
-eigen_qr_impl!(Mat5, Vec5)
+);
+iterable_impl!(Mat5, 5);
+iterable_mut_impl!(Mat5, 5);
+dim_impl!(Mat5, 5);
+indexable_impl!(Mat5, 5);
+index_impl!(Mat5, 5);
+at_fast_impl!(Mat5, 5);
+mat_mul_mat_impl!(Mat5, 5);
+mat_mul_vec_impl!(Mat5, Vec5, 5, ::zero);
+vec_mul_mat_impl!(Mat5, Vec5, 5, ::zero);
+mat_mul_pnt_impl!(Mat5, Pnt5, 5, Orig::orig);
+pnt_mul_mat_impl!(Mat5, Pnt5, 5, Orig::orig);
+inv_impl!(Mat5, 5);
+transpose_impl!(Mat5, 5);
+approx_eq_impl!(Mat5);
+row_impl!(Mat5, Vec5, 5);
+col_impl!(Mat5, Vec5, 5);
+col_slice_impl!(Mat5, Vec5, DVec5, 5);
+row_slice_impl!(Mat5, Vec5, DVec5, 5);
+diag_impl!(Mat5, Vec5, 5);
+to_homogeneous_impl!(Mat5, Mat6, 5, 6);
+from_homogeneous_impl!(Mat5, Mat6, 5, 6);
+outer_impl!(Vec5, Mat5);
+eigen_qr_impl!(Mat5, Vec5);
 
 /// Square matrix of dimension 6.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -427,7 +427,7 @@ pub struct Mat6<N> {
     pub m16: N, pub m26: N, pub m36: N, pub m46: N, pub m56: N, pub m66: N
 }
 
-eye_impl!(Mat6, 6, m11, m22, m33, m44, m55, m66)
+eye_impl!(Mat6, 6, m11, m22, m33, m44, m55, m66);
 
 mat_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
@@ -436,8 +436,8 @@ mat_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
-as_array_impl!(Mat6, 6)
+);
+as_array_impl!(Mat6, 6);
 mat_cast_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -445,7 +445,7 @@ mat_cast_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 add_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -453,7 +453,7 @@ add_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 sub_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -461,7 +461,7 @@ sub_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 scalar_add_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -469,7 +469,7 @@ scalar_add_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 scalar_sub_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -477,7 +477,7 @@ scalar_sub_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 scalar_mul_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -485,7 +485,7 @@ scalar_mul_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 scalar_div_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
@@ -493,14 +493,14 @@ scalar_div_impl!(Mat6,
   m41, m42, m43, m44, m45, m46,
   m51, m52, m53, m54, m55, m56,
   m61, m62, m63, m64, m65, m66
-)
+);
 absolute_impl!(Mat6, m11, m12, m13, m14, m15, m16, m21, m22, m23, m24, m25, m26,
   m31, m32, m33, m34, m35, m36, m41, m42, m43, m44, m45, m46, m51, m52, m53, m54, m55, m56,
-  m61, m62, m63, m64, m65, m66)
+  m61, m62, m63, m64, m65, m66);
 
 zero_impl!(Mat6, m11, m12, m13, m14, m15, m16, m21, m22, m23, m24, m25, m26,
   m31, m32, m33, m34, m35, m36, m41, m42, m43, m44, m45, m46, m51, m52, m53, m54, m55, m56,
-  m61, m62, m63, m64, m65, m66)
+  m61, m62, m63, m64, m65, m66);
 
 one_impl!(Mat6,
   ::one  , ::zero, ::zero, ::zero, ::zero, ::zero,
@@ -509,25 +509,25 @@ one_impl!(Mat6,
   ::zero, ::zero, ::zero, ::one  , ::zero, ::zero,
   ::zero, ::zero, ::zero, ::zero, ::one  , ::zero,
   ::zero, ::zero, ::zero, ::zero, ::zero, ::one
-)
-iterable_impl!(Mat6, 6)
-iterable_mut_impl!(Mat6, 6)
-dim_impl!(Mat6, 6)
-indexable_impl!(Mat6, 6)
-index_impl!(Mat6, 6)
-at_fast_impl!(Mat6, 6)
-mat_mul_mat_impl!(Mat6, 6)
-mat_mul_vec_impl!(Mat6, Vec6, 6, ::zero)
-vec_mul_mat_impl!(Mat6, Vec6, 6, ::zero)
-mat_mul_pnt_impl!(Mat6, Pnt6, 6, Orig::orig)
-pnt_mul_mat_impl!(Mat6, Pnt6, 6, Orig::orig)
-inv_impl!(Mat6, 6)
-transpose_impl!(Mat6, 6)
-approx_eq_impl!(Mat6)
-row_impl!(Mat6, Vec6, 6)
-col_impl!(Mat6, Vec6, 6)
-col_slice_impl!(Mat6, Vec6, DVec6, 6)
-row_slice_impl!(Mat6, Vec6, DVec6, 6)
-diag_impl!(Mat6, Vec6, 6)
-outer_impl!(Vec6, Mat6)
-eigen_qr_impl!(Mat6, Vec6)
+);
+iterable_impl!(Mat6, 6);
+iterable_mut_impl!(Mat6, 6);
+dim_impl!(Mat6, 6);
+indexable_impl!(Mat6, 6);
+index_impl!(Mat6, 6);
+at_fast_impl!(Mat6, 6);
+mat_mul_mat_impl!(Mat6, 6);
+mat_mul_vec_impl!(Mat6, Vec6, 6, ::zero);
+vec_mul_mat_impl!(Mat6, Vec6, 6, ::zero);
+mat_mul_pnt_impl!(Mat6, Pnt6, 6, Orig::orig);
+pnt_mul_mat_impl!(Mat6, Pnt6, 6, Orig::orig);
+inv_impl!(Mat6, 6);
+transpose_impl!(Mat6, 6);
+approx_eq_impl!(Mat6);
+row_impl!(Mat6, Vec6, 6);
+col_impl!(Mat6, Vec6, 6);
+col_slice_impl!(Mat6, Vec6, DVec6, 6);
+row_slice_impl!(Mat6, Vec6, DVec6, 6);
+diag_impl!(Mat6, Vec6, 6);
+outer_impl!(Vec6, Mat6);
+eigen_qr_impl!(Mat6, Vec6);

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -12,7 +12,7 @@ macro_rules! mat_impl(
         }
     }
   )
-)
+);
 
 macro_rules! as_array_impl(
     ($t: ident, $dim: expr) => (
@@ -55,7 +55,7 @@ macro_rules! as_array_impl(
             }
         }
     )
-)
+);
 
 macro_rules! at_fast_impl(
     ($t: ident, $dim: expr) => (
@@ -73,7 +73,7 @@ macro_rules! at_fast_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_cast_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -84,7 +84,7 @@ macro_rules! mat_cast_impl(
             }
         }
     )
-)
+);
 
 macro_rules! add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -95,7 +95,7 @@ macro_rules! add_impl(
             }
         }
     )
-)
+);
 
 macro_rules! sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -106,7 +106,7 @@ macro_rules! sub_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_mul_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -117,7 +117,7 @@ macro_rules! mat_mul_scalar_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_div_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -128,7 +128,7 @@ macro_rules! mat_div_scalar_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_add_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -139,7 +139,7 @@ macro_rules! mat_add_scalar_impl(
             }
         }
     )
-)
+);
 
 
 macro_rules! eye_impl(
@@ -153,7 +153,7 @@ macro_rules! eye_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_sub_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -164,7 +164,7 @@ macro_rules! mat_sub_scalar_impl(
             }
         }
     )
-)
+);
 
 macro_rules! absolute_impl(
   ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -175,7 +175,7 @@ macro_rules! absolute_impl(
         }
     }
   )
-)
+);
 
 macro_rules! iterable_impl(
   ($t: ident, $dim: expr) => (
@@ -188,7 +188,7 @@ macro_rules! iterable_impl(
         }
     }
   )
-)
+);
 
 macro_rules! iterable_mut_impl(
   ($t: ident, $dim: expr) => (
@@ -201,7 +201,7 @@ macro_rules! iterable_mut_impl(
         }
     }
   )
-)
+);
 
 macro_rules! one_impl(
   ($t: ident, $value0: expr $(, $valueN: expr)* ) => (
@@ -212,7 +212,7 @@ macro_rules! one_impl(
         }
     }
   )
-)
+);
 
 macro_rules! zero_impl(
   ($t: ident, $comp0: ident $(, $compN: ident)* ) => (
@@ -231,7 +231,7 @@ macro_rules! zero_impl(
         }
     }
   )
-)
+);
 
 macro_rules! dim_impl(
   ($t: ident, $dim: expr) => (
@@ -242,7 +242,7 @@ macro_rules! dim_impl(
         }
     }
   )
-)
+);
 
 macro_rules! indexable_impl(
   ($t: ident, $dim: expr) => (
@@ -287,7 +287,7 @@ macro_rules! indexable_impl(
         }
     }
   )
-)
+);
 
 macro_rules! index_impl(
     ($t: ident, $dim: expr) => (
@@ -307,7 +307,7 @@ macro_rules! index_impl(
             }
         }
     )
-)
+);
 
 macro_rules! col_slice_impl(
     ($t: ident, $tv: ident, $slice: ident, $dim: expr) => (
@@ -319,7 +319,7 @@ macro_rules! col_slice_impl(
             }
         }
     )
-)
+);
 
 macro_rules! row_impl(
   ($t: ident, $tv: ident, $dim: expr) => (
@@ -348,7 +348,7 @@ macro_rules! row_impl(
         }
     }
   )
-)
+);
 
 macro_rules! row_slice_impl(
     ($t: ident, $tv: ident, $slice: ident, $dim: expr) => (
@@ -360,7 +360,7 @@ macro_rules! row_slice_impl(
             }
         }
     )
-)
+);
 
 macro_rules! col_impl(
   ($t: ident, $tv: ident, $dim: expr) => (
@@ -389,7 +389,7 @@ macro_rules! col_impl(
         }
     }
   )
-)
+);
 
 macro_rules! diag_impl(
     ($t: ident, $tv: ident, $dim: expr) => (
@@ -422,7 +422,7 @@ macro_rules! diag_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mat_mul_mat_impl(
   ($t: ident, $dim: expr) => (
@@ -450,7 +450,7 @@ macro_rules! mat_mul_mat_impl(
         }
     }
   )
-)
+);
 
 macro_rules! vec_mul_mat_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
@@ -472,7 +472,7 @@ macro_rules! vec_mul_mat_impl(
         }
     }
   )
-)
+);
 
 macro_rules! mat_mul_vec_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
@@ -494,19 +494,19 @@ macro_rules! mat_mul_vec_impl(
         }
     }
   )
-)
+);
 
 macro_rules! pnt_mul_mat_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
-      vec_mul_mat_impl!($t, $v, $dim, $zero)
+      vec_mul_mat_impl!($t, $v, $dim, $zero);
   )
-)
+);
 
 macro_rules! mat_mul_pnt_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
-      mat_mul_vec_impl!($t, $v, $dim, $zero)
+      mat_mul_vec_impl!($t, $v, $dim, $zero);
   )
-)
+);
 
 macro_rules! inv_impl(
   ($t: ident, $dim: expr) => (
@@ -589,7 +589,7 @@ macro_rules! inv_impl(
         }
     }
   )
-)
+);
 
 macro_rules! transpose_impl(
   ($t: ident, $dim: expr) => (
@@ -612,7 +612,7 @@ macro_rules! transpose_impl(
         }
     }
   )
-)
+);
 
 macro_rules! approx_eq_impl(
   ($t: ident) => (
@@ -629,7 +629,7 @@ macro_rules! approx_eq_impl(
         }
     }
   )
-)
+);
 
 macro_rules! to_homogeneous_impl(
   ($t: ident, $t2: ident, $dim: expr, $dim2: expr) => (
@@ -648,7 +648,7 @@ macro_rules! to_homogeneous_impl(
         }
     }
   )
-)
+);
 
 macro_rules! from_homogeneous_impl(
   ($t: ident, $t2: ident, $dim: expr, $dim2: expr) => (
@@ -670,7 +670,7 @@ macro_rules! from_homogeneous_impl(
         }
     }
   )
-)
+);
 
 macro_rules! outer_impl(
     ($t: ident, $m: ident) => (
@@ -687,7 +687,7 @@ macro_rules! outer_impl(
             }
         }
     )
-)
+);
 
 macro_rules! eigen_qr_impl(
     ($t: ident, $v: ident) => (
@@ -698,4 +698,4 @@ macro_rules! eigen_qr_impl(
             }
         }
     )
-)
+);

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -38,36 +38,36 @@ pub struct Pnt1<N> {
     pub x: N
 }
 
-new_impl!(Pnt1, x)
-orig_impl!(Pnt1, x)
-ord_impl!(Pnt1, x)
-scalar_mul_impl!(Pnt1, x)
-scalar_div_impl!(Pnt1, x)
-scalar_add_impl!(Pnt1, x)
-scalar_sub_impl!(Pnt1, x)
-vec_cast_impl!(Pnt1, x)
-as_array_impl!(Pnt1, 1)
-index_impl!(Pnt1)
-indexable_impl!(Pnt1, 1)
-at_fast_impl!(Pnt1, 1)
-new_repeat_impl!(Pnt1, val, x)
-dim_impl!(Pnt1, 1)
-container_impl!(Pnt1)
-pnt_as_vec_impl!(Pnt1, Vec1, x)
-pnt_sub_impl!(Pnt1, Vec1)
-neg_impl!(Pnt1, x)
-pnt_add_vec_impl!(Pnt1, Vec1, x)
-pnt_sub_vec_impl!(Pnt1, Vec1, x)
-scalar_ops_impl!(Pnt1, x)
-approx_eq_impl!(Pnt1, x)
-from_iterator_impl!(Pnt1, iterator)
-bounded_impl!(Pnt1, x)
-axpy_impl!(Pnt1, x)
-iterable_impl!(Pnt1, 1)
-iterable_mut_impl!(Pnt1, 1)
-pnt_to_homogeneous_impl!(Pnt1, Pnt2, y, x)
-pnt_from_homogeneous_impl!(Pnt1, Pnt2, y, x)
-num_float_pnt_impl!(Pnt1, Vec1)
+new_impl!(Pnt1, x);
+orig_impl!(Pnt1, x);
+ord_impl!(Pnt1, x);
+scalar_mul_impl!(Pnt1, x);
+scalar_div_impl!(Pnt1, x);
+scalar_add_impl!(Pnt1, x);
+scalar_sub_impl!(Pnt1, x);
+vec_cast_impl!(Pnt1, x);
+as_array_impl!(Pnt1, 1);
+index_impl!(Pnt1);
+indexable_impl!(Pnt1, 1);
+at_fast_impl!(Pnt1, 1);
+new_repeat_impl!(Pnt1, val, x);
+dim_impl!(Pnt1, 1);
+container_impl!(Pnt1);
+pnt_as_vec_impl!(Pnt1, Vec1, x);
+pnt_sub_impl!(Pnt1, Vec1);
+neg_impl!(Pnt1, x);
+pnt_add_vec_impl!(Pnt1, Vec1, x);
+pnt_sub_vec_impl!(Pnt1, Vec1, x);
+scalar_ops_impl!(Pnt1, x);
+approx_eq_impl!(Pnt1, x);
+from_iterator_impl!(Pnt1, iterator);
+bounded_impl!(Pnt1, x);
+axpy_impl!(Pnt1, x);
+iterable_impl!(Pnt1, 1);
+iterable_mut_impl!(Pnt1, 1);
+pnt_to_homogeneous_impl!(Pnt1, Pnt2, y, x);
+pnt_from_homogeneous_impl!(Pnt1, Pnt2, y, x);
+num_float_pnt_impl!(Pnt1, Vec1);
 
 /// Point of dimension 2.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -78,36 +78,36 @@ pub struct Pnt2<N> {
     pub y: N
 }
 
-new_impl!(Pnt2, x, y)
-orig_impl!(Pnt2, x, y)
-ord_impl!(Pnt2, x, y)
-scalar_mul_impl!(Pnt2, x, y)
-scalar_div_impl!(Pnt2, x, y)
-scalar_add_impl!(Pnt2, x, y)
-scalar_sub_impl!(Pnt2, x, y)
-vec_cast_impl!(Pnt2, x, y)
-as_array_impl!(Pnt2, 2)
-index_impl!(Pnt2)
-indexable_impl!(Pnt2, 2)
-at_fast_impl!(Pnt2, 2)
-new_repeat_impl!(Pnt2, val, x, y)
-dim_impl!(Pnt2, 2)
-container_impl!(Pnt2)
-pnt_as_vec_impl!(Pnt2, Vec2, x, y)
-pnt_sub_impl!(Pnt2, Vec2)
-neg_impl!(Pnt2, x, y)
-pnt_add_vec_impl!(Pnt2, Vec2, x, y)
-pnt_sub_vec_impl!(Pnt2, Vec2, x, y)
-scalar_ops_impl!(Pnt2, x, y)
-approx_eq_impl!(Pnt2, x, y)
-from_iterator_impl!(Pnt2, iterator, iterator)
-bounded_impl!(Pnt2, x, y)
-axpy_impl!(Pnt2, x, y)
-iterable_impl!(Pnt2, 2)
-iterable_mut_impl!(Pnt2, 2)
-pnt_to_homogeneous_impl!(Pnt2, Pnt3, z, x, y)
-pnt_from_homogeneous_impl!(Pnt2, Pnt3, z, x, y)
-num_float_pnt_impl!(Pnt2, Vec2)
+new_impl!(Pnt2, x, y);
+orig_impl!(Pnt2, x, y);
+ord_impl!(Pnt2, x, y);
+scalar_mul_impl!(Pnt2, x, y);
+scalar_div_impl!(Pnt2, x, y);
+scalar_add_impl!(Pnt2, x, y);
+scalar_sub_impl!(Pnt2, x, y);
+vec_cast_impl!(Pnt2, x, y);
+as_array_impl!(Pnt2, 2);
+index_impl!(Pnt2);
+indexable_impl!(Pnt2, 2);
+at_fast_impl!(Pnt2, 2);
+new_repeat_impl!(Pnt2, val, x, y);
+dim_impl!(Pnt2, 2);
+container_impl!(Pnt2);
+pnt_as_vec_impl!(Pnt2, Vec2, x, y);
+pnt_sub_impl!(Pnt2, Vec2);
+neg_impl!(Pnt2, x, y);
+pnt_add_vec_impl!(Pnt2, Vec2, x, y);
+pnt_sub_vec_impl!(Pnt2, Vec2, x, y);
+scalar_ops_impl!(Pnt2, x, y);
+approx_eq_impl!(Pnt2, x, y);
+from_iterator_impl!(Pnt2, iterator, iterator);
+bounded_impl!(Pnt2, x, y);
+axpy_impl!(Pnt2, x, y);
+iterable_impl!(Pnt2, 2);
+iterable_mut_impl!(Pnt2, 2);
+pnt_to_homogeneous_impl!(Pnt2, Pnt3, z, x, y);
+pnt_from_homogeneous_impl!(Pnt2, Pnt3, z, x, y);
+num_float_pnt_impl!(Pnt2, Vec2);
 
 /// Point of dimension 3.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -120,36 +120,36 @@ pub struct Pnt3<N> {
     pub z: N
 }
 
-new_impl!(Pnt3, x, y, z)
-orig_impl!(Pnt3, x, y, z)
-ord_impl!(Pnt3, x, y, z)
-scalar_mul_impl!(Pnt3, x, y, z)
-scalar_div_impl!(Pnt3, x, y, z)
-scalar_add_impl!(Pnt3, x, y, z)
-scalar_sub_impl!(Pnt3, x, y, z)
-vec_cast_impl!(Pnt3, x, y, z)
-as_array_impl!(Pnt3, 3)
-index_impl!(Pnt3)
-indexable_impl!(Pnt3, 3)
-at_fast_impl!(Pnt3, 3)
-new_repeat_impl!(Pnt3, val, x, y, z)
-dim_impl!(Pnt3, 3)
-container_impl!(Pnt3)
-pnt_as_vec_impl!(Pnt3, Vec3, x, y, z)
-pnt_sub_impl!(Pnt3, Vec3)
-neg_impl!(Pnt3, x, y, z)
-pnt_add_vec_impl!(Pnt3, Vec3, x, y, z)
-pnt_sub_vec_impl!(Pnt3, Vec3, x, y, z)
-scalar_ops_impl!(Pnt3, x, y, z)
-approx_eq_impl!(Pnt3, x, y, z)
-from_iterator_impl!(Pnt3, iterator, iterator, iterator)
-bounded_impl!(Pnt3, x, y, z)
-axpy_impl!(Pnt3, x, y, z)
-iterable_impl!(Pnt3, 3)
-iterable_mut_impl!(Pnt3, 3)
-pnt_to_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z)
-pnt_from_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z)
-num_float_pnt_impl!(Pnt3, Vec3)
+new_impl!(Pnt3, x, y, z);
+orig_impl!(Pnt3, x, y, z);
+ord_impl!(Pnt3, x, y, z);
+scalar_mul_impl!(Pnt3, x, y, z);
+scalar_div_impl!(Pnt3, x, y, z);
+scalar_add_impl!(Pnt3, x, y, z);
+scalar_sub_impl!(Pnt3, x, y, z);
+vec_cast_impl!(Pnt3, x, y, z);
+as_array_impl!(Pnt3, 3);
+index_impl!(Pnt3);
+indexable_impl!(Pnt3, 3);
+at_fast_impl!(Pnt3, 3);
+new_repeat_impl!(Pnt3, val, x, y, z);
+dim_impl!(Pnt3, 3);
+container_impl!(Pnt3);
+pnt_as_vec_impl!(Pnt3, Vec3, x, y, z);
+pnt_sub_impl!(Pnt3, Vec3);
+neg_impl!(Pnt3, x, y, z);
+pnt_add_vec_impl!(Pnt3, Vec3, x, y, z);
+pnt_sub_vec_impl!(Pnt3, Vec3, x, y, z);
+scalar_ops_impl!(Pnt3, x, y, z);
+approx_eq_impl!(Pnt3, x, y, z);
+from_iterator_impl!(Pnt3, iterator, iterator, iterator);
+bounded_impl!(Pnt3, x, y, z);
+axpy_impl!(Pnt3, x, y, z);
+iterable_impl!(Pnt3, 3);
+iterable_mut_impl!(Pnt3, 3);
+pnt_to_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z);
+pnt_from_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z);
+num_float_pnt_impl!(Pnt3, Vec3);
 
 /// Point of dimension 4.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -164,36 +164,36 @@ pub struct Pnt4<N> {
     pub w: N
 }
 
-new_impl!(Pnt4, x, y, z, w)
-orig_impl!(Pnt4, x, y, z, w)
-ord_impl!(Pnt4, x, y, z, w)
-scalar_mul_impl!(Pnt4, x, y, z, w)
-scalar_div_impl!(Pnt4, x, y, z, w)
-scalar_add_impl!(Pnt4, x, y, z, w)
-scalar_sub_impl!(Pnt4, x, y, z, w)
-vec_cast_impl!(Pnt4, x, y, z, w)
-as_array_impl!(Pnt4, 4)
-index_impl!(Pnt4)
-indexable_impl!(Pnt4, 4)
-at_fast_impl!(Pnt4, 4)
-new_repeat_impl!(Pnt4, val, x, y, z, w)
-dim_impl!(Pnt4, 4)
-container_impl!(Pnt4)
-pnt_as_vec_impl!(Pnt4, Vec4, x, y, z, w)
-pnt_sub_impl!(Pnt4, Vec4)
-neg_impl!(Pnt4, x, y, z, w)
-pnt_add_vec_impl!(Pnt4, Vec4, x, y, z, w)
-pnt_sub_vec_impl!(Pnt4, Vec4, x, y, z, w)
-scalar_ops_impl!(Pnt4, x, y, z, w)
-approx_eq_impl!(Pnt4, x, y, z, w)
-from_iterator_impl!(Pnt4, iterator, iterator, iterator, iterator)
-bounded_impl!(Pnt4, x, y, z, w)
-axpy_impl!(Pnt4, x, y, z, w)
-iterable_impl!(Pnt4, 4)
-iterable_mut_impl!(Pnt4, 4)
-pnt_to_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w)
-pnt_from_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w)
-num_float_pnt_impl!(Pnt4, Vec4)
+new_impl!(Pnt4, x, y, z, w);
+orig_impl!(Pnt4, x, y, z, w);
+ord_impl!(Pnt4, x, y, z, w);
+scalar_mul_impl!(Pnt4, x, y, z, w);
+scalar_div_impl!(Pnt4, x, y, z, w);
+scalar_add_impl!(Pnt4, x, y, z, w);
+scalar_sub_impl!(Pnt4, x, y, z, w);
+vec_cast_impl!(Pnt4, x, y, z, w);
+as_array_impl!(Pnt4, 4);
+index_impl!(Pnt4);
+indexable_impl!(Pnt4, 4);
+at_fast_impl!(Pnt4, 4);
+new_repeat_impl!(Pnt4, val, x, y, z, w);
+dim_impl!(Pnt4, 4);
+container_impl!(Pnt4);
+pnt_as_vec_impl!(Pnt4, Vec4, x, y, z, w);
+pnt_sub_impl!(Pnt4, Vec4);
+neg_impl!(Pnt4, x, y, z, w);
+pnt_add_vec_impl!(Pnt4, Vec4, x, y, z, w);
+pnt_sub_vec_impl!(Pnt4, Vec4, x, y, z, w);
+scalar_ops_impl!(Pnt4, x, y, z, w);
+approx_eq_impl!(Pnt4, x, y, z, w);
+from_iterator_impl!(Pnt4, iterator, iterator, iterator, iterator);
+bounded_impl!(Pnt4, x, y, z, w);
+axpy_impl!(Pnt4, x, y, z, w);
+iterable_impl!(Pnt4, 4);
+iterable_mut_impl!(Pnt4, 4);
+pnt_to_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w);
+pnt_from_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w);
+num_float_pnt_impl!(Pnt4, Vec4);
 
 /// Point of dimension 5.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -210,36 +210,36 @@ pub struct Pnt5<N> {
     pub a: N
 }
 
-new_impl!(Pnt5, x, y, z, w, a)
-orig_impl!(Pnt5, x, y, z, w, a)
-ord_impl!(Pnt5, x, y, z, w, a)
-scalar_mul_impl!(Pnt5, x, y, z, w, a)
-scalar_div_impl!(Pnt5, x, y, z, w, a)
-scalar_add_impl!(Pnt5, x, y, z, w, a)
-scalar_sub_impl!(Pnt5, x, y, z, w, a)
-vec_cast_impl!(Pnt5, x, y, z, w, a)
-as_array_impl!(Pnt5, 5)
-index_impl!(Pnt5)
-indexable_impl!(Pnt5, 5)
-at_fast_impl!(Pnt5, 5)
-new_repeat_impl!(Pnt5, val, x, y, z, w, a)
-dim_impl!(Pnt5, 5)
-container_impl!(Pnt5)
-pnt_as_vec_impl!(Pnt5, Vec5, x, y, z, w, a)
-pnt_sub_impl!(Pnt5, Vec5)
-neg_impl!(Pnt5, x, y, z, w, a)
-pnt_add_vec_impl!(Pnt5, Vec5, x, y, z, w, a)
-pnt_sub_vec_impl!(Pnt5, Vec5, x, y, z, w, a)
-scalar_ops_impl!(Pnt5, x, y, z, w, a)
-approx_eq_impl!(Pnt5, x, y, z, w, a)
-from_iterator_impl!(Pnt5, iterator, iterator, iterator, iterator, iterator)
-bounded_impl!(Pnt5, x, y, z, w, a)
-axpy_impl!(Pnt5, x, y, z, w, a)
-iterable_impl!(Pnt5, 5)
-iterable_mut_impl!(Pnt5, 5)
-pnt_to_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a)
-pnt_from_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a)
-num_float_pnt_impl!(Pnt5, Vec5)
+new_impl!(Pnt5, x, y, z, w, a);
+orig_impl!(Pnt5, x, y, z, w, a);
+ord_impl!(Pnt5, x, y, z, w, a);
+scalar_mul_impl!(Pnt5, x, y, z, w, a);
+scalar_div_impl!(Pnt5, x, y, z, w, a);
+scalar_add_impl!(Pnt5, x, y, z, w, a);
+scalar_sub_impl!(Pnt5, x, y, z, w, a);
+vec_cast_impl!(Pnt5, x, y, z, w, a);
+as_array_impl!(Pnt5, 5);
+index_impl!(Pnt5);
+indexable_impl!(Pnt5, 5);
+at_fast_impl!(Pnt5, 5);
+new_repeat_impl!(Pnt5, val, x, y, z, w, a);
+dim_impl!(Pnt5, 5);
+container_impl!(Pnt5);
+pnt_as_vec_impl!(Pnt5, Vec5, x, y, z, w, a);
+pnt_sub_impl!(Pnt5, Vec5);
+neg_impl!(Pnt5, x, y, z, w, a);
+pnt_add_vec_impl!(Pnt5, Vec5, x, y, z, w, a);
+pnt_sub_vec_impl!(Pnt5, Vec5, x, y, z, w, a);
+scalar_ops_impl!(Pnt5, x, y, z, w, a);
+approx_eq_impl!(Pnt5, x, y, z, w, a);
+from_iterator_impl!(Pnt5, iterator, iterator, iterator, iterator, iterator);
+bounded_impl!(Pnt5, x, y, z, w, a);
+axpy_impl!(Pnt5, x, y, z, w, a);
+iterable_impl!(Pnt5, 5);
+iterable_mut_impl!(Pnt5, 5);
+pnt_to_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a);
+pnt_from_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a);
+num_float_pnt_impl!(Pnt5, Vec5);
 
 /// Point of dimension 6.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Show, Copy)]
@@ -258,31 +258,31 @@ pub struct Pnt6<N> {
     pub b: N
 }
 
-new_impl!(Pnt6, x, y, z, w, a, b)
-orig_impl!(Pnt6, x, y, z, w, a, b)
-ord_impl!(Pnt6, x, y, z, w, a, b)
-scalar_mul_impl!(Pnt6, x, y, z, w, a, b)
-scalar_div_impl!(Pnt6, x, y, z, w, a, b)
-scalar_add_impl!(Pnt6, x, y, z, w, a, b)
-scalar_sub_impl!(Pnt6, x, y, z, w, a, b)
-vec_cast_impl!(Pnt6, x, y, z, w, a, b)
-as_array_impl!(Pnt6, 6)
-index_impl!(Pnt6)
-indexable_impl!(Pnt6, 6)
-at_fast_impl!(Pnt6, 6)
-new_repeat_impl!(Pnt6, val, x, y, z, w, a, b)
-dim_impl!(Pnt6, 6)
-container_impl!(Pnt6)
-pnt_as_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b)
-pnt_sub_impl!(Pnt6, Vec6)
-neg_impl!(Pnt6, x, y, z, w, a, b)
-pnt_add_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b)
-pnt_sub_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b)
-scalar_ops_impl!(Pnt6, x, y, z, w, a, b)
-approx_eq_impl!(Pnt6, x, y, z, w, a, b)
-from_iterator_impl!(Pnt6, iterator, iterator, iterator, iterator, iterator, iterator)
-bounded_impl!(Pnt6, x, y, z, w, a, b)
-axpy_impl!(Pnt6, x, y, z, w, a, b)
-iterable_impl!(Pnt6, 6)
-iterable_mut_impl!(Pnt6, 6)
-num_float_pnt_impl!(Pnt6, Vec6)
+new_impl!(Pnt6, x, y, z, w, a, b);
+orig_impl!(Pnt6, x, y, z, w, a, b);
+ord_impl!(Pnt6, x, y, z, w, a, b);
+scalar_mul_impl!(Pnt6, x, y, z, w, a, b);
+scalar_div_impl!(Pnt6, x, y, z, w, a, b);
+scalar_add_impl!(Pnt6, x, y, z, w, a, b);
+scalar_sub_impl!(Pnt6, x, y, z, w, a, b);
+vec_cast_impl!(Pnt6, x, y, z, w, a, b);
+as_array_impl!(Pnt6, 6);
+index_impl!(Pnt6);
+indexable_impl!(Pnt6, 6);
+at_fast_impl!(Pnt6, 6);
+new_repeat_impl!(Pnt6, val, x, y, z, w, a, b);
+dim_impl!(Pnt6, 6);
+container_impl!(Pnt6);
+pnt_as_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b);
+pnt_sub_impl!(Pnt6, Vec6);
+neg_impl!(Pnt6, x, y, z, w, a, b);
+pnt_add_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b);
+pnt_sub_vec_impl!(Pnt6, Vec6, x, y, z, w, a, b);
+scalar_ops_impl!(Pnt6, x, y, z, w, a, b);
+approx_eq_impl!(Pnt6, x, y, z, w, a, b);
+from_iterator_impl!(Pnt6, iterator, iterator, iterator, iterator, iterator, iterator);
+bounded_impl!(Pnt6, x, y, z, w, a, b);
+axpy_impl!(Pnt6, x, y, z, w, a, b);
+iterable_impl!(Pnt6, 6);
+iterable_mut_impl!(Pnt6, 6);
+num_float_pnt_impl!(Pnt6, Vec6);

--- a/src/structs/pnt_macros.rs
+++ b/src/structs/pnt_macros.rs
@@ -17,7 +17,7 @@ macro_rules! orig_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_sub_impl(
     ($t: ident, $tv: ident) => (
@@ -28,7 +28,7 @@ macro_rules! pnt_sub_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_add_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -39,7 +39,7 @@ macro_rules! pnt_add_vec_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_sub_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -50,7 +50,7 @@ macro_rules! pnt_sub_vec_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_as_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -96,7 +96,7 @@ macro_rules! pnt_as_vec_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_to_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -112,7 +112,7 @@ macro_rules! pnt_to_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_from_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -127,7 +127,7 @@ macro_rules! pnt_from_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! num_float_pnt_impl(
     ($t: ident, $tv: ident) => (
@@ -139,4 +139,4 @@ macro_rules! num_float_pnt_impl(
             where N: BaseFloat + ApproxEq<N> {
         }
     )
-)
+);

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -441,30 +441,30 @@ impl<N: BaseNum> Transform<Pnt3<N>> for UnitQuat<N> {
     }
 }
 
-ord_impl!(Quat, w, i, j, k)
-vec_axis_impl!(Quat, w, i, j, k)
-vec_cast_impl!(Quat, w, i, j, k)
-as_array_impl!(Quat, 4)
-index_impl!(Quat)
-indexable_impl!(Quat, 4)
-at_fast_impl!(Quat, 4)
-new_repeat_impl!(Quat, val, w, i, j, k)
-dim_impl!(Quat, 3)
-container_impl!(Quat)
-add_impl!(Quat, w, i, j, k)
-sub_impl!(Quat, w, i, j, k)
-scalar_add_impl!(Quat, w, i, j, k)
-scalar_sub_impl!(Quat, w, i, j, k)
-scalar_mul_impl!(Quat, w, i, j, k)
-scalar_div_impl!(Quat, w, i, j, k)
-neg_impl!(Quat, w, i, j, k)
-scalar_ops_impl!(Quat, w, i, j, k)
-zero_one_impl!(Quat, w, i, j, k)
-approx_eq_impl!(Quat, w, i, j, k)
-from_iterator_impl!(Quat, iterator, iterator, iterator, iterator)
-bounded_impl!(Quat, w, i, j, k)
-axpy_impl!(Quat, w, i, j, k)
-iterable_impl!(Quat, 4)
-iterable_mut_impl!(Quat, 4)
+ord_impl!(Quat, w, i, j, k);
+vec_axis_impl!(Quat, w, i, j, k);
+vec_cast_impl!(Quat, w, i, j, k);
+as_array_impl!(Quat, 4);
+index_impl!(Quat);
+indexable_impl!(Quat, 4);
+at_fast_impl!(Quat, 4);
+new_repeat_impl!(Quat, val, w, i, j, k);
+dim_impl!(Quat, 3);
+container_impl!(Quat);
+add_impl!(Quat, w, i, j, k);
+sub_impl!(Quat, w, i, j, k);
+scalar_add_impl!(Quat, w, i, j, k);
+scalar_sub_impl!(Quat, w, i, j, k);
+scalar_mul_impl!(Quat, w, i, j, k);
+scalar_div_impl!(Quat, w, i, j, k);
+neg_impl!(Quat, w, i, j, k);
+scalar_ops_impl!(Quat, w, i, j, k);
+zero_one_impl!(Quat, w, i, j, k);
+approx_eq_impl!(Quat, w, i, j, k);
+from_iterator_impl!(Quat, iterator, iterator, iterator, iterator);
+bounded_impl!(Quat, w, i, j, k);
+axpy_impl!(Quat, w, i, j, k);
+iterable_impl!(Quat, 4);
+iterable_mut_impl!(Quat, 4);
 
-dim_impl!(UnitQuat, 3)
+dim_impl!(UnitQuat, 3);

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -376,62 +376,62 @@ Rotation<Vec4<N>> for Rot4<N> {
  * Common implementations.
  */
 
-submat_impl!(Rot2, Mat2)
-rotate_impl!(Rot2, Vec2, Pnt2)
-transform_impl!(Rot2, Vec2, Pnt2)
-dim_impl!(Rot2, 2)
-rot_mul_rot_impl!(Rot2)
-rot_mul_vec_impl!(Rot2, Vec2)
-vec_mul_rot_impl!(Rot2, Vec2)
-rot_mul_pnt_impl!(Rot2, Pnt2)
-pnt_mul_rot_impl!(Rot2, Pnt2)
-one_impl!(Rot2)
-rotation_matrix_impl!(Rot2, Vec2, Vec1)
-col_impl!(Rot2, Vec2)
-row_impl!(Rot2, Vec2)
-index_impl!(Rot2)
-absolute_impl!(Rot2, Mat2)
-to_homogeneous_impl!(Rot2, Mat3)
-inv_impl!(Rot2)
-transpose_impl!(Rot2)
-approx_eq_impl!(Rot2)
+submat_impl!(Rot2, Mat2);
+rotate_impl!(Rot2, Vec2, Pnt2);
+transform_impl!(Rot2, Vec2, Pnt2);
+dim_impl!(Rot2, 2);
+rot_mul_rot_impl!(Rot2);
+rot_mul_vec_impl!(Rot2, Vec2);
+vec_mul_rot_impl!(Rot2, Vec2);
+rot_mul_pnt_impl!(Rot2, Pnt2);
+pnt_mul_rot_impl!(Rot2, Pnt2);
+one_impl!(Rot2);
+rotation_matrix_impl!(Rot2, Vec2, Vec1);
+col_impl!(Rot2, Vec2);
+row_impl!(Rot2, Vec2);
+index_impl!(Rot2);
+absolute_impl!(Rot2, Mat2);
+to_homogeneous_impl!(Rot2, Mat3);
+inv_impl!(Rot2);
+transpose_impl!(Rot2);
+approx_eq_impl!(Rot2);
 
-submat_impl!(Rot3, Mat3)
-rotate_impl!(Rot3, Vec3, Pnt3)
-transform_impl!(Rot3, Vec3, Pnt3)
-dim_impl!(Rot3, 3)
-rot_mul_rot_impl!(Rot3)
-rot_mul_vec_impl!(Rot3, Vec3)
-vec_mul_rot_impl!(Rot3, Vec3)
-rot_mul_pnt_impl!(Rot3, Pnt3)
-pnt_mul_rot_impl!(Rot3, Pnt3)
-one_impl!(Rot3)
-rotation_matrix_impl!(Rot3, Vec3, Vec3)
-col_impl!(Rot3, Vec3)
-row_impl!(Rot3, Vec3)
-index_impl!(Rot3)
-absolute_impl!(Rot3, Mat3)
-to_homogeneous_impl!(Rot3, Mat4)
-inv_impl!(Rot3)
-transpose_impl!(Rot3)
-approx_eq_impl!(Rot3)
+submat_impl!(Rot3, Mat3);
+rotate_impl!(Rot3, Vec3, Pnt3);
+transform_impl!(Rot3, Vec3, Pnt3);
+dim_impl!(Rot3, 3);
+rot_mul_rot_impl!(Rot3);
+rot_mul_vec_impl!(Rot3, Vec3);
+vec_mul_rot_impl!(Rot3, Vec3);
+rot_mul_pnt_impl!(Rot3, Pnt3);
+pnt_mul_rot_impl!(Rot3, Pnt3);
+one_impl!(Rot3);
+rotation_matrix_impl!(Rot3, Vec3, Vec3);
+col_impl!(Rot3, Vec3);
+row_impl!(Rot3, Vec3);
+index_impl!(Rot3);
+absolute_impl!(Rot3, Mat3);
+to_homogeneous_impl!(Rot3, Mat4);
+inv_impl!(Rot3);
+transpose_impl!(Rot3);
+approx_eq_impl!(Rot3);
 
-submat_impl!(Rot4, Mat4)
-rotate_impl!(Rot4, Vec4, Pnt4)
-transform_impl!(Rot4, Vec4, Pnt4)
-dim_impl!(Rot4, 4)
-rot_mul_rot_impl!(Rot4)
-rot_mul_vec_impl!(Rot4, Vec4)
-vec_mul_rot_impl!(Rot4, Vec4)
-rot_mul_pnt_impl!(Rot4, Pnt4)
-pnt_mul_rot_impl!(Rot4, Pnt4)
-one_impl!(Rot4)
-rotation_matrix_impl!(Rot4, Vec4, Vec4)
-col_impl!(Rot4, Vec4)
-row_impl!(Rot4, Vec4)
-index_impl!(Rot4)
-absolute_impl!(Rot4, Mat4)
-to_homogeneous_impl!(Rot4, Mat5)
-inv_impl!(Rot4)
-transpose_impl!(Rot4)
-approx_eq_impl!(Rot4)
+submat_impl!(Rot4, Mat4);
+rotate_impl!(Rot4, Vec4, Pnt4);
+transform_impl!(Rot4, Vec4, Pnt4);
+dim_impl!(Rot4, 4);
+rot_mul_rot_impl!(Rot4);
+rot_mul_vec_impl!(Rot4, Vec4);
+vec_mul_rot_impl!(Rot4, Vec4);
+rot_mul_pnt_impl!(Rot4, Pnt4);
+pnt_mul_rot_impl!(Rot4, Pnt4);
+one_impl!(Rot4);
+rotation_matrix_impl!(Rot4, Vec4, Vec4);
+col_impl!(Rot4, Vec4);
+row_impl!(Rot4, Vec4);
+index_impl!(Rot4);
+absolute_impl!(Rot4, Mat4);
+to_homogeneous_impl!(Rot4, Mat5);
+inv_impl!(Rot4);
+transpose_impl!(Rot4);
+approx_eq_impl!(Rot4);

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -9,7 +9,7 @@ macro_rules! submat_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotate_impl(
     ($t: ident, $tv: ident, $tp: ident) => (
@@ -37,7 +37,7 @@ macro_rules! rotate_impl(
             }
         }
     )
-)
+);
 
 macro_rules! transform_impl(
     ($t: ident, $tv: ident, $tp: ident) => (
@@ -65,7 +65,7 @@ macro_rules! transform_impl(
             }
         }
     )
-)
+);
 
 macro_rules! dim_impl(
     ($t: ident, $dim: expr) => (
@@ -76,7 +76,7 @@ macro_rules! dim_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotation_matrix_impl(
     ($t: ident, $tlv: ident, $tav: ident) => (
@@ -87,7 +87,7 @@ macro_rules! rotation_matrix_impl(
             }
         }
     )
-)
+);
 
 macro_rules! one_impl(
     ($t: ident) => (
@@ -98,7 +98,7 @@ macro_rules! one_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rot_mul_rot_impl(
     ($t: ident) => (
@@ -109,7 +109,7 @@ macro_rules! rot_mul_rot_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rot_mul_vec_impl(
     ($t: ident, $tv: ident) => (
@@ -120,13 +120,13 @@ macro_rules! rot_mul_vec_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rot_mul_pnt_impl(
     ($t: ident, $tv: ident) => (
-        rot_mul_vec_impl!($t, $tv)
+        rot_mul_vec_impl!($t, $tv);
     )
-)
+);
 
 macro_rules! vec_mul_rot_impl(
     ($t: ident, $tv: ident) => (
@@ -137,13 +137,13 @@ macro_rules! vec_mul_rot_impl(
             }
         }
     )
-)
+);
 
 macro_rules! pnt_mul_rot_impl(
     ($t: ident, $tv: ident) => (
-        vec_mul_rot_impl!($t, $tv)
+        vec_mul_rot_impl!($t, $tv);
     )
-)
+);
 
 macro_rules! inv_impl(
     ($t: ident) => (
@@ -163,7 +163,7 @@ macro_rules! inv_impl(
             }
         }
     )
-)
+);
 
 macro_rules! transpose_impl(
     ($t: ident) => (
@@ -179,7 +179,7 @@ macro_rules! transpose_impl(
             }
         }
     )
-)
+);
 
 macro_rules! row_impl(
     ($t: ident, $tv: ident) => (
@@ -199,7 +199,7 @@ macro_rules! row_impl(
             }
         }
     )
-)
+);
 
 macro_rules! col_impl(
     ($t: ident, $tv: ident) => (
@@ -219,7 +219,7 @@ macro_rules! col_impl(
             }
         }
     )
-)
+);
 
 macro_rules! index_impl(
     ($t: ident) => (
@@ -235,7 +235,7 @@ macro_rules! index_impl(
             }
         }
     )
-)
+);
 
 macro_rules! to_homogeneous_impl(
     ($t: ident, $tm: ident) => (
@@ -246,7 +246,7 @@ macro_rules! to_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! approx_eq_impl(
     ($t: ident) => (
@@ -267,7 +267,7 @@ macro_rules! approx_eq_impl(
             }
         }
     )
-)
+);
 
 macro_rules! absolute_impl(
     ($t: ident, $tm: ident) => (
@@ -278,4 +278,4 @@ macro_rules! absolute_impl(
             }
         }
     )
-)
+);

--- a/src/structs/spec/primitives.rs
+++ b/src/structs/spec/primitives.rs
@@ -12,7 +12,7 @@ macro_rules! primitive_double_dispatch_cast_decl_trait(
             fn to(Self) -> $t;
         }
     )
-)
+);
 
 macro_rules! primitive_double_dispatch_cast_impl(
     ($ttarget: ident, $tself: ident, $tcast: ident) => (
@@ -23,7 +23,7 @@ macro_rules! primitive_double_dispatch_cast_impl(
             }
         }
     )
-)
+);
 
 macro_rules! primitive_cast_redispatch_impl(
     ($t:ident, $tcast: ident) => (
@@ -34,186 +34,186 @@ macro_rules! primitive_cast_redispatch_impl(
             }
         }
     )
-)
+);
 
-primitive_double_dispatch_cast_decl_trait!(f64,  f64Cast)
-primitive_double_dispatch_cast_decl_trait!(f32,  f32Cast)
-primitive_double_dispatch_cast_decl_trait!(i64,  i64Cast)
-primitive_double_dispatch_cast_decl_trait!(i32,  i32Cast)
-primitive_double_dispatch_cast_decl_trait!(i16,  i16Cast)
-primitive_double_dispatch_cast_decl_trait!(i8,   i8Cast)
-primitive_double_dispatch_cast_decl_trait!(u64,  u64Cast)
-primitive_double_dispatch_cast_decl_trait!(u32,  u32Cast)
-primitive_double_dispatch_cast_decl_trait!(u16,  u16Cast)
-primitive_double_dispatch_cast_decl_trait!(u8,   u8Cast)
-primitive_double_dispatch_cast_decl_trait!(int,  intCast)
-primitive_double_dispatch_cast_decl_trait!(uint, uintCast)
+primitive_double_dispatch_cast_decl_trait!(f64,  f64Cast);
+primitive_double_dispatch_cast_decl_trait!(f32,  f32Cast);
+primitive_double_dispatch_cast_decl_trait!(i64,  i64Cast);
+primitive_double_dispatch_cast_decl_trait!(i32,  i32Cast);
+primitive_double_dispatch_cast_decl_trait!(i16,  i16Cast);
+primitive_double_dispatch_cast_decl_trait!(i8,   i8Cast);
+primitive_double_dispatch_cast_decl_trait!(u64,  u64Cast);
+primitive_double_dispatch_cast_decl_trait!(u32,  u32Cast);
+primitive_double_dispatch_cast_decl_trait!(u16,  u16Cast);
+primitive_double_dispatch_cast_decl_trait!(u8,   u8Cast);
+primitive_double_dispatch_cast_decl_trait!(int,  intCast);
+primitive_double_dispatch_cast_decl_trait!(uint, uintCast);
 
-primitive_cast_redispatch_impl!(f64,  f64Cast)
-primitive_cast_redispatch_impl!(f32,  f32Cast)
-primitive_cast_redispatch_impl!(i64,  i64Cast)
-primitive_cast_redispatch_impl!(i32,  i32Cast)
-primitive_cast_redispatch_impl!(i16,  i16Cast)
-primitive_cast_redispatch_impl!(i8,   i8Cast)
-primitive_cast_redispatch_impl!(u64,  u64Cast)
-primitive_cast_redispatch_impl!(u32,  u32Cast)
-primitive_cast_redispatch_impl!(u16,  u16Cast)
-primitive_cast_redispatch_impl!(u8,   u8Cast)
-primitive_cast_redispatch_impl!(int,  intCast)
-primitive_cast_redispatch_impl!(uint, uintCast)
+primitive_cast_redispatch_impl!(f64,  f64Cast);
+primitive_cast_redispatch_impl!(f32,  f32Cast);
+primitive_cast_redispatch_impl!(i64,  i64Cast);
+primitive_cast_redispatch_impl!(i32,  i32Cast);
+primitive_cast_redispatch_impl!(i16,  i16Cast);
+primitive_cast_redispatch_impl!(i8,   i8Cast);
+primitive_cast_redispatch_impl!(u64,  u64Cast);
+primitive_cast_redispatch_impl!(u32,  u32Cast);
+primitive_cast_redispatch_impl!(u16,  u16Cast);
+primitive_cast_redispatch_impl!(u8,   u8Cast);
+primitive_cast_redispatch_impl!(int,  intCast);
+primitive_cast_redispatch_impl!(uint, uintCast);
 
-primitive_double_dispatch_cast_impl!(f64, f64,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, f32,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, i64,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, i32,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, i16,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, i8,   f64Cast)
-primitive_double_dispatch_cast_impl!(f64, u64,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, u32,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, u16,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, u8,   f64Cast)
-primitive_double_dispatch_cast_impl!(f64, int,  f64Cast)
-primitive_double_dispatch_cast_impl!(f64, uint, f64Cast)
+primitive_double_dispatch_cast_impl!(f64, f64,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, f32,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, i64,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, i32,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, i16,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, i8,   f64Cast);
+primitive_double_dispatch_cast_impl!(f64, u64,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, u32,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, u16,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, u8,   f64Cast);
+primitive_double_dispatch_cast_impl!(f64, int,  f64Cast);
+primitive_double_dispatch_cast_impl!(f64, uint, f64Cast);
 
-primitive_double_dispatch_cast_impl!(f32, f64,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, f32,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, i64,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, i32,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, i16,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, i8,   f32Cast)
-primitive_double_dispatch_cast_impl!(f32, u64,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, u32,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, u16,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, u8,   f32Cast)
-primitive_double_dispatch_cast_impl!(f32, int,  f32Cast)
-primitive_double_dispatch_cast_impl!(f32, uint, f32Cast)
+primitive_double_dispatch_cast_impl!(f32, f64,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, f32,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, i64,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, i32,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, i16,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, i8,   f32Cast);
+primitive_double_dispatch_cast_impl!(f32, u64,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, u32,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, u16,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, u8,   f32Cast);
+primitive_double_dispatch_cast_impl!(f32, int,  f32Cast);
+primitive_double_dispatch_cast_impl!(f32, uint, f32Cast);
 
-primitive_double_dispatch_cast_impl!(i64, f64,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, f32,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, i64,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, i32,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, i16,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, i8,   i64Cast)
-primitive_double_dispatch_cast_impl!(i64, u64,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, u32,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, u16,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, u8,   i64Cast)
-primitive_double_dispatch_cast_impl!(i64, int,  i64Cast)
-primitive_double_dispatch_cast_impl!(i64, uint, i64Cast)
+primitive_double_dispatch_cast_impl!(i64, f64,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, f32,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, i64,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, i32,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, i16,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, i8,   i64Cast);
+primitive_double_dispatch_cast_impl!(i64, u64,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, u32,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, u16,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, u8,   i64Cast);
+primitive_double_dispatch_cast_impl!(i64, int,  i64Cast);
+primitive_double_dispatch_cast_impl!(i64, uint, i64Cast);
 
-primitive_double_dispatch_cast_impl!(i32, f64,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, f32,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, i64,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, i32,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, i16,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, i8,   i32Cast)
-primitive_double_dispatch_cast_impl!(i32, u64,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, u32,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, u16,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, u8,   i32Cast)
-primitive_double_dispatch_cast_impl!(i32, int,  i32Cast)
-primitive_double_dispatch_cast_impl!(i32, uint, i32Cast)
+primitive_double_dispatch_cast_impl!(i32, f64,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, f32,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, i64,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, i32,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, i16,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, i8,   i32Cast);
+primitive_double_dispatch_cast_impl!(i32, u64,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, u32,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, u16,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, u8,   i32Cast);
+primitive_double_dispatch_cast_impl!(i32, int,  i32Cast);
+primitive_double_dispatch_cast_impl!(i32, uint, i32Cast);
 
-primitive_double_dispatch_cast_impl!(i16, f64,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, f32,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, i64,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, i32,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, i16,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, i8,   i16Cast)
-primitive_double_dispatch_cast_impl!(i16, u64,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, u32,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, u16,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, u8,   i16Cast)
-primitive_double_dispatch_cast_impl!(i16, int,  i16Cast)
-primitive_double_dispatch_cast_impl!(i16, uint, i16Cast)
+primitive_double_dispatch_cast_impl!(i16, f64,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, f32,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, i64,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, i32,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, i16,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, i8,   i16Cast);
+primitive_double_dispatch_cast_impl!(i16, u64,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, u32,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, u16,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, u8,   i16Cast);
+primitive_double_dispatch_cast_impl!(i16, int,  i16Cast);
+primitive_double_dispatch_cast_impl!(i16, uint, i16Cast);
 
-primitive_double_dispatch_cast_impl!(i8, f64,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, f32,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, i64,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, i32,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, i16,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, i8,   i8Cast)
-primitive_double_dispatch_cast_impl!(i8, u64,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, u32,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, u16,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, u8,   i8Cast)
-primitive_double_dispatch_cast_impl!(i8, int,  i8Cast)
-primitive_double_dispatch_cast_impl!(i8, uint, i8Cast)
+primitive_double_dispatch_cast_impl!(i8, f64,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, f32,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, i64,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, i32,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, i16,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, i8,   i8Cast);
+primitive_double_dispatch_cast_impl!(i8, u64,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, u32,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, u16,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, u8,   i8Cast);
+primitive_double_dispatch_cast_impl!(i8, int,  i8Cast);
+primitive_double_dispatch_cast_impl!(i8, uint, i8Cast);
 
-primitive_double_dispatch_cast_impl!(u64, f64,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, f32,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, i64,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, i32,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, i16,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, i8,   u64Cast)
-primitive_double_dispatch_cast_impl!(u64, u64,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, u32,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, u16,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, u8,   u64Cast)
-primitive_double_dispatch_cast_impl!(u64, int,  u64Cast)
-primitive_double_dispatch_cast_impl!(u64, uint, u64Cast)
+primitive_double_dispatch_cast_impl!(u64, f64,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, f32,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, i64,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, i32,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, i16,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, i8,   u64Cast);
+primitive_double_dispatch_cast_impl!(u64, u64,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, u32,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, u16,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, u8,   u64Cast);
+primitive_double_dispatch_cast_impl!(u64, int,  u64Cast);
+primitive_double_dispatch_cast_impl!(u64, uint, u64Cast);
 
-primitive_double_dispatch_cast_impl!(u32, f64,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, f32,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, i64,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, i32,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, i16,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, i8,   u32Cast)
-primitive_double_dispatch_cast_impl!(u32, u64,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, u32,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, u16,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, u8,   u32Cast)
-primitive_double_dispatch_cast_impl!(u32, int,  u32Cast)
-primitive_double_dispatch_cast_impl!(u32, uint, u32Cast)
+primitive_double_dispatch_cast_impl!(u32, f64,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, f32,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, i64,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, i32,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, i16,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, i8,   u32Cast);
+primitive_double_dispatch_cast_impl!(u32, u64,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, u32,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, u16,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, u8,   u32Cast);
+primitive_double_dispatch_cast_impl!(u32, int,  u32Cast);
+primitive_double_dispatch_cast_impl!(u32, uint, u32Cast);
 
-primitive_double_dispatch_cast_impl!(u16, f64,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, f32,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, i64,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, i32,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, i16,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, i8,   u16Cast)
-primitive_double_dispatch_cast_impl!(u16, u64,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, u32,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, u16,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, u8,   u16Cast)
-primitive_double_dispatch_cast_impl!(u16, int,  u16Cast)
-primitive_double_dispatch_cast_impl!(u16, uint, u16Cast)
+primitive_double_dispatch_cast_impl!(u16, f64,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, f32,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, i64,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, i32,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, i16,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, i8,   u16Cast);
+primitive_double_dispatch_cast_impl!(u16, u64,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, u32,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, u16,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, u8,   u16Cast);
+primitive_double_dispatch_cast_impl!(u16, int,  u16Cast);
+primitive_double_dispatch_cast_impl!(u16, uint, u16Cast);
 
-primitive_double_dispatch_cast_impl!(u8, f64,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, f32,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, i64,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, i32,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, i16,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, i8,   u8Cast)
-primitive_double_dispatch_cast_impl!(u8, u64,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, u32,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, u16,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, u8,   u8Cast)
-primitive_double_dispatch_cast_impl!(u8, int,  u8Cast)
-primitive_double_dispatch_cast_impl!(u8, uint, u8Cast)
+primitive_double_dispatch_cast_impl!(u8, f64,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, f32,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, i64,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, i32,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, i16,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, i8,   u8Cast);
+primitive_double_dispatch_cast_impl!(u8, u64,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, u32,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, u16,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, u8,   u8Cast);
+primitive_double_dispatch_cast_impl!(u8, int,  u8Cast);
+primitive_double_dispatch_cast_impl!(u8, uint, u8Cast);
 
-primitive_double_dispatch_cast_impl!(uint, f64,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, f32,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, i64,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, i32,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, i16,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, i8,   uintCast)
-primitive_double_dispatch_cast_impl!(uint, u64,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, u32,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, u16,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, u8,   uintCast)
-primitive_double_dispatch_cast_impl!(uint, int,  uintCast)
-primitive_double_dispatch_cast_impl!(uint, uint, uintCast)
+primitive_double_dispatch_cast_impl!(uint, f64,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, f32,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, i64,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, i32,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, i16,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, i8,   uintCast);
+primitive_double_dispatch_cast_impl!(uint, u64,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, u32,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, u16,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, u8,   uintCast);
+primitive_double_dispatch_cast_impl!(uint, int,  uintCast);
+primitive_double_dispatch_cast_impl!(uint, uint, uintCast);
 
-primitive_double_dispatch_cast_impl!(int, f64,  intCast)
-primitive_double_dispatch_cast_impl!(int, f32,  intCast)
-primitive_double_dispatch_cast_impl!(int, i64,  intCast)
-primitive_double_dispatch_cast_impl!(int, i32,  intCast)
-primitive_double_dispatch_cast_impl!(int, i16,  intCast)
-primitive_double_dispatch_cast_impl!(int, i8,   intCast)
-primitive_double_dispatch_cast_impl!(int, u64,  intCast)
-primitive_double_dispatch_cast_impl!(int, u32,  intCast)
-primitive_double_dispatch_cast_impl!(int, u16,  intCast)
-primitive_double_dispatch_cast_impl!(int, u8,   intCast)
-primitive_double_dispatch_cast_impl!(int, int,  intCast)
-primitive_double_dispatch_cast_impl!(int, uint, intCast)
+primitive_double_dispatch_cast_impl!(int, f64,  intCast);
+primitive_double_dispatch_cast_impl!(int, f32,  intCast);
+primitive_double_dispatch_cast_impl!(int, i64,  intCast);
+primitive_double_dispatch_cast_impl!(int, i32,  intCast);
+primitive_double_dispatch_cast_impl!(int, i16,  intCast);
+primitive_double_dispatch_cast_impl!(int, i8,   intCast);
+primitive_double_dispatch_cast_impl!(int, u64,  intCast);
+primitive_double_dispatch_cast_impl!(int, u32,  intCast);
+primitive_double_dispatch_cast_impl!(int, u16,  intCast);
+primitive_double_dispatch_cast_impl!(int, u8,   intCast);
+primitive_double_dispatch_cast_impl!(int, int,  intCast);
+primitive_double_dispatch_cast_impl!(int, uint, intCast);

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -39,47 +39,47 @@ pub struct Vec1<N> {
     pub x: N
 }
 
-new_impl!(Vec1, x)
-ord_impl!(Vec1, x)
-vec_axis_impl!(Vec1, x)
-vec_cast_impl!(Vec1, x)
-as_array_impl!(Vec1, 1)
-index_impl!(Vec1)
-indexable_impl!(Vec1, 1)
-at_fast_impl!(Vec1, 1)
-new_repeat_impl!(Vec1, val, x)
-dim_impl!(Vec1, 1)
-container_impl!(Vec1)
-// (specialized) basis_impl!(Vec1, 1)
-add_impl!(Vec1, x)
-sub_impl!(Vec1, x)
-mul_impl!(Vec1, x)
-div_impl!(Vec1, x)
-scalar_add_impl!(Vec1, x)
-scalar_sub_impl!(Vec1, x)
-scalar_mul_impl!(Vec1, x)
-scalar_div_impl!(Vec1, x)
-neg_impl!(Vec1, x)
-dot_impl!(Vec1, x)
-scalar_ops_impl!(Vec1, x)
-translation_impl!(Vec1)
-norm_impl!(Vec1, x)
-approx_eq_impl!(Vec1, x)
-zero_one_impl!(Vec1, x)
-from_iterator_impl!(Vec1, iterator)
-bounded_impl!(Vec1, x)
-axpy_impl!(Vec1, x)
-iterable_impl!(Vec1, 1)
-iterable_mut_impl!(Vec1, 1)
-vec_to_homogeneous_impl!(Vec1, Vec2, y, x)
-vec_from_homogeneous_impl!(Vec1, Vec2, y, x)
-translate_impl!(Vec1, Pnt1)
-rotate_impl!(Vec1)
-rotate_impl!(Pnt1)
-transform_impl!(Vec1, Pnt1)
-vec_as_pnt_impl!(Vec1, Pnt1, x)
-num_float_vec_impl!(Vec1)
-absolute_vec_impl!(Vec1, x)
+new_impl!(Vec1, x);
+ord_impl!(Vec1, x);
+vec_axis_impl!(Vec1, x);
+vec_cast_impl!(Vec1, x);
+as_array_impl!(Vec1, 1);
+index_impl!(Vec1);
+indexable_impl!(Vec1, 1);
+at_fast_impl!(Vec1, 1);
+new_repeat_impl!(Vec1, val, x);
+dim_impl!(Vec1, 1);
+container_impl!(Vec1);
+// (specialized); basis_impl!(Vec1, 1);
+add_impl!(Vec1, x);
+sub_impl!(Vec1, x);
+mul_impl!(Vec1, x);
+div_impl!(Vec1, x);
+scalar_add_impl!(Vec1, x);
+scalar_sub_impl!(Vec1, x);
+scalar_mul_impl!(Vec1, x);
+scalar_div_impl!(Vec1, x);
+neg_impl!(Vec1, x);
+dot_impl!(Vec1, x);
+scalar_ops_impl!(Vec1, x);
+translation_impl!(Vec1);
+norm_impl!(Vec1, x);
+approx_eq_impl!(Vec1, x);
+zero_one_impl!(Vec1, x);
+from_iterator_impl!(Vec1, iterator);
+bounded_impl!(Vec1, x);
+axpy_impl!(Vec1, x);
+iterable_impl!(Vec1, 1);
+iterable_mut_impl!(Vec1, 1);
+vec_to_homogeneous_impl!(Vec1, Vec2, y, x);
+vec_from_homogeneous_impl!(Vec1, Vec2, y, x);
+translate_impl!(Vec1, Pnt1);
+rotate_impl!(Vec1);
+rotate_impl!(Pnt1);
+transform_impl!(Vec1, Pnt1);
+vec_as_pnt_impl!(Vec1, Pnt1, x);
+num_float_vec_impl!(Vec1);
+absolute_vec_impl!(Vec1, x);
 
 /// Vector of dimension 2.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Zero, Show, Copy)]
@@ -90,47 +90,47 @@ pub struct Vec2<N> {
     pub y: N
 }
 
-new_impl!(Vec2, x, y)
-ord_impl!(Vec2, x, y)
-vec_axis_impl!(Vec2, x, y)
-vec_cast_impl!(Vec2, x, y)
-as_array_impl!(Vec2, 2)
-index_impl!(Vec2)
-indexable_impl!(Vec2, 2)
-at_fast_impl!(Vec2, 2)
-new_repeat_impl!(Vec2, val, x, y)
-dim_impl!(Vec2, 2)
-container_impl!(Vec2)
-// (specialized) basis_impl!(Vec2, 1)
-add_impl!(Vec2, x, y)
-sub_impl!(Vec2, x, y)
-mul_impl!(Vec2, x, y)
-div_impl!(Vec2, x, y)
-scalar_add_impl!(Vec2, x, y)
-scalar_sub_impl!(Vec2, x, y)
-scalar_mul_impl!(Vec2, x, y)
-scalar_div_impl!(Vec2, x, y)
-neg_impl!(Vec2, x, y)
-dot_impl!(Vec2, x, y)
-scalar_ops_impl!(Vec2, x, y)
-translation_impl!(Vec2)
-norm_impl!(Vec2, x, y)
-approx_eq_impl!(Vec2, x, y)
-zero_one_impl!(Vec2, x, y)
-from_iterator_impl!(Vec2, iterator, iterator)
-bounded_impl!(Vec2, x, y)
-axpy_impl!(Vec2, x, y)
-iterable_impl!(Vec2, 2)
-iterable_mut_impl!(Vec2, 2)
-vec_to_homogeneous_impl!(Vec2, Vec3, z, x, y)
-vec_from_homogeneous_impl!(Vec2, Vec3, z, x, y)
-translate_impl!(Vec2, Pnt2)
-rotate_impl!(Vec2)
-rotate_impl!(Pnt2)
-transform_impl!(Vec2, Pnt2)
-vec_as_pnt_impl!(Vec2, Pnt2, x, y)
-num_float_vec_impl!(Vec2)
-absolute_vec_impl!(Vec2, x, y)
+new_impl!(Vec2, x, y);
+ord_impl!(Vec2, x, y);
+vec_axis_impl!(Vec2, x, y);
+vec_cast_impl!(Vec2, x, y);
+as_array_impl!(Vec2, 2);
+index_impl!(Vec2);
+indexable_impl!(Vec2, 2);
+at_fast_impl!(Vec2, 2);
+new_repeat_impl!(Vec2, val, x, y);
+dim_impl!(Vec2, 2);
+container_impl!(Vec2);
+// (specialized); basis_impl!(Vec2, 1);
+add_impl!(Vec2, x, y);
+sub_impl!(Vec2, x, y);
+mul_impl!(Vec2, x, y);
+div_impl!(Vec2, x, y);
+scalar_add_impl!(Vec2, x, y);
+scalar_sub_impl!(Vec2, x, y);
+scalar_mul_impl!(Vec2, x, y);
+scalar_div_impl!(Vec2, x, y);
+neg_impl!(Vec2, x, y);
+dot_impl!(Vec2, x, y);
+scalar_ops_impl!(Vec2, x, y);
+translation_impl!(Vec2);
+norm_impl!(Vec2, x, y);
+approx_eq_impl!(Vec2, x, y);
+zero_one_impl!(Vec2, x, y);
+from_iterator_impl!(Vec2, iterator, iterator);
+bounded_impl!(Vec2, x, y);
+axpy_impl!(Vec2, x, y);
+iterable_impl!(Vec2, 2);
+iterable_mut_impl!(Vec2, 2);
+vec_to_homogeneous_impl!(Vec2, Vec3, z, x, y);
+vec_from_homogeneous_impl!(Vec2, Vec3, z, x, y);
+translate_impl!(Vec2, Pnt2);
+rotate_impl!(Vec2);
+rotate_impl!(Pnt2);
+transform_impl!(Vec2, Pnt2);
+vec_as_pnt_impl!(Vec2, Pnt2, x, y);
+num_float_vec_impl!(Vec2);
+absolute_vec_impl!(Vec2, x, y);
 
 /// Vector of dimension 3.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Zero, Show, Copy)]
@@ -143,47 +143,47 @@ pub struct Vec3<N> {
     pub z: N
 }
 
-new_impl!(Vec3, x, y, z)
-ord_impl!(Vec3, x, y, z)
-vec_axis_impl!(Vec3, x, y, z)
-vec_cast_impl!(Vec3, x, y, z)
-as_array_impl!(Vec3, 3)
-index_impl!(Vec3)
-indexable_impl!(Vec3, 3)
-at_fast_impl!(Vec3, 3)
-new_repeat_impl!(Vec3, val, x, y, z)
-dim_impl!(Vec3, 3)
-container_impl!(Vec3)
-// (specialized) basis_impl!(Vec3, 1)
-add_impl!(Vec3, x, y, z)
-sub_impl!(Vec3, x, y, z)
-mul_impl!(Vec3, x, y, z)
-div_impl!(Vec3, x, y, z)
-scalar_add_impl!(Vec3, x, y, z)
-scalar_sub_impl!(Vec3, x, y, z)
-scalar_mul_impl!(Vec3, x, y, z)
-scalar_div_impl!(Vec3, x, y, z)
-neg_impl!(Vec3, x, y, z)
-dot_impl!(Vec3, x, y, z)
-scalar_ops_impl!(Vec3, x, y, z)
-translation_impl!(Vec3)
-norm_impl!(Vec3, x, y ,z)
-approx_eq_impl!(Vec3, x, y, z)
-zero_one_impl!(Vec3, x, y, z)
-from_iterator_impl!(Vec3, iterator, iterator, iterator)
-bounded_impl!(Vec3, x, y, z)
-axpy_impl!(Vec3, x, y, z)
-iterable_impl!(Vec3, 3)
-iterable_mut_impl!(Vec3, 3)
-vec_to_homogeneous_impl!(Vec3, Vec4, w, x, y, z)
-vec_from_homogeneous_impl!(Vec3, Vec4, w, x, y, z)
-translate_impl!(Vec3, Pnt3)
-rotate_impl!(Vec3)
-rotate_impl!(Pnt3)
-transform_impl!(Vec3, Pnt3)
-vec_as_pnt_impl!(Vec3, Pnt3, x, y, z)
-num_float_vec_impl!(Vec3)
-absolute_vec_impl!(Vec3, x, y, z)
+new_impl!(Vec3, x, y, z);
+ord_impl!(Vec3, x, y, z);
+vec_axis_impl!(Vec3, x, y, z);
+vec_cast_impl!(Vec3, x, y, z);
+as_array_impl!(Vec3, 3);
+index_impl!(Vec3);
+indexable_impl!(Vec3, 3);
+at_fast_impl!(Vec3, 3);
+new_repeat_impl!(Vec3, val, x, y, z);
+dim_impl!(Vec3, 3);
+container_impl!(Vec3);
+// (specialized); basis_impl!(Vec3, 1);
+add_impl!(Vec3, x, y, z);
+sub_impl!(Vec3, x, y, z);
+mul_impl!(Vec3, x, y, z);
+div_impl!(Vec3, x, y, z);
+scalar_add_impl!(Vec3, x, y, z);
+scalar_sub_impl!(Vec3, x, y, z);
+scalar_mul_impl!(Vec3, x, y, z);
+scalar_div_impl!(Vec3, x, y, z);
+neg_impl!(Vec3, x, y, z);
+dot_impl!(Vec3, x, y, z);
+scalar_ops_impl!(Vec3, x, y, z);
+translation_impl!(Vec3);
+norm_impl!(Vec3, x, y ,z);
+approx_eq_impl!(Vec3, x, y, z);
+zero_one_impl!(Vec3, x, y, z);
+from_iterator_impl!(Vec3, iterator, iterator, iterator);
+bounded_impl!(Vec3, x, y, z);
+axpy_impl!(Vec3, x, y, z);
+iterable_impl!(Vec3, 3);
+iterable_mut_impl!(Vec3, 3);
+vec_to_homogeneous_impl!(Vec3, Vec4, w, x, y, z);
+vec_from_homogeneous_impl!(Vec3, Vec4, w, x, y, z);
+translate_impl!(Vec3, Pnt3);
+rotate_impl!(Vec3);
+rotate_impl!(Pnt3);
+transform_impl!(Vec3, Pnt3);
+vec_as_pnt_impl!(Vec3, Pnt3, x, y, z);
+num_float_vec_impl!(Vec3);
+absolute_vec_impl!(Vec3, x, y, z);
 
 
 /// Vector of dimension 4.
@@ -199,47 +199,47 @@ pub struct Vec4<N> {
     pub w: N
 }
 
-new_impl!(Vec4, x, y, z, w)
-ord_impl!(Vec4, x, y, z, w)
-vec_axis_impl!(Vec4, x, y, z, w)
-vec_cast_impl!(Vec4, x, y, z, w)
-as_array_impl!(Vec4, 4)
-index_impl!(Vec4)
-indexable_impl!(Vec4, 4)
-at_fast_impl!(Vec4, 4)
-new_repeat_impl!(Vec4, val, x, y, z, w)
-dim_impl!(Vec4, 4)
-container_impl!(Vec4)
-basis_impl!(Vec4, 4)
-add_impl!(Vec4, x, y, z, w)
-sub_impl!(Vec4, x, y, z, w)
-mul_impl!(Vec4, x, y, z, w)
-div_impl!(Vec4, x, y, z, w)
-scalar_add_impl!(Vec4, x, y, z, w)
-scalar_sub_impl!(Vec4, x, y, z, w)
-scalar_mul_impl!(Vec4, x, y, z, w)
-scalar_div_impl!(Vec4, x, y, z, w)
-neg_impl!(Vec4, x, y, z, w)
-dot_impl!(Vec4, x, y, z, w)
-scalar_ops_impl!(Vec4, x, y, z, w)
-translation_impl!(Vec4)
-norm_impl!(Vec4, x, y, z, w)
-approx_eq_impl!(Vec4, x, y, z, w)
-zero_one_impl!(Vec4, x, y, z, w)
-from_iterator_impl!(Vec4, iterator, iterator, iterator, iterator)
-bounded_impl!(Vec4, x, y, z, w)
-axpy_impl!(Vec4, x, y, z, w)
-iterable_impl!(Vec4, 4)
-iterable_mut_impl!(Vec4, 4)
-vec_to_homogeneous_impl!(Vec4, Vec5, a, x, y, z, w)
-vec_from_homogeneous_impl!(Vec4, Vec5, a, x, y, z, w)
-translate_impl!(Vec4, Pnt4)
-rotate_impl!(Vec4)
-rotate_impl!(Pnt4)
-transform_impl!(Vec4, Pnt4)
-vec_as_pnt_impl!(Vec4, Pnt4, x, y, z, w)
-num_float_vec_impl!(Vec4)
-absolute_vec_impl!(Vec4, x, y, z, w)
+new_impl!(Vec4, x, y, z, w);
+ord_impl!(Vec4, x, y, z, w);
+vec_axis_impl!(Vec4, x, y, z, w);
+vec_cast_impl!(Vec4, x, y, z, w);
+as_array_impl!(Vec4, 4);
+index_impl!(Vec4);
+indexable_impl!(Vec4, 4);
+at_fast_impl!(Vec4, 4);
+new_repeat_impl!(Vec4, val, x, y, z, w);
+dim_impl!(Vec4, 4);
+container_impl!(Vec4);
+basis_impl!(Vec4, 4);
+add_impl!(Vec4, x, y, z, w);
+sub_impl!(Vec4, x, y, z, w);
+mul_impl!(Vec4, x, y, z, w);
+div_impl!(Vec4, x, y, z, w);
+scalar_add_impl!(Vec4, x, y, z, w);
+scalar_sub_impl!(Vec4, x, y, z, w);
+scalar_mul_impl!(Vec4, x, y, z, w);
+scalar_div_impl!(Vec4, x, y, z, w);
+neg_impl!(Vec4, x, y, z, w);
+dot_impl!(Vec4, x, y, z, w);
+scalar_ops_impl!(Vec4, x, y, z, w);
+translation_impl!(Vec4);
+norm_impl!(Vec4, x, y, z, w);
+approx_eq_impl!(Vec4, x, y, z, w);
+zero_one_impl!(Vec4, x, y, z, w);
+from_iterator_impl!(Vec4, iterator, iterator, iterator, iterator);
+bounded_impl!(Vec4, x, y, z, w);
+axpy_impl!(Vec4, x, y, z, w);
+iterable_impl!(Vec4, 4);
+iterable_mut_impl!(Vec4, 4);
+vec_to_homogeneous_impl!(Vec4, Vec5, a, x, y, z, w);
+vec_from_homogeneous_impl!(Vec4, Vec5, a, x, y, z, w);
+translate_impl!(Vec4, Pnt4);
+rotate_impl!(Vec4);
+rotate_impl!(Pnt4);
+transform_impl!(Vec4, Pnt4);
+vec_as_pnt_impl!(Vec4, Pnt4, x, y, z, w);
+num_float_vec_impl!(Vec4);
+absolute_vec_impl!(Vec4, x, y, z, w);
 
 /// Vector of dimension 5.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Zero, Show, Copy)]
@@ -256,47 +256,47 @@ pub struct Vec5<N> {
     pub a: N
 }
 
-new_impl!(Vec5, x, y, z, w, a)
-ord_impl!(Vec5, x, y, z, w, a)
-vec_axis_impl!(Vec5, x, y, z, w, a)
-vec_cast_impl!(Vec5, x, y, z, w, a)
-as_array_impl!(Vec5, 5)
-index_impl!(Vec5)
-indexable_impl!(Vec5, 5)
-at_fast_impl!(Vec5, 5)
-new_repeat_impl!(Vec5, val, x, y, z, w, a)
-dim_impl!(Vec5, 5)
-container_impl!(Vec5)
-basis_impl!(Vec5, 5)
-add_impl!(Vec5, x, y, z, w, a)
-sub_impl!(Vec5, x, y, z, w, a)
-mul_impl!(Vec5, x, y, z, w, a)
-div_impl!(Vec5, x, y, z, w, a)
-scalar_add_impl!(Vec5, x, y, z, w, a)
-scalar_sub_impl!(Vec5, x, y, z, w, a)
-scalar_mul_impl!(Vec5, x, y, z, w, a)
-scalar_div_impl!(Vec5, x, y, z, w, a)
-neg_impl!(Vec5, x, y, z, w, a)
-dot_impl!(Vec5, x, y, z, w, a)
-scalar_ops_impl!(Vec5, x, y, z, w, a)
-translation_impl!(Vec5)
-norm_impl!(Vec5, x, y, z, w, a)
-approx_eq_impl!(Vec5, x, y, z, w, a)
-zero_one_impl!(Vec5, x, y, z, w, a)
-from_iterator_impl!(Vec5, iterator, iterator, iterator, iterator, iterator)
-bounded_impl!(Vec5, x, y, z, w, a)
-axpy_impl!(Vec5, x, y, z, w, a)
-iterable_impl!(Vec5, 5)
-iterable_mut_impl!(Vec5, 5)
-vec_to_homogeneous_impl!(Vec5, Vec6, b, x, y, z, w, a)
-vec_from_homogeneous_impl!(Vec5, Vec6, b, x, y, z, w, a)
-translate_impl!(Vec5, Pnt5)
-rotate_impl!(Vec5)
-rotate_impl!(Pnt5)
-transform_impl!(Vec5, Pnt5)
-vec_as_pnt_impl!(Vec5, Pnt5, x, y, z, w, a)
-num_float_vec_impl!(Vec5)
-absolute_vec_impl!(Vec5, x, y, z, w, a)
+new_impl!(Vec5, x, y, z, w, a);
+ord_impl!(Vec5, x, y, z, w, a);
+vec_axis_impl!(Vec5, x, y, z, w, a);
+vec_cast_impl!(Vec5, x, y, z, w, a);
+as_array_impl!(Vec5, 5);
+index_impl!(Vec5);
+indexable_impl!(Vec5, 5);
+at_fast_impl!(Vec5, 5);
+new_repeat_impl!(Vec5, val, x, y, z, w, a);
+dim_impl!(Vec5, 5);
+container_impl!(Vec5);
+basis_impl!(Vec5, 5);
+add_impl!(Vec5, x, y, z, w, a);
+sub_impl!(Vec5, x, y, z, w, a);
+mul_impl!(Vec5, x, y, z, w, a);
+div_impl!(Vec5, x, y, z, w, a);
+scalar_add_impl!(Vec5, x, y, z, w, a);
+scalar_sub_impl!(Vec5, x, y, z, w, a);
+scalar_mul_impl!(Vec5, x, y, z, w, a);
+scalar_div_impl!(Vec5, x, y, z, w, a);
+neg_impl!(Vec5, x, y, z, w, a);
+dot_impl!(Vec5, x, y, z, w, a);
+scalar_ops_impl!(Vec5, x, y, z, w, a);
+translation_impl!(Vec5);
+norm_impl!(Vec5, x, y, z, w, a);
+approx_eq_impl!(Vec5, x, y, z, w, a);
+zero_one_impl!(Vec5, x, y, z, w, a);
+from_iterator_impl!(Vec5, iterator, iterator, iterator, iterator, iterator);
+bounded_impl!(Vec5, x, y, z, w, a);
+axpy_impl!(Vec5, x, y, z, w, a);
+iterable_impl!(Vec5, 5);
+iterable_mut_impl!(Vec5, 5);
+vec_to_homogeneous_impl!(Vec5, Vec6, b, x, y, z, w, a);
+vec_from_homogeneous_impl!(Vec5, Vec6, b, x, y, z, w, a);
+translate_impl!(Vec5, Pnt5);
+rotate_impl!(Vec5);
+rotate_impl!(Pnt5);
+transform_impl!(Vec5, Pnt5);
+vec_as_pnt_impl!(Vec5, Pnt5, x, y, z, w, a);
+num_float_vec_impl!(Vec5);
+absolute_vec_impl!(Vec5, x, y, z, w, a);
 
 /// Vector of dimension 6.
 #[deriving(Eq, PartialEq, Encodable, Decodable, Clone, Hash, Rand, Zero, Show, Copy)]
@@ -315,42 +315,42 @@ pub struct Vec6<N> {
     pub b: N
 }
 
-new_impl!(Vec6, x, y, z, w, a, b)
-ord_impl!(Vec6, x, y, z, w, a, b)
-vec_axis_impl!(Vec6, x, y, z, w, a, b)
-vec_cast_impl!(Vec6, x, y, z, w, a, b)
-as_array_impl!(Vec6, 6)
-index_impl!(Vec6)
-indexable_impl!(Vec6, 6)
-at_fast_impl!(Vec6, 6)
-new_repeat_impl!(Vec6, val, x, y, z, w, a, b)
-dim_impl!(Vec6, 6)
-container_impl!(Vec6)
-basis_impl!(Vec6, 6)
-add_impl!(Vec6, x, y, z, w, a, b)
-sub_impl!(Vec6, x, y, z, w, a, b)
-mul_impl!(Vec6, x, y, z, w, a, b)
-div_impl!(Vec6, x, y, z, w, a, b)
-scalar_add_impl!(Vec6, x, y, z, w, a, b)
-scalar_sub_impl!(Vec6, x, y, z, w, a, b)
-scalar_mul_impl!(Vec6, x, y, z, w, a, b)
-scalar_div_impl!(Vec6, x, y, z, w, a, b)
-neg_impl!(Vec6, x, y, z, w, a, b)
-dot_impl!(Vec6, x, y, z, w, a, b)
-scalar_ops_impl!(Vec6, x, y, z, w, a, b)
-translation_impl!(Vec6)
-norm_impl!(Vec6, x, y, z, w, a, b)
-approx_eq_impl!(Vec6, x, y, z, w, a, b)
-zero_one_impl!(Vec6, x, y, z, w, a, b)
-from_iterator_impl!(Vec6, iterator, iterator, iterator, iterator, iterator, iterator)
-bounded_impl!(Vec6, x, y, z, w, a, b)
-axpy_impl!(Vec6, x, y, z, w, a, b)
-iterable_impl!(Vec6, 6)
-iterable_mut_impl!(Vec6, 6)
-translate_impl!(Vec6, Pnt6)
-rotate_impl!(Vec6)
-rotate_impl!(Pnt6)
-transform_impl!(Vec6, Pnt6)
-vec_as_pnt_impl!(Vec6, Pnt6, x, y, z, w, a, b)
-num_float_vec_impl!(Vec6)
-absolute_vec_impl!(Vec6, x, y, z, w, a, b)
+new_impl!(Vec6, x, y, z, w, a, b);
+ord_impl!(Vec6, x, y, z, w, a, b);
+vec_axis_impl!(Vec6, x, y, z, w, a, b);
+vec_cast_impl!(Vec6, x, y, z, w, a, b);
+as_array_impl!(Vec6, 6);
+index_impl!(Vec6);
+indexable_impl!(Vec6, 6);
+at_fast_impl!(Vec6, 6);
+new_repeat_impl!(Vec6, val, x, y, z, w, a, b);
+dim_impl!(Vec6, 6);
+container_impl!(Vec6);
+basis_impl!(Vec6, 6);
+add_impl!(Vec6, x, y, z, w, a, b);
+sub_impl!(Vec6, x, y, z, w, a, b);
+mul_impl!(Vec6, x, y, z, w, a, b);
+div_impl!(Vec6, x, y, z, w, a, b);
+scalar_add_impl!(Vec6, x, y, z, w, a, b);
+scalar_sub_impl!(Vec6, x, y, z, w, a, b);
+scalar_mul_impl!(Vec6, x, y, z, w, a, b);
+scalar_div_impl!(Vec6, x, y, z, w, a, b);
+neg_impl!(Vec6, x, y, z, w, a, b);
+dot_impl!(Vec6, x, y, z, w, a, b);
+scalar_ops_impl!(Vec6, x, y, z, w, a, b);
+translation_impl!(Vec6);
+norm_impl!(Vec6, x, y, z, w, a, b);
+approx_eq_impl!(Vec6, x, y, z, w, a, b);
+zero_one_impl!(Vec6, x, y, z, w, a, b);
+from_iterator_impl!(Vec6, iterator, iterator, iterator, iterator, iterator, iterator);
+bounded_impl!(Vec6, x, y, z, w, a, b);
+axpy_impl!(Vec6, x, y, z, w, a, b);
+iterable_impl!(Vec6, 6);
+iterable_mut_impl!(Vec6, 6);
+translate_impl!(Vec6, Pnt6);
+rotate_impl!(Vec6);
+rotate_impl!(Pnt6);
+transform_impl!(Vec6, Pnt6);
+vec_as_pnt_impl!(Vec6, Pnt6, x, y, z, w, a, b);
+num_float_vec_impl!(Vec6);
+absolute_vec_impl!(Vec6, x, y, z, w, a, b);

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -13,7 +13,7 @@ macro_rules! new_impl(
             }
         }
     )
-)
+);
 
 macro_rules! as_array_impl(
     ($t: ident, $dim: expr) => (
@@ -56,7 +56,7 @@ macro_rules! as_array_impl(
             }
         }
     )
-)
+);
 
 macro_rules! at_fast_impl(
     ($t: ident, $dim: expr) => (
@@ -74,7 +74,7 @@ macro_rules! at_fast_impl(
             }
         }
     )
-)
+);
 
 // FIXME: N should be bounded by Ord instead of BaseFloat…
 // However, f32/f64 does not implement Ord…
@@ -149,7 +149,7 @@ macro_rules! ord_impl(
             }
         }
     )
-)
+);
 
 macro_rules! vec_axis_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -177,7 +177,7 @@ macro_rules! vec_axis_impl(
             )*
         }
     )
-)
+);
 
 macro_rules! vec_cast_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -188,7 +188,7 @@ macro_rules! vec_cast_impl(
             }
         }
     )
-)
+);
 
 macro_rules! indexable_impl(
     ($t: ident, $dim: expr) => (
@@ -232,7 +232,7 @@ macro_rules! indexable_impl(
             }
         }
     )
-)
+);
 
 macro_rules! index_impl(
     ($t: ident) => (
@@ -248,7 +248,7 @@ macro_rules! index_impl(
             }
         }
     )
-)
+);
 
 macro_rules! new_repeat_impl(
     ($t: ident, $param: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -263,7 +263,7 @@ macro_rules! new_repeat_impl(
             }
         }
     )
-)
+);
 
 macro_rules! iterable_impl(
     ($t: ident, $dim: expr) => (
@@ -276,7 +276,7 @@ macro_rules! iterable_impl(
             }
         }
     )
-)
+);
 
 macro_rules! iterable_mut_impl(
     ($t: ident, $dim: expr) => (
@@ -289,7 +289,7 @@ macro_rules! iterable_mut_impl(
             }
         }
     )
-)
+);
 
 macro_rules! dim_impl(
     ($t: ident, $dim: expr) => (
@@ -300,7 +300,7 @@ macro_rules! dim_impl(
             }
         }
     )
-)
+);
 
 macro_rules! container_impl(
     ($t: ident) => (
@@ -311,7 +311,7 @@ macro_rules! container_impl(
             }
         }
     )
-)
+);
 
 macro_rules! basis_impl(
     ($t: ident, $dim: expr) => (
@@ -375,7 +375,7 @@ macro_rules! basis_impl(
             }
         }
     )
-)
+);
 
 macro_rules! axpy_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -387,7 +387,7 @@ macro_rules! axpy_impl(
             }
         }
     )
-)
+);
 
 macro_rules! add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -398,7 +398,7 @@ macro_rules! add_impl(
             }
         }
     )
-)
+);
 
 macro_rules! scalar_add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -410,7 +410,7 @@ macro_rules! scalar_add_impl(
             }
         }
     )
-)
+);
 
 macro_rules! sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -421,7 +421,7 @@ macro_rules! sub_impl(
             }
         }
     )
-)
+);
 
 macro_rules! scalar_sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -432,7 +432,7 @@ macro_rules! scalar_sub_impl(
             }
         }
     )
-)
+);
 
 macro_rules! mul_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -443,7 +443,7 @@ macro_rules! mul_impl(
             }
         }
     )
-)
+);
 
 macro_rules! scalar_mul_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -454,7 +454,7 @@ macro_rules! scalar_mul_impl(
             }
         }
     )
-)
+);
 
 macro_rules! div_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -465,7 +465,7 @@ macro_rules! div_impl(
             }
         }
     )
-)
+);
 
 macro_rules! scalar_div_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -476,7 +476,7 @@ macro_rules! scalar_div_impl(
             }
         }
     )
-)
+);
 
 macro_rules! neg_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -487,7 +487,7 @@ macro_rules! neg_impl(
             }
         }
     )
-)
+);
 
 macro_rules! dot_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -498,7 +498,7 @@ macro_rules! dot_impl(
             }
         }
     )
-)
+);
 
 macro_rules! scalar_ops_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -530,7 +530,7 @@ macro_rules! scalar_ops_impl(
             }
         }
     )
-)
+);
 
 macro_rules! translation_impl(
     ($t: ident) => (
@@ -571,7 +571,7 @@ macro_rules! translation_impl(
             }
         }
     )
-)
+);
 
 macro_rules! norm_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -599,7 +599,7 @@ macro_rules! norm_impl(
             }
         }
     )
-)
+);
 
 macro_rules! approx_eq_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -622,7 +622,7 @@ macro_rules! approx_eq_impl(
             }
         }
     )
-)
+);
 
 macro_rules! zero_one_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -652,7 +652,7 @@ macro_rules! zero_one_impl(
             }
         }
     )
-)
+);
 
 macro_rules! from_iterator_impl(
     ($t: ident, $param0: ident $(, $paramN: ident)*) => (
@@ -663,7 +663,7 @@ macro_rules! from_iterator_impl(
             }
         }
     )
-)
+);
 
 macro_rules! bounded_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -685,7 +685,7 @@ macro_rules! bounded_impl(
             }
         }
     )
-)
+);
 
 macro_rules! vec_to_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -700,7 +700,7 @@ macro_rules! vec_to_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! vec_from_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -715,7 +715,7 @@ macro_rules! vec_from_homogeneous_impl(
             }
         }
     )
-)
+);
 
 macro_rules! translate_impl(
     ($tv: ident, $t: ident) => (
@@ -729,7 +729,7 @@ macro_rules! translate_impl(
             }
         }
     )
-)
+);
 
 macro_rules! rotate_impl(
     ($t: ident) => (
@@ -743,7 +743,7 @@ macro_rules! rotate_impl(
             }
         }
     )
-)
+);
 
 macro_rules! transform_impl(
     ($tv: ident, $t: ident) => (
@@ -757,7 +757,7 @@ macro_rules! transform_impl(
             }
         }
     )
-)
+);
 
 macro_rules! vec_as_pnt_impl(
     ($tv: ident, $t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -792,7 +792,7 @@ macro_rules! vec_as_pnt_impl(
             }
         }
     )
-)
+);
 
 macro_rules! num_float_vec_impl(
     ($t: ident) => (
@@ -804,7 +804,7 @@ macro_rules! num_float_vec_impl(
             where N: BaseFloat + ApproxEq<N> {
         }
     )
-)
+);
 
 macro_rules! absolute_vec_impl(
   ($t: ident, $comp0: ident $(,$compN: ident)*) => (
@@ -815,4 +815,4 @@ macro_rules! absolute_vec_impl(
         }
     }
   )
-)
+);

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -342,7 +342,7 @@ macro_rules! impl_absolute(
             }
         }
     }
-)
+);
 macro_rules! impl_absolute_id(
     ($n: ty) => {
         impl Absolute<$n> for $n {
@@ -352,20 +352,20 @@ macro_rules! impl_absolute_id(
             }
         }
     }
-)
+);
 
-impl_absolute!(f32)
-impl_absolute!(f64)
-impl_absolute!(i8)
-impl_absolute!(i16)
-impl_absolute!(i32)
-impl_absolute!(i64)
-impl_absolute!(int)
-impl_absolute_id!(u8)
-impl_absolute_id!(u16)
-impl_absolute_id!(u32)
-impl_absolute_id!(u64)
-impl_absolute_id!(uint)
+impl_absolute!(f32);
+impl_absolute!(f64);
+impl_absolute!(i8);
+impl_absolute!(i16);
+impl_absolute!(i32);
+impl_absolute!(i64);
+impl_absolute!(int);
+impl_absolute_id!(u8);
+impl_absolute_id!(u16);
+impl_absolute_id!(u32);
+impl_absolute_id!(u64);
+impl_absolute_id!(uint);
 
 macro_rules! impl_axpy(
     ($n: ty) => {
@@ -376,17 +376,17 @@ macro_rules! impl_axpy(
             }
         }
     }
-)
+);
 
-impl_axpy!(f32)
-impl_axpy!(f64)
-impl_axpy!(i8)
-impl_axpy!(i16)
-impl_axpy!(i32)
-impl_axpy!(i64)
-impl_axpy!(int)
-impl_axpy!(u8)
-impl_axpy!(u16)
-impl_axpy!(u32)
-impl_axpy!(u64)
-impl_axpy!(uint)
+impl_axpy!(f32);
+impl_axpy!(f64);
+impl_axpy!(i8);
+impl_axpy!(i16);
+impl_axpy!(i32);
+impl_axpy!(i64);
+impl_axpy!(int);
+impl_axpy!(u8);
+impl_axpy!(u16);
+impl_axpy!(u32);
+impl_axpy!(u64);
+impl_axpy!(uint);

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -313,20 +313,20 @@ macro_rules! impl_zero_one(
             }
         }
     }
-)
+);
 
-impl_zero_one!(f32, 0.0, 1.0)
-impl_zero_one!(f64, 0.0, 1.0)
-impl_zero_one!(i8, 0, 1)
-impl_zero_one!(i16, 0, 1)
-impl_zero_one!(i32, 0, 1)
-impl_zero_one!(i64, 0, 1)
-impl_zero_one!(int, 0, 1)
-impl_zero_one!(u8, 0, 1)
-impl_zero_one!(u16, 0, 1)
-impl_zero_one!(u32, 0, 1)
-impl_zero_one!(u64, 0, 1)
-impl_zero_one!(uint, 0, 1)
+impl_zero_one!(f32, 0.0, 1.0);
+impl_zero_one!(f64, 0.0, 1.0);
+impl_zero_one!(i8, 0, 1);
+impl_zero_one!(i16, 0, 1);
+impl_zero_one!(i32, 0, 1);
+impl_zero_one!(i64, 0, 1);
+impl_zero_one!(int, 0, 1);
+impl_zero_one!(u8, 0, 1);
+impl_zero_one!(u16, 0, 1);
+impl_zero_one!(u32, 0, 1);
+impl_zero_one!(u64, 0, 1);
+impl_zero_one!(uint, 0, 1);
 
 
 // Bounded
@@ -344,20 +344,20 @@ macro_rules! impl_bounded(
             }
         }
     }
-)
+);
 
-impl_bounded!(f32, Float::min_value(), Float::max_value())
-impl_bounded!(f64, Float::min_value(), Float::max_value())
-impl_bounded!(i8, Int::min_value(), Int::max_value())
-impl_bounded!(i16, Int::min_value(), Int::max_value())
-impl_bounded!(i32, Int::min_value(), Int::max_value())
-impl_bounded!(i64, Int::min_value(), Int::max_value())
-impl_bounded!(int, Int::min_value(), Int::max_value())
-impl_bounded!(u8, Int::min_value(), Int::max_value())
-impl_bounded!(u16, Int::min_value(), Int::max_value())
-impl_bounded!(u32, Int::min_value(), Int::max_value())
-impl_bounded!(u64, Int::min_value(), Int::max_value())
-impl_bounded!(uint, Int::min_value(), Int::max_value())
+impl_bounded!(f32, Float::min_value(), Float::max_value());
+impl_bounded!(f64, Float::min_value(), Float::max_value());
+impl_bounded!(i8, Int::min_value(), Int::max_value());
+impl_bounded!(i16, Int::min_value(), Int::max_value());
+impl_bounded!(i32, Int::min_value(), Int::max_value());
+impl_bounded!(i64, Int::min_value(), Int::max_value());
+impl_bounded!(int, Int::min_value(), Int::max_value());
+impl_bounded!(u8, Int::min_value(), Int::max_value());
+impl_bounded!(u16, Int::min_value(), Int::max_value());
+impl_bounded!(u32, Int::min_value(), Int::max_value());
+impl_bounded!(u64, Int::min_value(), Int::max_value());
+impl_bounded!(uint, Int::min_value(), Int::max_value());
 
 
 // BaseFloat
@@ -441,10 +441,10 @@ macro_rules! impl_base_float(
             }
         }
     }
-)
+);
 
 impl BaseNum for f32 { }
 impl BaseNum for f64 { }
 
-impl_base_float!(f32)
-impl_base_float!(f64)
+impl_base_float!(f32);
+impl_base_float!(f64);

--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -17,7 +17,7 @@ macro_rules! test_inv_mat_impl(
       }
     }
   );
-)
+);
 
 macro_rules! test_transpose_mat_impl(
   ($t: ty) => (
@@ -27,7 +27,7 @@ macro_rules! test_transpose_mat_impl(
       assert!(na::transpose(&na::transpose(&randmat)) == randmat);
     }
   );
-)
+);
 
 macro_rules! test_qr_impl(
   ($t: ty) => (
@@ -40,7 +40,7 @@ macro_rules! test_qr_impl(
       assert!(na::approx_eq(&randmat,  &recomp));
     }
   );
-)
+);
 
 // NOTE: deactivated untile we get a better convergence rate.
 // macro_rules! test_eigen_qr_impl(

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -21,7 +21,7 @@ macro_rules! test_iterator_impl(
             assert!(nv == mv && nv == v * n);
         }
     )
-)
+);
 
 macro_rules! test_commut_dot_impl(
     ($t: ty) => (
@@ -32,7 +32,7 @@ macro_rules! test_commut_dot_impl(
             assert!(na::approx_eq(&na::dot(&v1, &v2), &na::dot(&v2, &v1)));
         }
     );
-)
+);
 
 macro_rules! test_scalar_op_impl(
     ($t: ty, $n: ty) => (
@@ -55,7 +55,7 @@ macro_rules! test_scalar_op_impl(
             assert!(na::approx_eq(&v1, &v0));
         }
     );
-)
+);
 
 macro_rules! test_basis_impl(
     ($t: ty) => (
@@ -73,7 +73,7 @@ macro_rules! test_basis_impl(
             })
         }
     );
-)
+);
 
 macro_rules! test_subspace_basis_impl(
     ($t: ty) => (
@@ -97,7 +97,7 @@ macro_rules! test_subspace_basis_impl(
             })
         }
     );
-)
+);
 
 #[test]
 fn test_cross_vec3() {


### PR DESCRIPTION
This is a fix for the latest nightly, see https://github.com/rust-lang/rust/pull/19984.
