### PR TITLE
Add 'compact-display' feature that prints vectors and matrices compactly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
 abomonation-serialize = [ "abomonation" ]
 debug = [ ]
 alloc = [ ]
+compact-display = []
 
 [dependencies]
 typenum        = "1.10"


### PR DESCRIPTION
I use nalgebra for writing a renderer and other computer-graphics applications. I often print out vector and matrix data for debugging and information purposes, but the default Display implementation is extremely large, especially when printing an array of values. 

This PR adds a feature, "compact-display" that switches to an alternate implementation which prints vectors and matrices as a parenthesized list of rows to save on space. 