### PR TITLE
Polar decomposition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nalgebra"
-version = "0.18.1"
+version = "0.18.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "Linear algebra library with transformations and statically-sized or dynamically-sized matrices."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ rand_xorshift = "0.1"
 ### We can't just let this uncommented because that would break
 ### compilation for #[no-std] because of the terrible Cargo bug
 ### https://github.com/rust-lang/cargo/issues/4866
-#criterion = "0.2.10"
+criterion = "0.2.10"
 
 [workspace]
 members = [ "nalgebra-lapack", "nalgebra-glm" ]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -35,5 +35,6 @@ criterion_main!(
     linalg::schur,
     linalg::solve,
     linalg::svd,
+    linalg::polar,
     linalg::symmetric_eigen,
 );

--- a/benches/linalg/mod.rs
+++ b/benches/linalg/mod.rs
@@ -7,6 +7,7 @@ pub use self::qr::qr;
 pub use self::schur::schur;
 pub use self::solve::solve;
 pub use self::svd::svd;
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::polar::polar;
 pub use self::symmetric_eigen::symmetric_eigen;
 
@@ -19,6 +20,7 @@ mod qr;
 mod schur;
 mod solve;
 mod svd;
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod polar;
 mod symmetric_eigen;
 // mod eigen;

--- a/benches/linalg/mod.rs
+++ b/benches/linalg/mod.rs
@@ -7,6 +7,7 @@ pub use self::qr::qr;
 pub use self::schur::schur;
 pub use self::solve::solve;
 pub use self::svd::svd;
+pub use self::polar::polar;
 pub use self::symmetric_eigen::symmetric_eigen;
 
 mod bidiagonal;
@@ -18,5 +19,6 @@ mod qr;
 mod schur;
 mod solve;
 mod svd;
+mod polar;
 mod symmetric_eigen;
 // mod eigen;

--- a/benches/linalg/polar.rs
+++ b/benches/linalg/polar.rs
@@ -1,0 +1,101 @@
+use na::{Matrix4, Polar};
+
+fn polar_decompose_4x4(bh: &mut criterion::Criterion) {
+    let m = Matrix4::<f64>::new_random();
+    bh.bench_function("polar_decompose_4x4", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+}
+
+fn polar_decompose_10x10(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(10, 10);
+    bh.bench_function("polar_decompose_10x10", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+}
+
+fn polar_decompose_100x100(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(100, 100);
+    bh.bench_function("polar_decompose_100x100", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+}
+
+fn polar_decompose_200x200(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(200, 200);
+    bh.bench_function("polar_decompose_200x200", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+}
+
+fn rank_4x4(bh: &mut criterion::Criterion) {
+    let m = Matrix4::<f64>::new_random();
+    bh.bench_function("rank_4x4", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
+}
+
+fn rank_10x10(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(10, 10);
+    bh.bench_function("rank_10x10", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
+}
+
+fn rank_100x100(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(100, 100);
+    bh.bench_function("rank_100x100", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
+}
+
+fn rank_200x200(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(200, 200);
+    bh.bench_function("rank_200x200", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
+}
+
+fn singular_values_4x4(bh: &mut criterion::Criterion) {
+    let m = Matrix4::<f64>::new_random();
+    bh.bench_function("singular_values_4x4", move |bh| bh.iter(|| test::black_box(m.singular_values())));
+}
+
+fn singular_values_10x10(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(10, 10);
+    bh.bench_function("singular_values_10x10", move |bh| bh.iter(|| test::black_box(m.singular_values())));
+}
+
+fn singular_values_100x100(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(100, 100);
+    bh.bench_function("singular_values_100x100", move |bh| bh.iter(|| test::black_box(m.singular_values())));
+}
+
+fn singular_values_200x200(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(200, 200);
+    bh.bench_function("singular_values_200x200", move |bh| bh.iter(|| test::black_box(m.singular_values())));
+}
+
+fn pseudo_inverse_4x4(bh: &mut criterion::Criterion) {
+    let m = Matrix4::<f64>::new_random();
+    bh.bench_function("pseudo_inverse_4x4", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
+}
+
+fn pseudo_inverse_10x10(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(10, 10);
+    bh.bench_function("pseudo_inverse_10x10", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
+}
+
+fn pseudo_inverse_100x100(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(100, 100);
+    bh.bench_function("pseudo_inverse_100x100", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
+}
+
+fn pseudo_inverse_200x200(bh: &mut criterion::Criterion) {
+    let m = crate::reproductible_dmatrix(200, 200);
+    bh.bench_function("pseudo_inverse_200x200", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
+}
+
+
+criterion_group!(polar,
+    polar_decompose_4x4,
+    polar_decompose_10x10,
+    polar_decompose_100x100,
+    polar_decompose_200x200,
+    rank_4x4,
+    rank_10x10,
+    rank_100x100,
+    rank_200x200,
+    singular_values_4x4,
+    singular_values_10x10,
+    singular_values_100x100,
+    singular_values_200x200,
+    pseudo_inverse_4x4,
+    pseudo_inverse_10x10,
+    pseudo_inverse_100x100,
+    pseudo_inverse_200x200
+);

--- a/benches/linalg/polar.rs
+++ b/benches/linalg/polar.rs
@@ -1,101 +1,28 @@
-use na::{Matrix4, Polar};
+use na::{DMatrix, Polar};
 
 fn polar_decompose_4x4(bh: &mut criterion::Criterion) {
-    let m = Matrix4::<f64>::new_random();
-    bh.bench_function("polar_decompose_4x4", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+    let m = DMatrix::<f64>::new_random(4,4);
+    bh.bench_function("polar_decompose_4x4", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone()))));
 }
 
 fn polar_decompose_10x10(bh: &mut criterion::Criterion) {
     let m = crate::reproductible_dmatrix(10, 10);
-    bh.bench_function("polar_decompose_10x10", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+    bh.bench_function("polar_decompose_10x10", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone()))));
 }
 
 fn polar_decompose_100x100(bh: &mut criterion::Criterion) {
     let m = crate::reproductible_dmatrix(100, 100);
-    bh.bench_function("polar_decompose_100x100", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+    bh.bench_function("polar_decompose_100x100", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone()))));
 }
 
 fn polar_decompose_200x200(bh: &mut criterion::Criterion) {
     let m = crate::reproductible_dmatrix(200, 200);
-    bh.bench_function("polar_decompose_200x200", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone(), true, true))));
+    bh.bench_function("polar_decompose_200x200", move |bh| bh.iter(|| test::black_box(Polar::new(m.clone()))));
 }
-
-fn rank_4x4(bh: &mut criterion::Criterion) {
-    let m = Matrix4::<f64>::new_random();
-    bh.bench_function("rank_4x4", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
-}
-
-fn rank_10x10(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(10, 10);
-    bh.bench_function("rank_10x10", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
-}
-
-fn rank_100x100(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(100, 100);
-    bh.bench_function("rank_100x100", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
-}
-
-fn rank_200x200(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(200, 200);
-    bh.bench_function("rank_200x200", move |bh| bh.iter(|| test::black_box(m.rank(1.0e-10))));
-}
-
-fn singular_values_4x4(bh: &mut criterion::Criterion) {
-    let m = Matrix4::<f64>::new_random();
-    bh.bench_function("singular_values_4x4", move |bh| bh.iter(|| test::black_box(m.singular_values())));
-}
-
-fn singular_values_10x10(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(10, 10);
-    bh.bench_function("singular_values_10x10", move |bh| bh.iter(|| test::black_box(m.singular_values())));
-}
-
-fn singular_values_100x100(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(100, 100);
-    bh.bench_function("singular_values_100x100", move |bh| bh.iter(|| test::black_box(m.singular_values())));
-}
-
-fn singular_values_200x200(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(200, 200);
-    bh.bench_function("singular_values_200x200", move |bh| bh.iter(|| test::black_box(m.singular_values())));
-}
-
-fn pseudo_inverse_4x4(bh: &mut criterion::Criterion) {
-    let m = Matrix4::<f64>::new_random();
-    bh.bench_function("pseudo_inverse_4x4", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
-}
-
-fn pseudo_inverse_10x10(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(10, 10);
-    bh.bench_function("pseudo_inverse_10x10", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
-}
-
-fn pseudo_inverse_100x100(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(100, 100);
-    bh.bench_function("pseudo_inverse_100x100", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
-}
-
-fn pseudo_inverse_200x200(bh: &mut criterion::Criterion) {
-    let m = crate::reproductible_dmatrix(200, 200);
-    bh.bench_function("pseudo_inverse_200x200", move |bh| bh.iter(|| test::black_box(m.clone().pseudo_inverse(1.0e-10))));
-}
-
 
 criterion_group!(polar,
     polar_decompose_4x4,
     polar_decompose_10x10,
     polar_decompose_100x100,
     polar_decompose_200x200,
-    rank_4x4,
-    rank_10x10,
-    rank_100x100,
-    rank_200x200,
-    singular_values_4x4,
-    singular_values_10x10,
-    singular_values_100x100,
-    singular_values_200x200,
-    pseudo_inverse_4x4,
-    pseudo_inverse_10x10,
-    pseudo_inverse_100x100,
-    pseudo_inverse_200x200
 );

--- a/nalgebra-glm/src/geometric.rs
+++ b/nalgebra-glm/src/geometric.rs
@@ -4,7 +4,7 @@ use crate::aliases::{TVec, TVec3};
 use crate::traits::{Alloc, Dimension, Number};
 
 /// The cross product of two vectors.
-pub fn cross<N: Number, D: Dimension>(x: &TVec3<N>, y: &TVec3<N>) -> TVec3<N> {
+pub fn cross<N: Number>(x: &TVec3<N>, y: &TVec3<N>) -> TVec3<N> {
     x.cross(y)
 }
 

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -565,6 +565,7 @@ where
         );
 
         if ncols2 == 0 {
+            self.fill(N::zero());
             return;
         }
 
@@ -1005,6 +1006,12 @@ where N: Scalar + Zero + ClosedAdd + ClosedMul
                 (nrows2, ncols3),
                 "gemm: dimensions mismatch for addition."
             );
+
+
+            if a.ncols() == 0 {
+                self.fill(N::zero());
+                return;
+            }
 
             // We assume large matrices will be Dynamic but small matrices static.
             // We could use matrixmultiply for large statically-sized matrices but the performance

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -918,7 +918,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// # use nalgebra::Vector3;
     /// assert_eq!(Vector3::new(-1.0, 2.0, 3.0).max(), 3.0);
     /// assert_eq!(Vector3::new(-1.0, -2.0, -3.0).max(), -1.0);
-    /// assert_eq!(Vector3::<u32>::new(5, 2, 3).max(), 5);
+    /// assert_eq!(Vector3::new(5u32, 2, 3).max(), 5);
     /// ```
     #[inline]
     pub fn max(&self) -> N
@@ -960,7 +960,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// # use nalgebra::Vector3;
     /// assert_eq!(Vector3::new(-1.0, 2.0, 3.0).min(), -1.0);
     /// assert_eq!(Vector3::new(1.0, 2.0, 3.0).min(), 1.0);
-    /// assert_eq!(Vector3::<u32>::new(5, 2, 3).min(), 2);
+    /// assert_eq!(Vector3::new(5u32, 2, 3).min(), 2);
     /// ```
     #[inline]
     pub fn min(&self) -> N

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -918,10 +918,11 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// # use nalgebra::Vector3;
     /// assert_eq!(Vector3::new(-1.0, 2.0, 3.0).max(), 3.0);
     /// assert_eq!(Vector3::new(-1.0, -2.0, -3.0).max(), -1.0);
+    /// assert_eq!(Vector3::<u32>::new(5, 2, 3).max(), 5);
     /// ```
     #[inline]
     pub fn max(&self) -> N
-        where N: PartialOrd + Signed {
+        where N: PartialOrd + Zero {
         self.xcmp(|e| e, Ordering::Greater)
     }
 
@@ -959,10 +960,11 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     /// # use nalgebra::Vector3;
     /// assert_eq!(Vector3::new(-1.0, 2.0, 3.0).min(), -1.0);
     /// assert_eq!(Vector3::new(1.0, 2.0, 3.0).min(), 1.0);
+    /// assert_eq!(Vector3::<u32>::new(5, 2, 3).min(), 2);
     /// ```
     #[inline]
     pub fn min(&self) -> N
-        where N: PartialOrd + Signed {
+        where N: PartialOrd + Zero {
         self.xcmp(|e| e, Ordering::Less)
     }
 }

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -15,6 +15,7 @@ mod qr;
 mod schur;
 mod solve;
 mod svd;
+mod polar;
 mod symmetric_eigen;
 mod symmetric_tridiagonal;
 mod convolution;

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -32,6 +32,7 @@ pub use self::permutation_sequence::*;
 pub use self::qr::*;
 pub use self::schur::*;
 pub use self::svd::*;
+pub use self::polar::*;
 pub use self::symmetric_eigen::*;
 pub use self::symmetric_tridiagonal::*;
 pub use self::convolution::*;

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -15,6 +15,7 @@ mod qr;
 mod schur;
 mod solve;
 mod svd;
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod polar;
 mod symmetric_eigen;
 mod symmetric_tridiagonal;
@@ -33,6 +34,7 @@ pub use self::permutation_sequence::*;
 pub use self::qr::*;
 pub use self::schur::*;
 pub use self::svd::*;
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::polar::*;
 pub use self::symmetric_eigen::*;
 pub use self::symmetric_tridiagonal::*;

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -8,6 +8,23 @@ use crate::linalg::SVD;
 use alga::general::{ComplexField};
 
 /// Polar Decomposition of a general matrix.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde-serialize",
+    serde(bound(
+            serialize = "MatrixD<N>: Serialize,
+                        MatrixD<N>: Serialize,
+                        MatrixD<N>: Serialize"
+    ))
+)]
+#[cfg_attr(
+    feature = "serde-serialize",
+    serde(bound(
+            deserialize = "MatrixD<N>: Serialize,
+                        MatrixD<N>: Serialize,
+                        MatrixD<N>: Serialize"
+    ))
+)]
 #[derive(Clone, Debug)]
 pub struct Polar<N: ComplexField>
 {

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -12,17 +12,17 @@ use alga::general::{ComplexField};
 #[cfg_attr(
     feature = "serde-serialize",
     serde(bound(
-            serialize = "MatrixD<N>: Serialize,
-                        MatrixD<N>: Serialize,
-                        MatrixD<N>: Serialize"
+            serialize = "DMatrix<N>: Serialize,
+                        DMatrix<N>: Serialize,
+                        DMatrix<N>: Serialize"
     ))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
     serde(bound(
-            deserialize = "MatrixD<N>: Serialize,
-                        MatrixD<N>: Serialize,
-                        MatrixD<N>: Serialize"
+            deserialize = "DMatrix<N>: Serialize,
+                        DMatrix<N>: Serialize,
+                        DMatrix<N>: Serialize"
     ))
 )]
 #[derive(Clone, Debug)]
@@ -96,6 +96,38 @@ where
             })
         } else {
             None
+        }
+    }
+
+    /// Rebuild the original matrix usign the left decompositon (A=PR)
+    ///
+    /// This is useful if some of the values have been manually modified.
+    /// Returns `Err` if the right- and left- singular vectors have not been
+    /// computed at construction-time.
+    pub fn recompose_left(self) -> Result<DMatrix<N>, &'static str> {
+        match (&self.r, &self.p_l) {
+            (Some(r), Some(p_l)) => {
+                Ok(p_l*r)
+            }
+            (None, None) => Err("Polar recomposition: P and R have not been computed."),
+            (None, _) => Err("Polar recomposition: P has not been computed."),
+            (_, None) => Err("Polar recomposition: R has not been computed."),
+        }
+    }
+
+    /// Rebuild the original matrix usign the right decompositon (A=RP)
+    ///
+    /// This is useful if some of the values have been manually modified.
+    /// Returns `Err` if the right- and left- singular vectors have not been
+    /// computed at construction-time.
+    pub fn recompose_right(self) -> Result<DMatrix<N>, &'static str> {
+        match (&self.r, &self.p_r) {
+            (Some(r), Some(p_r)) => {
+                Ok(r*p_r)
+            }
+            (None, None) => Err("Polar recomposition: P and R have not been computed."),
+            (None, _) => Err("Polar recomposition: P has not been computed."),
+            (_, None) => Err("Polar recomposition: R has not been computed."),
         }
     }
 }

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -84,7 +84,7 @@ where
 
             let p_l =
                 if let Some(u) = svd.u {
-                    Some(u.adjoint()*&sigma*u)
+                    Some(&u*&sigma*u.adjoint())
                 } else {
                     None
                 };

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -20,9 +20,9 @@ use alga::general::{ComplexField};
 #[cfg_attr(
     feature = "serde-serialize",
     serde(bound(
-            deserialize = "DMatrix<N>: Serialize,
-                        DMatrix<N>: Serialize,
-                        DMatrix<N>: Serialize"
+            deserialize = "DMatrix<N>: Deserialize<'de>,
+                        DMatrix<N>: Deserialize<'de>,
+                        DMatrix<N>: Deserialize<'de>"
     ))
 )]
 #[derive(Clone, Debug)]

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -7,8 +7,6 @@ use crate::{DMatrix};
 use crate::linalg::SVD;
 use alga::general::{ComplexField};
 
-use std::marker::PhantomData;
-
 /// Polar Decomposition of a general matrix.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -8,7 +8,7 @@ use crate::linalg::SVD;
 use alga::general::{ComplexField};
 
 /// Polar Decomposition of a general matrix.
-// #[derive(Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Polar<N: ComplexField>
 {
     /// The rotation matrix
@@ -18,18 +18,6 @@ pub struct Polar<N: ComplexField>
     /// The right hermitian matrix (A = RP)
     pub p_r: Option<DMatrix<N>>
 }
-
-// impl<N: ComplexField, R: DimMin<C>, C: DimName> Copy for Polar<N, R, C>
-// where
-//     DefaultAllocator: Allocator<N, R, C>
-//     + Allocator<N, R, R>
-//     + Allocator<N, C, C>,
-
-//     DMatrix<N, R, C>: Copy,
-//     DMatrix<N, R, R>: Copy,
-//     DMatrix<N, C, C>: Copy,
-// {
-// }
 
 impl<N: ComplexField> Polar<N>
 where
@@ -95,30 +83,27 @@ where
     }
 }
 
-//impl<N: ComplexField, R: DimMin<C>, C: DimName, S: Storage<N, R, C>> Matrix<N, R, C, S>
-//where
-//    DefaultAllocator: Allocator<N, R, C>
-//        + Allocator<N, R, R>
-//        + Allocator<N, C, C>,
-//{
-//    /// Computes the Polar Decomposition of the matrix using its SVD
-//    pub fn polar(self) -> Polar<N, R, C> {
-//        Polar::new(self.into_owned())
-//    }
+impl<N: ComplexField> DMatrix<N>
+where
+{
+    /// Computes the Polar Decomposition of the matrix using its SVD
+    pub fn polar(self) -> Polar<N> {
+        Polar::new(self.into_owned())
+    }
 
-//    /// Attempts to compute the Polar Decomposition using the SVD of the matrix
-//    ///
-//    /// # Arguments
-//    ///
-//    /// * `eps`       − tolerance used to determine when a value converged to 0.
-//    /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-//    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-//    /// continues indefinitely until convergence.
-//    pub fn try_polar(
-//        self,
-//        eps: N::RealField,
-//        max_niter: usize,
-//    ) -> Option<Polar<N, R, C>> {
-//        Polar::try_new(self.into_owned(), eps, max_niter)
-//    }
-//}
+    /// Attempts to compute the Polar Decomposition using the SVD of the matrix
+    ///
+    /// # Arguments
+    ///
+    /// * `eps`       − tolerance used to determine when a value converged to 0.
+    /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
+    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    /// continues indefinitely until convergence.
+    pub fn try_polar(
+        self,
+        eps: N::RealField,
+        max_niter: usize,
+    ) -> Option<Polar<N>> {
+        Polar::try_new(self.into_owned(), eps, max_niter)
+    }
+}

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use approx::AbsDiffEq;
 
-use crate::allocator::Allocator;
-use crate::base::{DefaultAllocator};
 use crate::{DMatrix};
-use crate::dimension::{DimName, DimMin, DimMinimum, NamedDim};
 use crate::linalg::SVD;
 use alga::general::{ComplexField};
 
@@ -55,7 +52,7 @@ where
     /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
     /// continues indefinitely until convergence.
     pub fn try_new(
-        mut matrix: DMatrix<N>,
+        matrix: DMatrix<N>,
         eps: N::RealField,
         max_niter: usize
     ) -> Option<Self> {

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -1,0 +1,125 @@
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
+use approx::AbsDiffEq;
+
+use crate::allocator::Allocator;
+use crate::base::{DefaultAllocator};
+use crate::{DMatrix};
+use crate::dimension::{DimName, DimMin, DimMinimum, NamedDim};
+use crate::linalg::SVD;
+use alga::general::{ComplexField};
+
+/// Polar Decomposition of a general matrix.
+// #[derive(Clone, Debug)]
+pub struct Polar<N: ComplexField>
+{
+    /// The rotation matrix
+    pub r: Option<DMatrix<N>>,
+    /// The left hermitian matrix (A = PR)
+    pub p_l: Option<DMatrix<N>>,
+    /// The right hermitian matrix (A = RP)
+    pub p_r: Option<DMatrix<N>>
+}
+
+// impl<N: ComplexField, R: DimMin<C>, C: DimName> Copy for Polar<N, R, C>
+// where
+//     DefaultAllocator: Allocator<N, R, C>
+//     + Allocator<N, R, R>
+//     + Allocator<N, C, C>,
+
+//     DMatrix<N, R, C>: Copy,
+//     DMatrix<N, R, R>: Copy,
+//     DMatrix<N, C, C>: Copy,
+// {
+// }
+
+impl<N: ComplexField> Polar<N>
+where
+{
+    /// Computes the Polar Decomposition of the matrix using its SVD
+    pub fn new(matrix: DMatrix<N>) -> Self {
+        Self::try_new(
+            matrix,
+            N::RealField::default_epsilon(),
+            0
+        ).unwrap()
+    }
+
+    /// Attempts to compute the Polar Decomposition using the SVD of the matrix
+    ///
+    /// # Arguments
+    ///
+    /// * `eps`           − tolerance used to determine when a value converged to 0.
+    /// * `max_niter`     − maximum total number of iterations performed by the algorithm. If this
+    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    /// continues indefinitely until convergence.
+    pub fn try_new(
+        mut matrix: DMatrix<N>,
+        eps: N::RealField,
+        max_niter: usize
+    ) -> Option<Self> {
+
+        let svd_opt = SVD::try_new(matrix, true, true, eps, max_niter);
+
+        if let Some(svd) = svd_opt {
+
+            let r: Option<DMatrix<N>> =
+                if let (Some(u), Some(v_t)) = (svd.u, svd.v_t) {
+                    Some(u*v_t)
+                } else {
+                    None
+                };
+
+            let p_r =
+                if let Some(v_t) = svd.v_t {
+                    Some(v_t.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*v_t)
+                } else {
+                    None
+                };
+
+            let p_l =
+                if let Some(u) = svd.u{
+                    Some(u.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*u)
+                } else {
+                    None
+                };
+
+            Some(Self {
+                r,
+                p_l,
+                p_r,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+//impl<N: ComplexField, R: DimMin<C>, C: DimName, S: Storage<N, R, C>> Matrix<N, R, C, S>
+//where
+//    DefaultAllocator: Allocator<N, R, C>
+//        + Allocator<N, R, R>
+//        + Allocator<N, C, C>,
+//{
+//    /// Computes the Polar Decomposition of the matrix using its SVD
+//    pub fn polar(self) -> Polar<N, R, C> {
+//        Polar::new(self.into_owned())
+//    }
+
+//    /// Attempts to compute the Polar Decomposition using the SVD of the matrix
+//    ///
+//    /// # Arguments
+//    ///
+//    /// * `eps`       − tolerance used to determine when a value converged to 0.
+//    /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
+//    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+//    /// continues indefinitely until convergence.
+//    pub fn try_polar(
+//        self,
+//        eps: N::RealField,
+//        max_niter: usize,
+//    ) -> Option<Polar<N, R, C>> {
+//        Polar::try_new(self.into_owned(), eps, max_niter)
+//    }
+//}

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -7,6 +7,8 @@ use crate::{DMatrix};
 use crate::linalg::SVD;
 use alga::general::{ComplexField};
 
+use std::marker::PhantomData;
+
 /// Polar Decomposition of a general matrix.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -65,22 +65,24 @@ where
         if let Some(svd) = svd_opt {
 
             let r: Option<DMatrix<N>> =
-                if let (Some(u), Some(v_t)) = (svd.u, svd.v_t) {
+                if let (Some(u), Some(v_t)) = (&svd.u, &svd.v_t) {
                     Some(u*v_t)
                 } else {
                     None
                 };
 
+            let sigma: DMatrix<N> = DMatrix::from_diagonal(&svd.singular_values.map(|e| N::from_real(e)));;
+
             let p_r =
-                if let Some(v_t) = svd.v_t {
-                    Some(v_t.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*v_t)
+                if let Some(v_t)  = &svd.v_t {
+                    Some(v_t.adjoint()*&sigma*v_t)
                 } else {
                     None
                 };
 
             let p_l =
-                if let Some(u) = svd.u{
-                    Some(u.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*u)
+                if let Some(u) = svd.u {
+                    Some(u.adjoint()*&sigma*u)
                 } else {
                     None
                 };

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -113,6 +113,38 @@ where
             (_, None) => Err("Polar recomposition: R has not been computed."),
         }
     }
+
+    /// Rebuild the original matrix usign the left decompositon (A=PR)
+    ///
+    /// This is useful if some of the values have been manually modified.
+    /// Returns `Err` if the right- and left- singular vectors have not been
+    /// computed at construction-time.
+    pub fn recompose_left(self) -> Result<DMatrix<N>, &'static str> {
+        match (&self.r, &self.p_l) {
+            (Some(r), Some(p_l)) => {
+                Ok(p_l*r)
+            }
+            (None, None) => Err("Polar recomposition: P and R have not been computed."),
+            (None, _) => Err("Polar recomposition: P has not been computed."),
+            (_, None) => Err("Polar recomposition: R has not been computed."),
+        }
+    }
+
+    /// Rebuild the original matrix usign the right decompositon (A=RP)
+    ///
+    /// This is useful if some of the values have been manually modified.
+    /// Returns `Err` if the right- and left- singular vectors have not been
+    /// computed at construction-time.
+    pub fn recompose_right(self) -> Result<DMatrix<N>, &'static str> {
+        match (&self.r, &self.p_r) {
+            (Some(r), Some(p_r)) => {
+                Ok(r*p_r)
+            }
+            (None, None) => Err("Polar recomposition: P and R have not been computed."),
+            (None, _) => Err("Polar recomposition: P has not been computed."),
+            (_, None) => Err("Polar recomposition: R has not been computed."),
+        }
+    }
 }
 
 impl<N: ComplexField> DMatrix<N>

--- a/src/linalg/polar.rs
+++ b/src/linalg/polar.rs
@@ -72,7 +72,7 @@ where
             };
 
         let sigma: DMatrix<N> = DMatrix::from_diagonal(&svd.singular_values.map(|e| N::from_real(e)));;
-        let p_r = svd.u.as_ref().map(|v_t| v_t.adjoint() * &sigma * v_t);
+        let p_r = svd.v_t.as_ref().map(|v_t| v_t.adjoint() * &sigma * v_t);
         let p_l = svd.u.as_ref().map(|u| u * &sigma * u.adjoint());
 
         Some(Self {
@@ -90,7 +90,7 @@ where
     pub fn recompose_left(self) -> Result<DMatrix<N>, &'static str> {
         match (&self.r, &self.p_l) {
             (Some(r), Some(p_l)) => {
-                Ok(p_l*r)
+                Ok(p_l * r)
             }
             (None, None) => Err("Polar recomposition: P and R have not been computed."),
             (None, _) => Err("Polar recomposition: P has not been computed."),
@@ -106,7 +106,7 @@ where
     pub fn recompose_right(self) -> Result<DMatrix<N>, &'static str> {
         match (&self.r, &self.p_r) {
             (Some(r), Some(p_r)) => {
-                Ok(r*p_r)
+                Ok(r * p_r)
             }
             (None, None) => Err("Polar recomposition: P and R have not been computed."),
             (None, _) => Err("Polar recomposition: P has not been computed."),

--- a/tests/core/empty.rs
+++ b/tests/core/empty.rs
@@ -1,9 +1,30 @@
 use na::{DMatrix, DVector};
 
 #[test]
-fn empty_mul() {
+fn empty_matrix_mul_vector() {
     // Issue #644
     let m = DMatrix::<f32>::zeros(8, 0);
     let v = DVector::<f32>::zeros(0);
     assert_eq!(m * v, DVector::zeros(8));
+}
+
+#[test]
+fn empty_matrix_mul_matrix() {
+    let m1 = DMatrix::<f32>::zeros(3, 0);
+    let m2 = DMatrix::<f32>::zeros(0, 4);
+    assert_eq!(m1 * m2, DMatrix::zeros(3, 4));
+}
+
+#[test]
+fn empty_matrix_tr_mul_vector() {
+    let m = DMatrix::<f32>::zeros(0, 5);
+    let v = DVector::<f32>::zeros(0);
+    assert_eq!(m.tr_mul(&v), DVector::zeros(5));
+}
+
+#[test]
+fn empty_matrix_tr_mul_matrix() {
+    let m1 = DMatrix::<f32>::zeros(0, 3);
+    let m2 = DMatrix::<f32>::zeros(0, 4);
+    assert_eq!(m1.tr_mul(&m2), DMatrix::zeros(3, 4));
 }

--- a/tests/core/empty.rs
+++ b/tests/core/empty.rs
@@ -1,0 +1,9 @@
+use na::{DMatrix, DVector};
+
+#[test]
+fn empty_mul() {
+    // Issue #644
+    let m = DMatrix::<f32>::zeros(8, 0);
+    let v = DVector::<f32>::zeros(0);
+    assert_eq!(m * v, DVector::zeros(8));
+}

--- a/tests/core/empty.rs
+++ b/tests/core/empty.rs
@@ -13,6 +13,11 @@ fn empty_matrix_mul_matrix() {
     let m1 = DMatrix::<f32>::zeros(3, 0);
     let m2 = DMatrix::<f32>::zeros(0, 4);
     assert_eq!(m1 * m2, DMatrix::zeros(3, 4));
+
+    // Still works with larger matrices.
+    let m1 = DMatrix::<f32>::zeros(13, 0);
+    let m2 = DMatrix::<f32>::zeros(0, 14);
+    assert_eq!(m1 * m2, DMatrix::zeros(13, 14));
 }
 
 #[test]
@@ -27,4 +32,29 @@ fn empty_matrix_tr_mul_matrix() {
     let m1 = DMatrix::<f32>::zeros(0, 3);
     let m2 = DMatrix::<f32>::zeros(0, 4);
     assert_eq!(m1.tr_mul(&m2), DMatrix::zeros(3, 4));
+}
+
+#[test]
+fn empty_matrix_gemm() {
+    let mut res = DMatrix::repeat(3, 4, 1.0);
+    let m1 = DMatrix::<f32>::zeros(3, 0);
+    let m2 = DMatrix::<f32>::zeros(0, 4);
+    res.gemm(1.0, &m1, &m2, 0.5);
+    assert_eq!(res, DMatrix::repeat(3, 4, 0.5));
+
+    // Still works with lager matrices.
+    let mut res = DMatrix::repeat(13, 14, 1.0);
+    let m1 = DMatrix::<f32>::zeros(13, 0);
+    let m2 = DMatrix::<f32>::zeros(0, 14);
+    res.gemm(1.0, &m1, &m2, 0.5);
+    assert_eq!(res, DMatrix::repeat(13, 14, 0.5));
+}
+
+#[test]
+fn empty_matrix_gemm_tr() {
+    let mut res = DMatrix::repeat(3, 4, 1.0);
+    let m1 = DMatrix::<f32>::zeros(0, 3);
+    let m2 = DMatrix::<f32>::zeros(0, 4);
+    res.gemm_tr(1.0, &m1, &m2, 0.5);
+    assert_eq!(res, DMatrix::repeat(3, 4, 0.5));
 }

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -8,6 +8,7 @@ mod matrix_slice;
 #[cfg(feature = "mint")]
 mod mint;
 mod serde;
+mod empty;
 
 
 #[cfg(feature = "arbitrary")]

--- a/tests/linalg/mod.rs
+++ b/tests/linalg/mod.rs
@@ -12,4 +12,5 @@ mod solve;
 mod svd;
 mod tridiagonal;
 mod convolution;
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod polar;

--- a/tests/linalg/mod.rs
+++ b/tests/linalg/mod.rs
@@ -12,3 +12,4 @@ mod solve;
 mod svd;
 mod tridiagonal;
 mod convolution;
+mod polar;

--- a/tests/linalg/polar.rs
+++ b/tests/linalg/polar.rs
@@ -1,0 +1,40 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+#[cfg(test)]
+#[cfg(feature = "arbitrary")]
+mod quickcheck_tests {
+    macro_rules! gen_tests(
+        ($module: ident, $scalar: ty) => {
+            mod $module {
+                use na::{
+                    DMatrix, DVector, ComplexField
+                };
+                use std::cmp;
+                #[allow(unused_imports)]
+                use crate::core::helper::{RandScalar, RandComplex};
+
+                quickcheck! {
+                    fn polar(m: DMatrix<$scalar>) -> bool {
+                        let m = m.map(|e| e.0);
+                        if m.len() > 0 {
+                            let polar = m.clone().polar();
+                            let recomp_m_l = polar.clone().recompose_left().unwrap();
+                            let recomp_m_r = polar.clone().recompose_right().unwrap();
+
+                            relative_eq!(m, recomp_m_l, epsilon = 1.0e-5) &&
+                            relative_eq!(m, recomp_m_r, epsilon = 1.0e-5) &&
+                            false
+                        }
+                        else {
+                            true && false
+                        }
+                    }
+
+                }
+            }
+        }
+    );
+
+    gen_tests!(complex, RandComplex<f64>);
+    gen_tests!(f64, RandScalar<f64>);
+}

--- a/tests/linalg/polar.rs
+++ b/tests/linalg/polar.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-#[cfg(test)]
 #[cfg(feature = "arbitrary")]
 mod quickcheck_tests {
     macro_rules! gen_tests(
@@ -14,7 +13,7 @@ mod quickcheck_tests {
                 use crate::core::helper::{RandScalar, RandComplex};
 
                 quickcheck! {
-                    fn polar(m: DMatrix<$scalar>) -> bool {
+                    fn polar_recompose(m: DMatrix<$scalar>) -> bool {
                         let m = m.map(|e| e.0);
                         if m.len() > 0 {
                             let polar = m.clone().polar();
@@ -22,14 +21,12 @@ mod quickcheck_tests {
                             let recomp_m_r = polar.clone().recompose_right().unwrap();
 
                             relative_eq!(m, recomp_m_l, epsilon = 1.0e-5) &&
-                            relative_eq!(m, recomp_m_r, epsilon = 1.0e-5) &&
-                            false
+                            relative_eq!(m, recomp_m_r, epsilon = 1.0e-5) 
                         }
                         else {
-                            true && false
+                            true 
                         }
                     }
-
                 }
             }
         }

--- a/tests/linalg/polar.rs
+++ b/tests/linalg/polar.rs
@@ -20,8 +20,27 @@ mod quickcheck_tests {
                             let recomp_m_l = polar.clone().recompose_left().unwrap();
                             let recomp_m_r = polar.clone().recompose_right().unwrap();
 
+                            println!("Hello");
+                            println!("Size of R: {:?}", polar.clone().r.unwrap().shape());
+                            println!("Size of p_R: {:?}", polar.clone().p_r.unwrap().shape());
+                            println!("Size of p_L: {:?}", polar.clone().p_l.unwrap().shape());
+
                             relative_eq!(m, recomp_m_l, epsilon = 1.0e-5) &&
                             relative_eq!(m, recomp_m_r, epsilon = 1.0e-5) 
+                        }
+                        else {
+                            true 
+                        }
+                    }
+
+                    fn polar_properties(m: DMatrix<$scalar>) -> bool {
+                        let m = m.map(|e| e.0);
+                        if m.len() > 0 {
+                            let polar = m.clone().polar();
+                            let p_r= polar.p_r.unwrap();
+                            let p_l= polar.p_l.unwrap();
+
+                            p_r.is_square() && p_l.is_square()
                         }
                         else {
                             true 


### PR DESCRIPTION
Hello. As detailed in [this thread](https://discourse.nphysics.org/t/matrix-polar-decomposition/409) in the user forum, I am implementing the [matricial polar decomposition](https://en.wikipedia.org/wiki/Polar_decomposition) in nalgebra.

The bulk of the code is ready. However, I am having some issues with the traits needed to properly compile the code. 

Cleanup and further implementations are still in the 'to do' list.

Any pointers on the specific type traits needed would be appreciated.

The compile errors are

```
error[E0277]: cannot multiply `base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>` to `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>`
  --> src/linalg/polar.rs:76:39
   |
76 |                     Some(v_t.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*v_t)
   |                                       ^ no implementation for `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>> * base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>`
   |
   = help: the trait `std::ops::Mul<base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>>` is not implemented for `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>`
   = help: consider adding a `where base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>: std::ops::Mul<base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>>` bound

error[E0277]: cannot multiply `base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>` to `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>`
  --> src/linalg/polar.rs:83:37
   |
83 |                     Some(u.adjoint()*DMatrix::from_diagonal(&svd.singular_values)*u)
   |                                     ^ no implementation for `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>> * base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>`
   |
   = help: the trait `std::ops::Mul<base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>>` is not implemented for `base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>`
   = help: consider adding a `where base::matrix::Matrix<N, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<N, base::dimension::Dynamic, base::dimension::Dynamic>>: std::ops::Mul<base::matrix::Matrix<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic, base::vec_storage::VecStorage<<N as alga::general::ComplexField>::RealField, base::dimension::Dynamic, base::dimension::Dynamic>>>` bound

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `nalgebra`.


To learn more, run the command again with --verbose.
```


