### PR TITLE
Update to the latest simba version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,10 @@ jobs:
       - checkout
       - run:
           name: test
-          command: cargo test --all-features
+          command: cargo test --features arbitrary --features serde-serialize --features abomonation-serialize --features sparse --features debug --features io --features compare --features libm
       - run:
           name: test nalgebra-glm
-          command: cargo test -p nalgebra-glm --all-features
+          command: cargo test -p nalgebra-glm  --features arbitrary --features serde-serialize --features abomonation-serialize --features sparse --features debug --features io --features compare --features libm
   build-wasm:
     executor: rust-executor
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default         = [ "std" ]
 std             = [ "matrixmultiply", "rand/std", "rand_distr", "simba/std" ]
 stdweb          = [ "rand/stdweb" ]
 arbitrary       = [ "quickcheck" ]
-serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
+serde-serialize = [ "serde", "num-complex/serde" ]
 abomonation-serialize = [ "abomonation" ]
 sparse = [ ]
 debug = [ "approx/num-complex", "rand/std" ]
@@ -44,8 +44,7 @@ simba          = { version = "0.1", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.2", optional = true }
 matrixmultiply = { version = "0.2", optional = true }
-serde          = { version = "1.0", optional = true }
-serde_derive   = { version = "1.0", optional = true }
+serde          = { version = "1.0", features = [ "derive" ], optional = true }
 abomonation    = { version = "0.7", optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "0.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.2", default-features = false }
 num-rational   = { version = "0.2", default-features = false }
 approx         = { version = "0.3", default-features = false }
-simba          = { version = "0.1", default-features = false }
+simba          = { version = "0.2", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.2", optional = true }
 matrixmultiply = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ debug = [ "approx/num-complex", "rand/std" ]
 alloc = [ ]
 io = [ "pest", "pest_derive" ]
 compare = [ "matrixcompare-core" ]
+libm = [ "simba/libm" ]
+libm-force = [ "simba/libm_force" ]
+
 
 [dependencies]
 typenum        = "1.11"
@@ -75,6 +78,3 @@ path = "benches/lib.rs"
 
 [profile.bench]
 lto = true
-
-#[patch.crates-io]
-#simba = { path = "../simba" }

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -24,5 +24,5 @@ abomonation-serialize = [ "nalgebra/abomonation-serialize" ]
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.3", default-features = false }
-simba = { version = "0.1", default-features = false }
+simba = { version = "0.2", default-features = false }
 nalgebra = { path =  "..", version = "0.21", default-features = false }

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -26,7 +26,7 @@ intel-mkl  = ["lapack-src/intel-mkl"]
 nalgebra      = { version = "0.21", path = ".." }
 num-traits    = "0.2"
 num-complex   = { version = "0.2", default-features = false }
-simba         = "0.1"
+simba         = "0.2"
 serde         = { version = "1.0", optional = true }
 serde_derive  = { version = "1.0", optional = true }
 lapack        = { version = "0.16", default-features = false }

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -1011,6 +1011,14 @@ where
     N: Scalar + Zero + One,
     DefaultAllocator: Allocator<N, R>,
 {
+    /// The column vector with `val` as its i-th component.
+    #[inline]
+    pub fn ith(i: usize, val: N) -> Self {
+        let mut res = Self::zeros();
+        res[i] = val;
+        res
+    }
+
     /// The column vector with a 1 as its first component, and zero elsewhere.
     #[inline]
     pub fn x() -> Self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,9 @@ pub fn zero<T: Zero>() -> T {
 /// The range must not be empty.
 #[inline]
 pub fn wrap<T>(mut val: T, min: T, max: T) -> T
-where T: Copy + PartialOrd + ClosedAdd + ClosedSub {
+where
+    T: Copy + PartialOrd + ClosedAdd + ClosedSub,
+{
     assert!(min < max, "Invalid wrapping bounds.");
     let width = max - min;
 
@@ -388,7 +390,9 @@ pub fn partial_sort2<'a, T: PartialOrd>(a: &'a T, b: &'a T) -> Option<(&'a T, &'
 /// * [distance_squared](fn.distance_squared.html)
 #[inline]
 pub fn center<N: SimdComplexField, D: DimName>(p1: &Point<N, D>, p2: &Point<N, D>) -> Point<N, D>
-where DefaultAllocator: Allocator<N, D> {
+where
+    DefaultAllocator: Allocator<N, D>,
+{
     ((&p1.coords + &p2.coords) * convert::<_, N>(0.5)).into()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,11 +90,9 @@ an optimized set of tools for computer graphics and physics. Those features incl
 #[cfg(feature = "arbitrary")]
 extern crate quickcheck;
 
-#[cfg(feature = "serde")]
-extern crate serde;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-serialize")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 #[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
@@ -190,9 +188,7 @@ pub fn zero<T: Zero>() -> T {
 /// The range must not be empty.
 #[inline]
 pub fn wrap<T>(mut val: T, min: T, max: T) -> T
-where
-    T: Copy + PartialOrd + ClosedAdd + ClosedSub,
-{
+where T: Copy + PartialOrd + ClosedAdd + ClosedSub {
     assert!(min < max, "Invalid wrapping bounds.");
     let width = max - min;
 
@@ -392,9 +388,7 @@ pub fn partial_sort2<'a, T: PartialOrd>(a: &'a T, b: &'a T) -> Option<(&'a T, &'
 /// * [distance_squared](fn.distance_squared.html)
 #[inline]
 pub fn center<N: SimdComplexField, D: DimName>(p1: &Point<N, D>, p2: &Point<N, D>) -> Point<N, D>
-where
-    DefaultAllocator: Allocator<N, D>,
-{
+where DefaultAllocator: Allocator<N, D> {
     ((&p1.coords + &p2.coords) * convert::<_, N>(0.5)).into()
 }
 

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -5,6 +5,10 @@ mod bidiagonal;
 mod cholesky;
 mod convolution;
 mod determinant;
+// FIXME: this should not be needed. However, the exp uses
+// explicit float operations on `f32` and `f64`. We need to
+// get rid of these to allow exp to be used on a no-std context.
+#[cfg(feature = "std")]
 mod exp;
 mod full_piv_lu;
 pub mod givens;
@@ -27,6 +31,7 @@ mod symmetric_tridiagonal;
 pub use self::bidiagonal::*;
 pub use self::cholesky::*;
 pub use self::convolution::*;
+#[cfg(feature = "std")]
 pub use self::exp::*;
 pub use self::full_piv_lu::*;
 pub use self::hessenberg::*;


### PR DESCRIPTION
Because simba only enables `libm` if its `libm` feature is enabled, this PR adds the `libm` and `libm-force` feature to nalgebra in order to transitively enable the corresponding features on simba.