### PR TITLE
Add methods for in-place reshaping of matrices

### DIFF
--- a/examples/matrix_construction.rs
+++ b/examples/matrix_construction.rs
@@ -1,6 +1,6 @@
 extern crate nalgebra as na;
 
-use na::{DMatrix, Matrix2x3, RowVector3, Vector2};
+use na::{DMatrix, Matrix2x3, Matrix3x2, RowVector3, Vector2};
 
 fn main() {
     // All the following matrices are equal but constructed in different ways.

--- a/examples/reshaping.rs
+++ b/examples/reshaping.rs
@@ -1,0 +1,33 @@
+extern crate nalgebra as na;
+
+use na::{DMatrix, Dynamic, Matrix2x3, Matrix3x2, U2, U3};
+
+fn main() {
+    // Matrices can be reshaped in-place without moving or copying values.
+    let m1 = Matrix2x3::new(1.1, 1.2, 1.3, 2.1, 2.2, 2.3);
+    let m2 = Matrix3x2::new(1.1, 2.2, 2.1, 1.3, 1.2, 2.3);
+
+    let m3 = m1.reshape_generic(U3, U2);
+    assert_eq!(m3, m2);
+
+    // Note that, for statically sized matrices, invalid reshapes will not compile:
+    //let m4 = m3.reshape_generic(U3, U3);
+
+    // If dynamically sized matrices are used, the reshaping is checked at run-time.
+    let dm1 = DMatrix::from_vec(
+        4,
+        3,
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    );
+    let dm2 = DMatrix::from_vec(
+        6,
+        2,
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    );
+
+    let dm3 = dm1.reshape_generic(Dynamic::new(6), Dynamic::new(2));
+    assert_eq!(dm3, dm2);
+
+    // Invalid reshapings of dynamic matrices will panic at run-time.
+    //let dm4 = dm3.reshape_generic(Dynamic::new(6), Dynamic::new(6));
+}

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -24,7 +24,9 @@ use typenum::Prod;
 use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
 use crate::base::dimension::{DimName, U1};
-use crate::base::storage::{ContiguousStorage, ContiguousStorageMut, Owned, Storage, StorageMut};
+use crate::base::storage::{
+    ContiguousStorage, ContiguousStorageMut, Owned, ReshapableStorage, Storage, StorageMut,
+};
 use crate::base::Scalar;
 
 /*
@@ -265,6 +267,25 @@ where
     Prod<R::Value, C::Value>: ArrayLength<N>,
     DefaultAllocator: Allocator<N, R, C, Buffer = Self>,
 {
+}
+
+impl<N, R1, C1, R2, C2> ReshapableStorage<N, R1, C1, R2, C2> for ArrayStorage<N, R1, C1>
+where
+    N: Scalar,
+    R1: DimName,
+    C1: DimName,
+    R1::Value: Mul<C1::Value>,
+    Prod<R1::Value, C1::Value>: ArrayLength<N>,
+    R2: DimName,
+    C2: DimName,
+    R2::Value: Mul<C2::Value, Output = Prod<R1::Value, C1::Value>>,
+    Prod<R2::Value, C2::Value>: ArrayLength<N>,
+{
+    type Output = ArrayStorage<N, R2, C2>;
+
+    fn reshape_generic(self, _: R2, _: C2) -> Self::Output {
+        ArrayStorage { data: self.data }
+    }
 }
 
 /*

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -171,7 +171,7 @@ pub unsafe trait StorageMut<N: Scalar, R: Dim, C: Dim = U1>: Storage<N, R, C> {
 
 /// A matrix storage that is stored contiguously in memory.
 ///
-/// The storage requirement means that for any value of `i` in `[0, nrows * ncols[`, the value
+/// The storage requirement means that for any value of `i` in `[0, nrows * ncols]`, the value
 /// `.get_unchecked_linear` returns one of the matrix component. This trait is unsafe because
 /// failing to comply to this may cause Undefined Behaviors.
 pub unsafe trait ContiguousStorage<N: Scalar, R: Dim, C: Dim = U1>:
@@ -181,10 +181,26 @@ pub unsafe trait ContiguousStorage<N: Scalar, R: Dim, C: Dim = U1>:
 
 /// A mutable matrix storage that is stored contiguously in memory.
 ///
-/// The storage requirement means that for any value of `i` in `[0, nrows * ncols[`, the value
+/// The storage requirement means that for any value of `i` in `[0, nrows * ncols]`, the value
 /// `.get_unchecked_linear` returns one of the matrix component. This trait is unsafe because
 /// failing to comply to this may cause Undefined Behaviors.
 pub unsafe trait ContiguousStorageMut<N: Scalar, R: Dim, C: Dim = U1>:
     ContiguousStorage<N, R, C> + StorageMut<N, R, C>
 {
+}
+
+/// A matrix storage that can be reshaped in-place.
+pub trait ReshapableStorage<N, R1, C1, R2, C2>: Storage<N, R1, C1>
+where
+    N: Scalar,
+    R1: Dim,
+    C1: Dim,
+    R2: Dim,
+    C2: Dim,
+{
+    /// The reshaped storage type.
+    type Output: Storage<N, R2, C2>;
+
+    /// Reshapes the storage into the output storage type.
+    fn reshape_generic(self, nrows: R2, ncols: C2) -> Self::Output;
 }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -8,7 +8,9 @@ use crate::base::allocator::Allocator;
 use crate::base::constraint::{SameNumberOfRows, ShapeConstraint};
 use crate::base::default_allocator::DefaultAllocator;
 use crate::base::dimension::{Dim, DimName, Dynamic, U1};
-use crate::base::storage::{ContiguousStorage, ContiguousStorageMut, Owned, Storage, StorageMut};
+use crate::base::storage::{
+    ContiguousStorage, ContiguousStorageMut, Owned, ReshapableStorage, Storage, StorageMut,
+};
 use crate::base::{Scalar, Vector};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -229,6 +231,42 @@ unsafe impl<N: Scalar, C: Dim> ContiguousStorageMut<N, Dynamic, C> for VecStorag
 {
 }
 
+impl<N, C1, C2> ReshapableStorage<N, Dynamic, C1, Dynamic, C2> for VecStorage<N, Dynamic, C1>
+where
+    N: Scalar,
+    C1: Dim,
+    C2: Dim,
+{
+    type Output = VecStorage<N, Dynamic, C2>;
+
+    fn reshape_generic(self, nrows: Dynamic, ncols: C2) -> Self::Output {
+        assert_eq!(nrows.value() * ncols.value(), self.data.len());
+        VecStorage {
+            data: self.data,
+            nrows,
+            ncols,
+        }
+    }
+}
+
+impl<N, C1, R2> ReshapableStorage<N, Dynamic, C1, R2, Dynamic> for VecStorage<N, Dynamic, C1>
+where
+    N: Scalar,
+    C1: Dim,
+    R2: DimName,
+{
+    type Output = VecStorage<N, R2, Dynamic>;
+
+    fn reshape_generic(self, nrows: R2, ncols: Dynamic) -> Self::Output {
+        assert_eq!(nrows.value() * ncols.value(), self.data.len());
+        VecStorage {
+            data: self.data,
+            nrows,
+            ncols,
+        }
+    }
+}
+
 unsafe impl<N: Scalar, R: DimName> StorageMut<N, R, Dynamic> for VecStorage<N, R, Dynamic>
 where
     DefaultAllocator: Allocator<N, R, Dynamic, Buffer = Self>,
@@ -241,6 +279,42 @@ where
     #[inline]
     fn as_mut_slice(&mut self) -> &mut [N] {
         &mut self.data[..]
+    }
+}
+
+impl<N, R1, C2> ReshapableStorage<N, R1, Dynamic, Dynamic, C2> for VecStorage<N, R1, Dynamic>
+where
+    N: Scalar,
+    R1: DimName,
+    C2: Dim,
+{
+    type Output = VecStorage<N, Dynamic, C2>;
+
+    fn reshape_generic(self, nrows: Dynamic, ncols: C2) -> Self::Output {
+        assert_eq!(nrows.value() * ncols.value(), self.data.len());
+        VecStorage {
+            data: self.data,
+            nrows,
+            ncols,
+        }
+    }
+}
+
+impl<N, R1, R2> ReshapableStorage<N, R1, Dynamic, R2, Dynamic> for VecStorage<N, R1, Dynamic>
+where
+    N: Scalar,
+    R1: DimName,
+    R2: DimName,
+{
+    type Output = VecStorage<N, R2, Dynamic>;
+
+    fn reshape_generic(self, nrows: R2, ncols: Dynamic) -> Self::Output {
+        assert_eq!(nrows.value() * ncols.value(), self.data.len());
+        VecStorage {
+            data: self.data,
+            nrows,
+            ncols,
+        }
     }
 }
 


### PR DESCRIPTION
Based on the conversation on Discord, this allows for the reshaping of matrices in a way that guarantees that the elements won't be moved or copied.

Additionally, there are a few fixes for typos that I noticed while working on this.