### PR TITLE
Use Vector3::new in first example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ extern crate nalgebra as na;
 use na::{Vector3, Rotation3};
 
 fn main() {
-    let axis  = Vector3::x_axis();
+    let axis  = Vector3::new(1.0, 0.0, 0.0);
     let angle = 1.57;
     let b     = Rotation3::from_axis_angle(&axis, angle);
 


### PR DESCRIPTION
The `new` function on vectors is oddly hard to find in the documentation (the first time I tried using nalgebra I think I actually gave up before finding it...). Given that creating a vector is likely one of the very first things beginners are likely to want to do, it is worth demonstrating it here.