### PR TITLE
Re-export alga docs to improve discoverability of trait implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,15 @@ use num::Signed;
 
 pub use alga::general::{Id, Real};
 
+/// Documentation for traits implemented from `alga`.
+///
+/// For documentation purposes only; do not rely on items from this module.
+// Use https://github.com/rust-lang/rust/pull/53076, once stabilized.
+#[deprecated(note = "For documentation purposes only; do not rely on items from this module.")]
+pub mod alga_documentation {
+    pub use alga::*;
+}
+
 /*
  *
  * Multiplicative identity.


### PR DESCRIPTION
Implements the suggestion I made in https://github.com/rustsim/nalgebra/issues/511#issuecomment-450224279.

This provides a one-stop place to find out which traits from `alga` are implemented for types from `nalgebra`.

For example, here's how rustdoc renders `alga_documentation::linear::AffineTransformation`:
![screenshot--2018 12 27-15-18-27](https://user-images.githubusercontent.com/3820879/50493314-ae226e00-09ea-11e9-915a-f88c99e7003f.png)

Once [`doc_cfg`](https://github.com/rust-lang/rust/pull/53076) is stabilized, the `deprecated` notice should be superceded (or augmented) by `#[cfg(rustdoc)]`.