### PR TITLE
Update version in docs header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ Simply add the following to your `Cargo.toml` file:
 
 ```.ignore
 [dependencies]
-nalgebra = "0.18"
+nalgebra = "0.21"
 ```
 
 


### PR DESCRIPTION
Looks like the docs are pointing to an outdated version, this is a fix for that