### PR TITLE
Add methods to get transposed views of matrices

### DIFF
--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -249,6 +249,7 @@ macro_rules! matrix_slice_impl(
      $fixed_columns_with_step: ident,
      $columns_generic: ident,
      $columns_generic_with_step: ident,
+     $transposed_slice: ident,
      $slice: ident,
      $slice_with_steps: ident,
      $fixed_slice: ident,
@@ -433,6 +434,27 @@ macro_rules! matrix_slice_impl(
 
                 unsafe {
                     let data = $SliceStorage::new_with_strides_unchecked($data, (0, first_col), shape, strides);
+                    Matrix::from_data_statically_unchecked(data)
+                }
+            }
+
+            /*
+             *
+             * Transposed slicing.
+             *
+             */
+            /// Returns a slice containing the same values as `Self.transpose()` but without
+            /// copying.
+            #[inline]
+            pub fn $transposed_slice($me: $Me) -> $MatrixSlice<N, C, R, S::CStride, S::RStride> {
+                let my_shape   = $me.data.shape();
+                let my_strides = $me.data.strides();
+
+                let shape   = (my_shape.1,   my_shape.0);
+                let strides = (my_strides.1, my_strides.0);
+
+                unsafe {
+                    let data = $SliceStorage::new_with_strides_unchecked($data, (0, 0), shape, strides);
                     Matrix::from_data_statically_unchecked(data)
                 }
             }
@@ -635,6 +657,7 @@ matrix_slice_impl!(
      fixed_columns_with_step,
      columns_generic,
      columns_generic_with_step,
+     transposed_slice,
      slice,
      slice_with_steps,
      fixed_slice,
@@ -662,6 +685,7 @@ matrix_slice_impl!(
      fixed_columns_with_step_mut,
      columns_generic_mut,
      columns_generic_with_step_mut,
+     transposed_slice_mut,
      slice_mut,
      slice_with_steps_mut,
      fixed_slice_mut,

--- a/tests/core/matrix_slice.rs
+++ b/tests/core/matrix_slice.rs
@@ -4,9 +4,9 @@
 use na::{U2, U3, U4};
 use na::{DMatrix,
          RowVector4,
-         Vector3,
+         Vector3, Vector4,
          Matrix2, Matrix3,
-         Matrix2x3, Matrix3x2, Matrix3x4, Matrix4x2, Matrix2x4, Matrix6x2, Matrix2x6,
+         Matrix2x3, Matrix3x2, Matrix3x4, Matrix4x3, Matrix4x2, Matrix2x4, Matrix6x2, Matrix2x6,
          MatrixSlice2, MatrixSlice3, MatrixSlice2x3, MatrixSlice3x2,
          MatrixSliceXx3, MatrixSlice2xX, DMatrixSlice,
          MatrixSliceMut2, MatrixSliceMut3, MatrixSliceMut2x3, MatrixSliceMut3x2,
@@ -195,6 +195,47 @@ fn columns_range_pair() {
                                   22.0, 23.0, 24.0,
                                   32.0, 33.0, 34.0);
     assert!(l.eq(&expected_l) && r.eq(&expected_r));
+}
+
+#[test]
+fn transposed_slice() {
+    let a = Matrix3x4::new(11.0, 12.0, 13.0, 14.0,
+                           21.0, 22.0, 23.0, 24.0,
+                           31.0, 32.0, 33.0, 34.0);
+    let s1 = a.transposed_slice();
+    let s2_tmp = a.fixed_slice::<U2, U2>(1,2);
+    let s2 = s2_tmp.transposed_slice();
+    let s3_tmp = a.row(0);
+    let s3 = s3_tmp.transposed_slice();
+
+    let expected_owned_s1 = Matrix4x3::new(11.0, 21.0, 31.0,
+                                           12.0, 22.0, 32.0,
+                                           13.0, 23.0, 33.0,
+                                           14.0, 24.0, 34.0);
+    let expected_owned_s2 = Matrix2::new(23.0, 33.0,
+                                         24.0, 34.0);
+    let expected_owned_s3 = Vector4::new(11.0, 12.0, 13.0, 14.0);
+    assert_eq!(expected_owned_s1, s1.clone_owned());
+    assert_eq!(expected_owned_s2, s2.clone_owned());
+    assert_eq!(expected_owned_s3, s3.clone_owned());
+}
+
+#[test]
+fn transposed_slice_mut() {
+    let mut a = Matrix3x4::new(11.0, 12.0, 13.0, 14.0,
+                               21.0, 22.0, 23.0, 24.0,
+                               31.0, 32.0, 33.0, 34.0);
+
+    {
+        let mut s1 = a.transposed_slice_mut();
+        *(s1.index_mut((1,0))) = 0.0;
+        s1.row_mut(3).fill(0.0);
+    }
+
+    let expected_a = Matrix3x4::new(11.0,  0.0, 13.0, 0.0,
+                                    21.0, 22.0, 23.0, 0.0,
+                                    31.0, 32.0, 33.0, 0.0);
+    assert_eq!(expected_a, a);
 }
 
 #[test]


### PR DESCRIPTION
It works by flipping the shapes and strides. This should be much cheaper than copying.

This enables code like `m.row(0).transposed_slice().argmax()` to get argmax along the rows, and in general might be very useful for performance.