### PR TITLE
Add UDU factorization

### DIFF
--- a/src/linalg/col_piv_qr.rs
+++ b/src/linalg/col_piv_qr.rs
@@ -66,7 +66,8 @@ where
         let min_nrows_ncols = nrows.min(ncols);
         let mut p = PermutationSequence::identity_generic(min_nrows_ncols);
 
-        let mut diag = unsafe { MatrixMN::new_uninitialized_generic(min_nrows_ncols, U1) };
+        let mut diag =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
 
         if min_nrows_ncols.value() == 0 {
             return ColPivQR {

--- a/src/linalg/decomposition.rs
+++ b/src/linalg/decomposition.rs
@@ -1,8 +1,8 @@
 use crate::storage::Storage;
 use crate::{
     Allocator, Bidiagonal, Cholesky, ColPivQR, ComplexField, DefaultAllocator, Dim, DimDiff,
-    DimMin, DimMinimum, DimSub, FullPivLU, Hessenberg, Matrix, Schur, SymmetricEigen,
-    SymmetricTridiagonal, LU, QR, SVD, U1,
+    DimMin, DimMinimum, DimSub, FullPivLU, Hessenberg, Matrix, RealField, Schur, SymmetricEigen,
+    SymmetricTridiagonal, LU, QR, SVD, U1, UDU
 };
 
 /// # Rectangular matrix decomposition
@@ -134,6 +134,7 @@ impl<N: ComplexField, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
 /// | -------------------------|---------------------------|--------------|
 /// | Hessenberg               | `Q * H * Qᵀ`             | `Q` is a unitary matrix and `H` an upper-Hessenberg matrix. |
 /// | Cholesky                 | `L * Lᵀ`                 | `L` is a lower-triangular matrix. |
+/// | UDU                      | `U * D * Uᵀ`             | `U` is a upper-triangular matrix, and `D` a diagonal matrix. |
 /// | Schur decomposition      | `Q * T * Qᵀ`             | `Q` is an unitary matrix and `T` a quasi-upper-triangular matrix. |
 /// | Symmetric eigendecomposition | `Q ~ Λ ~ Qᵀ`   | `Q` is an unitary matrix, and `Λ` is a real diagonal matrix. |
 /// | Symmetric tridiagonalization | `Q ~ T ~ Qᵀ`   | `Q` is an unitary matrix, and `T` is a tridiagonal matrix. |
@@ -147,6 +148,18 @@ impl<N: ComplexField, D: Dim, S: Storage<N, D, D>> Matrix<N, D, D, S> {
         DefaultAllocator: Allocator<N, D, D>,
     {
         Cholesky::new(self.into_owned())
+    }
+
+    /// Attempts to compute the UDU decomposition of this matrix.
+    ///
+    /// The input matrix `self` is assumed to be symmetric and this decomposition will only read
+    /// the upper-triangular part of `self`.
+    pub fn udu(self) -> UDU<N, D>
+    where
+        N: RealField,
+        DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
+    {
+        UDU::new(self.into_owned())
     }
 
     /// Computes the Hessenberg decomposition of this matrix using householder reflections.

--- a/src/linalg/decomposition.rs
+++ b/src/linalg/decomposition.rs
@@ -2,7 +2,7 @@ use crate::storage::Storage;
 use crate::{
     Allocator, Bidiagonal, Cholesky, ColPivQR, ComplexField, DefaultAllocator, Dim, DimDiff,
     DimMin, DimMinimum, DimSub, FullPivLU, Hessenberg, Matrix, RealField, Schur, SymmetricEigen,
-    SymmetricTridiagonal, LU, QR, SVD, U1, UDU
+    SymmetricTridiagonal, LU, QR, SVD, U1, UDU,
 };
 
 /// # Rectangular matrix decomposition

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -25,6 +25,7 @@ mod solve;
 mod svd;
 mod symmetric_eigen;
 mod symmetric_tridiagonal;
+mod udu;
 
 //// TODO: Not complete enough for publishing.
 //// This handles only cases where each eigenvalue has multiplicity one.
@@ -45,3 +46,4 @@ pub use self::schur::*;
 pub use self::svd::*;
 pub use self::symmetric_eigen::*;
 pub use self::symmetric_tridiagonal::*;
+pub use self::udu::*;

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
 use crate::base::{DefaultAllocator, MatrixN};
-use crate::dimension::DimName;
+use crate::dimension::Dim;
 use simba::scalar::ComplexField;
 
 /// UDU factorization
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
-pub struct UDU<N: ComplexField, D: DimName>
+pub struct UDU<N: ComplexField, D: Dim>
 where
     DefaultAllocator: Allocator<N, D, D>,
 {
@@ -19,14 +19,14 @@ where
     pub d: MatrixN<N, D>,
 }
 
-impl<N: ComplexField, D: DimName> Copy for UDU<N, D>
+impl<N: ComplexField, D: Dim> Copy for UDU<N, D>
 where
     DefaultAllocator: Allocator<N, D, D>,
     MatrixN<N, D>: Copy,
 {
 }
 
-impl<N: ComplexField, D: DimName> UDU<N, D>
+impl<N: ComplexField, D: Dim> UDU<N, D>
 where
     DefaultAllocator: Allocator<N, D, D>,
 {
@@ -34,10 +34,11 @@ where
     /// NOTE: The provided matrix MUST be symmetric, and no verification is done in this regard.
     /// Ref.: "Optimal control and estimation-Dover Publications", Robert F. Stengel, (1994) page 360
     pub fn new(p: MatrixN<N, D>) -> Self {
-        let mut d = MatrixN::<N, D>::zeros();
-        let mut u = MatrixN::<N, D>::zeros();
-
         let n = p.ncols();
+        let n_as_dim = D::from_usize(n);
+
+        let mut d = MatrixN::<N, D>::zeros_generic(n_as_dim, n_as_dim);
+        let mut u = MatrixN::<N, D>::zeros_generic(n_as_dim, n_as_dim);
 
         d[(n - 1, n - 1)] = p[(n - 1, n - 1)];
         u[(n - 1, n - 1)] = N::one();

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -32,7 +32,7 @@ where
     DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {
     /// Computes the UDU^T factorization
-    /// NOTE: The provided matrix MUST be symmetric, and no verification is done in this regard.
+    /// The input matrix `p` is assumed to be symmetric and this decomposition will only read the upper-triangular part of `p`.
     /// Ref.: "Optimal control and estimation-Dover Publications", Robert F. Stengel, (1994) page 360
     pub fn new(p: MatrixN<N, D>) -> Self {
         let n = p.ncols();

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
-use crate::base::{DefaultAllocator, MatrixN};
+use crate::base::{DefaultAllocator, MatrixN, VectorN, U1};
 use crate::dimension::Dim;
 use simba::scalar::ComplexField;
 
@@ -11,24 +11,25 @@ use simba::scalar::ComplexField;
 #[derive(Clone, Debug)]
 pub struct UDU<N: ComplexField, D: Dim>
 where
-    DefaultAllocator: Allocator<N, D, D>,
+    DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {
     /// The upper triangular matrix resulting from the factorization
     pub u: MatrixN<N, D>,
     /// The diagonal matrix resulting from the factorization
-    pub d: MatrixN<N, D>,
+    pub d: VectorN<N, D>,
 }
 
 impl<N: ComplexField, D: Dim> Copy for UDU<N, D>
 where
-    DefaultAllocator: Allocator<N, D, D>,
+    DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
+    VectorN<N, D>: Copy,
     MatrixN<N, D>: Copy,
 {
 }
 
 impl<N: ComplexField, D: Dim> UDU<N, D>
 where
-    DefaultAllocator: Allocator<N, D, D>,
+    DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {
     /// Computes the UDU^T factorization
     /// NOTE: The provided matrix MUST be symmetric, and no verification is done in this regard.
@@ -37,36 +38,41 @@ where
         let n = p.ncols();
         let n_as_dim = D::from_usize(n);
 
-        let mut d = MatrixN::<N, D>::zeros_generic(n_as_dim, n_as_dim);
+        let mut d = VectorN::<N, D>::zeros_generic(n_as_dim, U1);
         let mut u = MatrixN::<N, D>::zeros_generic(n_as_dim, n_as_dim);
 
-        d[(n - 1, n - 1)] = p[(n - 1, n - 1)];
+        d[n - 1] = p[(n - 1, n - 1)];
         u[(n - 1, n - 1)] = N::one();
 
         for j in (0..n - 1).rev() {
-            u[(j, n - 1)] = p[(j, n - 1)] / d[(n - 1, n - 1)];
+            u[(j, n - 1)] = p[(j, n - 1)] / d[n - 1];
         }
 
         for j in (0..n - 1).rev() {
             for k in j + 1..n {
-                d[(j, j)] = d[(j, j)] + d[(k, k)] * u[(j, k)].powi(2);
+                d[j] = d[j] + d[k] * u[(j, k)].powi(2);
             }
 
-            d[(j, j)] = p[(j, j)] - d[(j, j)];
+            d[j] = p[(j, j)] - d[j];
 
             for i in (0..=j).rev() {
                 for k in j + 1..n {
-                    u[(i, j)] = u[(i, j)] + d[(k, k)] * u[(j, k)] * u[(i, k)];
+                    u[(i, j)] = u[(i, j)] + d[k] * u[(j, k)] * u[(i, k)];
                 }
 
                 u[(i, j)] = p[(i, j)] - u[(i, j)];
 
-                u[(i, j)] /= d[(j, j)];
+                u[(i, j)] /= d[j];
             }
 
             u[(j, j)] = N::one();
         }
 
         Self { u, d }
+    }
+
+    /// Returns the diagonal elements as a matrix
+    pub fn d_matrix(&self) -> MatrixN<N, D> {
+        MatrixN::from_diagonal(&self.d)
     }
 }

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -37,24 +37,24 @@ where
         let mut d = MatrixN::<N, D>::zeros();
         let mut u = MatrixN::<N, D>::zeros();
 
-        let n = p.ncols() - 1;
+        let n = p.ncols();
 
-        d[(n, n)] = p[(n, n)];
-        u[(n, n)] = N::one();
+        d[(n - 1, n - 1)] = p[(n - 1, n - 1)];
+        u[(n - 1, n - 1)] = N::one();
 
-        for j in (0..n).rev() {
-            u[(j, n)] = p[(j, n)] / d[(n, n)];
+        for j in (0..n - 1).rev() {
+            u[(j, n - 1)] = p[(j, n - 1)] / d[(n - 1, n - 1)];
         }
 
-        for j in (0..n).rev() {
-            for k in j + 1..=n {
+        for j in (0..n - 1).rev() {
+            for k in j + 1..n {
                 d[(j, j)] = d[(j, j)] + d[(k, k)] * u[(j, k)].powi(2);
             }
 
             d[(j, j)] = p[(j, j)] - d[(j, j)];
 
             for i in (0..=j).rev() {
-                for k in j + 1..=n {
+                for k in j + 1..n {
                     u[(i, j)] = u[(i, j)] + d[(k, k)] * u[(j, k)] * u[(i, k)];
                 }
 

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -1,0 +1,68 @@
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
+use crate::allocator::Allocator;
+use crate::base::{DefaultAllocator, MatrixN};
+use crate::dimension::DimName;
+use simba::scalar::ComplexField;
+
+/// UDU factorization
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+pub struct UDU<N: ComplexField, D: DimName>
+where
+    DefaultAllocator: Allocator<N, D, D>,
+{
+    /// The upper triangular matrix resulting from the factorization
+    pub u: MatrixN<N, D>,
+    /// The diagonal matrix resulting from the factorization
+    pub d: MatrixN<N, D>,
+}
+
+impl<N: ComplexField, D: DimName> Copy for UDU<N, D>
+where
+    DefaultAllocator: Allocator<N, D, D>,
+    MatrixN<N, D>: Copy,
+{
+}
+
+impl<N: ComplexField, D: DimName> UDU<N, D>
+where
+    DefaultAllocator: Allocator<N, D, D>,
+{
+    /// Computes the UDU^T factorization as per NASA's "Navigation Filter Best Practices", NTRS document ID 20180003657
+    /// section 7.2 page 64.
+    /// NOTE: The provided matrix MUST be symmetric.
+    pub fn new(matrix: MatrixN<N, D>) -> Self {
+        let mut d = MatrixN::<N, D>::zeros();
+        let mut u = MatrixN::<N, D>::zeros();
+
+        let n = matrix.ncols();
+
+        d[(n, n)] = matrix[(n, n)];
+        u[(n, n)] = N::one();
+
+        for j in (0..n - 1).rev() {
+            u[(j, n)] = matrix[(j, n)] / d[(n, n)];
+        }
+
+        for j in (1..n).rev() {
+            d[(j, j)] = matrix[(j, j)];
+            for k in (j + 1..n).rev() {
+                d[(j, j)] = d[(j, j)] + d[(k, k)] * u[(j, k)].powi(2);
+            }
+
+            u[(j, j)] = N::one();
+
+            for i in (0..j - 1).rev() {
+                u[(i, j)] = matrix[(i, j)];
+                for k in j + 1..n {
+                    u[(i, j)] = u[(i, j)] + d[(k, k)] * u[(i, k)] * u[(j, k)];
+                }
+                u[(i, j)] /= d[(j, j)];
+            }
+        }
+
+        Self { u, d }
+    }
+}

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -7,7 +7,7 @@ use crate::dimension::Dim;
 use crate::storage::Storage;
 use simba::scalar::RealField;
 
-/// UDU factorization
+/// UDU factorization.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
@@ -42,8 +42,11 @@ impl<N: RealField, D: Dim> UDU<N, D>
 where
     DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {
-    /// Computes the UDU^T factorization
-    /// The input matrix `p` is assumed to be symmetric and this decomposition will only read the upper-triangular part of `p`.
+    /// Computes the UDU^T factorization.
+    ///
+    /// The input matrix `p` is assumed to be symmetric and this decomposition will only read
+    /// the upper-triangular part of `p`.
+    ///
     /// Ref.: "Optimal control and estimation-Dover Publications", Robert F. Stengel, (1994) page 360
     pub fn new(p: MatrixN<N, D>) -> Self {
         let n = p.ncols();

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -4,10 +4,21 @@ use serde::{Deserialize, Serialize};
 use crate::allocator::Allocator;
 use crate::base::{DefaultAllocator, MatrixN, VectorN, U1};
 use crate::dimension::Dim;
+use crate::storage::Storage;
 use simba::scalar::ComplexField;
 
 /// UDU factorization
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde-serialize",
+    serde(bound(serialize = "VectorN<N, D>: Serialize, MatrixN<N, D>: Serialize"))
+)]
+#[cfg_attr(
+    feature = "serde-serialize",
+    serde(bound(
+        deserialize = "VectorN<N, D>: Deserialize<'de>, MatrixN<N, D>: Deserialize<'de>"
+    ))
+)]
 #[derive(Clone, Debug)]
 pub struct UDU<N: ComplexField, D: Dim>
 where
@@ -36,33 +47,30 @@ where
     /// Ref.: "Optimal control and estimation-Dover Publications", Robert F. Stengel, (1994) page 360
     pub fn new(p: MatrixN<N, D>) -> Self {
         let n = p.ncols();
-        let n_as_dim = D::from_usize(n);
+        let n_dim = p.data.shape().1;
 
-        let mut d = VectorN::<N, D>::zeros_generic(n_as_dim, U1);
-        let mut u = MatrixN::<N, D>::zeros_generic(n_as_dim, n_as_dim);
+        let mut d = VectorN::zeros_generic(n_dim, U1);
+        let mut u = MatrixN::zeros_generic(n_dim, n_dim);
 
         d[n - 1] = p[(n - 1, n - 1)];
-        u[(n - 1, n - 1)] = N::one();
+        u.column_mut(n - 1)
+            .axpy(N::one() / d[n - 1], &p.column(n - 1), N::zero());
 
         for j in (0..n - 1).rev() {
-            u[(j, n - 1)] = p[(j, n - 1)] / d[n - 1];
-        }
-
-        for j in (0..n - 1).rev() {
+            let mut d_j = d[j];
             for k in j + 1..n {
-                d[j] = d[j] + d[k] * u[(j, k)].powi(2);
+                d_j += d[k] * u[(j, k)].powi(2);
             }
 
-            d[j] = p[(j, j)] - d[j];
+            d[j] = p[(j, j)] - d_j;
 
             for i in (0..=j).rev() {
+                let mut u_ij = u[(i, j)];
                 for k in j + 1..n {
-                    u[(i, j)] = u[(i, j)] + d[k] * u[(j, k)] * u[(i, k)];
+                    u_ij += d[k] * u[(j, k)] * u[(i, k)];
                 }
 
-                u[(i, j)] = p[(i, j)] - u[(i, j)];
-
-                u[(i, j)] /= d[j];
+                u[(i, j)] = (p[(i, j)] - u_ij) / d[j];
             }
 
             u[(j, j)] = N::one();

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -5,7 +5,7 @@ use crate::allocator::Allocator;
 use crate::base::{DefaultAllocator, MatrixN, VectorN, U1};
 use crate::dimension::Dim;
 use crate::storage::Storage;
-use simba::scalar::ComplexField;
+use simba::scalar::RealField;
 
 /// UDU factorization
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -20,7 +20,7 @@ use simba::scalar::ComplexField;
     ))
 )]
 #[derive(Clone, Debug)]
-pub struct UDU<N: ComplexField, D: Dim>
+pub struct UDU<N: RealField, D: Dim>
 where
     DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {
@@ -30,7 +30,7 @@ where
     pub d: VectorN<N, D>,
 }
 
-impl<N: ComplexField, D: Dim> Copy for UDU<N, D>
+impl<N: RealField, D: Dim> Copy for UDU<N, D>
 where
     DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
     VectorN<N, D>: Copy,
@@ -38,7 +38,7 @@ where
 {
 }
 
-impl<N: ComplexField, D: Dim> UDU<N, D>
+impl<N: RealField, D: Dim> UDU<N, D>
 where
     DefaultAllocator: Allocator<N, D> + Allocator<N, D, D>,
 {

--- a/tests/linalg/mod.rs
+++ b/tests/linalg/mod.rs
@@ -14,3 +14,4 @@ mod schur;
 mod solve;
 mod svd;
 mod tridiagonal;
+mod udu;

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -11,7 +11,7 @@ fn udu_simple() {
 
     let udu = UDU::new(m);
     // Rebuild
-    let p = udu.u * udu.d * udu.u.transpose();
+    let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
     assert!(relative_eq!(m, p, epsilon = 3.0e-16));
 }
@@ -39,7 +39,7 @@ mod quickcheck_tests {
                         let m = m.map(|e| e.0);
 
                         let udu = UDU::new(m.clone());
-                        let p = &udu.u * &udu.d * &udu.u.transpose();
+                        let p = &udu.u * &udu.d_matrix() * &udu.u.transpose();
 
                         relative_eq!(m, p, epsilon = 1.0e-7)
                     }
@@ -48,7 +48,7 @@ mod quickcheck_tests {
                         let m = m.map(|e| e.0);
 
                         let udu = UDU::new(m.clone());
-                        let p = udu.u * udu.d * udu.u.transpose();
+                        let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
                         relative_eq!(m, p, epsilon = 3.0e-16)
                     }

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -16,6 +16,22 @@ fn udu_simple() {
     assert!(relative_eq!(m, p, epsilon = 3.0e-16));
 }
 
+#[test]
+#[should_panic]
+#[rustfmt::skip]
+fn udu_non_sym_panic() {
+    let m = Matrix3::new(
+        2.0, -1.0,  0.0,
+        1.0, -2.0,  3.0,
+       -2.0,  1.0,  0.0);
+
+    let udu = UDU::new(m);
+    // Rebuild
+    let p = udu.u * udu.d_matrix() * udu.u.transpose();
+
+    assert!(relative_eq!(m, p, epsilon = 3.0e-16));
+}
+
 #[cfg(feature = "arbitrary")]
 mod quickcheck_tests {
     #[allow(unused_imports)]

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -1,4 +1,4 @@
-use na::{Matrix3, UDU};
+use na::Matrix3;
 
 #[test]
 #[rustfmt::skip]
@@ -8,7 +8,8 @@ fn udu_simple() {
        -1.0,  2.0, -1.0,
         0.0, -1.0,  2.0);
 
-    let udu = UDU::new(m);
+    let udu = m.udu();
+    
     // Rebuild
     let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
@@ -24,7 +25,7 @@ fn udu_non_sym_panic() {
         1.0, -2.0,  3.0,
        -2.0,  1.0,  0.0);
 
-    let udu = UDU::new(m);
+    let udu = m.udu();
     // Rebuild
     let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
@@ -39,7 +40,7 @@ mod quickcheck_tests {
     macro_rules! gen_tests(
         ($module: ident, $scalar: ty) => {
             mod $module {
-                use na::{UDU, DMatrix, Matrix4};
+                use na::{DMatrix, Matrix4};
                 #[allow(unused_imports)]
                 use crate::core::helper::{RandScalar, RandComplex};
 
@@ -48,7 +49,7 @@ mod quickcheck_tests {
                         let n = std::cmp::max(1, std::cmp::min(n, 10));
                         let m = DMatrix::<$scalar>::new_random(n, n).map(|e| e.0).hermitian_part();
 
-                        let udu = UDU::new(m.clone());
+                        let udu = m.clone().udu();
                         let p = &udu.u * &udu.d_matrix() * &udu.u.transpose();
 
                         relative_eq!(m, p, epsilon = 1.0e-7)
@@ -57,7 +58,7 @@ mod quickcheck_tests {
                     fn udu_static(m: Matrix4<$scalar>) -> bool {
                         let m = m.map(|e| e.0).hermitian_part();
 
-                        let udu = UDU::new(m.clone());
+                        let udu = m.udu();
                         let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
                         relative_eq!(m, p, epsilon = 1.0e-7)

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -10,16 +10,10 @@ fn udu_simple() {
         0.0, -1.0,  2.0);
 
     let udu = UDU::new(m);
-
-    println!("u = {}", udu.u);
-    println!("d = {}", udu.d);
-
     // Rebuild
     let p = &udu.u * &udu.d * &udu.u.transpose();
 
-    println!("{}", p);
-
-    assert!(relative_eq!(m, p, epsilon = 1.0e-7));
+    assert!(relative_eq!(m, 2.0*p, epsilon = 1.0e-7));
 }
 
 #[cfg(feature = "arbitrary")]

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -1,5 +1,4 @@
-use na::Matrix3;
-use na::UDU;
+use na::{Matrix3, UDU};
 
 #[test]
 #[rustfmt::skip]
@@ -40,19 +39,14 @@ mod quickcheck_tests {
     macro_rules! gen_tests(
         ($module: ident, $scalar: ty) => {
             mod $module {
-                use std::cmp;
-                use na::{DMatrix, Matrix4};
+                use na::{UDU, DMatrix, Matrix4};
                 #[allow(unused_imports)]
                 use crate::core::helper::{RandScalar, RandComplex};
 
                 quickcheck! {
-                    fn udu(m: DMatrix<$scalar>) -> bool {
-                        let mut m = m;
-                        if m.len() == 0 {
-                             m = DMatrix::<$scalar>::new_random(1, 1);
-                        }
-
-                        let m = m.map(|e| e.0);
+                    fn udu(n: usize) -> bool {
+                        let n = std::cmp::max(1, std::cmp::min(n, 10));
+                        let m = DMatrix::<$scalar>::new_random(n, n).map(|e| e.0).hermitian_part();
 
                         let udu = UDU::new(m.clone());
                         let p = &udu.u * &udu.d_matrix() * &udu.u.transpose();
@@ -61,18 +55,17 @@ mod quickcheck_tests {
                     }
 
                     fn udu_static(m: Matrix4<$scalar>) -> bool {
-                        let m = m.map(|e| e.0);
+                        let m = m.map(|e| e.0).hermitian_part();
 
                         let udu = UDU::new(m.clone());
                         let p = udu.u * udu.d_matrix() * udu.u.transpose();
 
-                        relative_eq!(m, p, epsilon = 3.0e-16)
+                        relative_eq!(m, p, epsilon = 1.0e-7)
                     }
                 }
             }
         }
     );
 
-    gen_tests!(complex, RandComplex<f64>);
     gen_tests!(f64, RandScalar<f64>);
 }

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -11,9 +11,9 @@ fn udu_simple() {
 
     let udu = UDU::new(m);
     // Rebuild
-    let p = &udu.u * &udu.d * &udu.u.transpose();
+    let p = udu.u * udu.d * udu.u.transpose();
 
-    assert!(relative_eq!(m, 2.0*p, epsilon = 1.0e-7));
+    assert!(relative_eq!(m, p, epsilon = 3.0e-16));
 }
 
 #[cfg(feature = "arbitrary")]
@@ -48,9 +48,9 @@ mod quickcheck_tests {
                         let m = m.map(|e| e.0);
 
                         let udu = UDU::new(m.clone());
-                        let p = &udu.u * &udu.d * &udu.u.transpose();
+                        let p = udu.u * udu.d * udu.u.transpose();
 
-                        relative_eq!(m, p, epsilon = 1.0e-7)
+                        relative_eq!(m, p, epsilon = 3.0e-16)
                     }
                 }
             }

--- a/tests/linalg/udu.rs
+++ b/tests/linalg/udu.rs
@@ -1,0 +1,68 @@
+use na::Matrix3;
+use na::UDU;
+
+#[test]
+#[rustfmt::skip]
+fn udu_simple() {
+    let m = Matrix3::new(
+        2.0, -1.0,  0.0,
+       -1.0,  2.0, -1.0,
+        0.0, -1.0,  2.0);
+
+    let udu = UDU::new(m);
+
+    println!("u = {}", udu.u);
+    println!("d = {}", udu.d);
+
+    // Rebuild
+    let p = &udu.u * &udu.d * &udu.u.transpose();
+
+    println!("{}", p);
+
+    assert!(relative_eq!(m, p, epsilon = 1.0e-7));
+}
+
+#[cfg(feature = "arbitrary")]
+mod quickcheck_tests {
+    #[allow(unused_imports)]
+    use crate::core::helper::{RandComplex, RandScalar};
+
+    macro_rules! gen_tests(
+        ($module: ident, $scalar: ty) => {
+            mod $module {
+                use std::cmp;
+                use na::{DMatrix, Matrix4};
+                #[allow(unused_imports)]
+                use crate::core::helper::{RandScalar, RandComplex};
+
+                quickcheck! {
+                    fn udu(m: DMatrix<$scalar>) -> bool {
+                        let mut m = m;
+                        if m.len() == 0 {
+                             m = DMatrix::<$scalar>::new_random(1, 1);
+                        }
+
+                        let m = m.map(|e| e.0);
+
+                        let udu = UDU::new(m.clone());
+                        let p = &udu.u * &udu.d * &udu.u.transpose();
+
+                        relative_eq!(m, p, epsilon = 1.0e-7)
+                    }
+
+                    fn udu_static(m: Matrix4<$scalar>) -> bool {
+                        let m = m.map(|e| e.0);
+
+                        let udu = UDU::new(m.clone());
+                        let p = &udu.u * &udu.d * &udu.u.transpose();
+
+                        relative_eq!(m, p, epsilon = 1.0e-7)
+                    }
+                }
+            }
+        }
+    );
+
+    gen_tests!(complex, RandComplex<f64>);
+    gen_tests!(f64, RandScalar<f64>);
+}


### PR DESCRIPTION
Closes #762 

Concerns:
1. The structure is defined as `UDU<N: ComplexField, D: DimName>` instead of `UDU<N: ComplexField, D: Dim>`. That's because I could not find a way to initialize a zero matrix with `D: Dim`. How can I fix that?
2. The diagonal matrix is currently stored as `Matrix<N, D>` but it could easily be a `Vector<N, D>`. Is that preferable? It's an easy change.
3. On line 51 and 58 of src/linalg/udu.rs, the compiler did not accept an AddAssign operation, so I had to resort to an Add (e.g. `d[(j, j)] = d[(j, j)] + ...`). Is there a way I can specify in the `N` constraint that it needs to allow for AddAssign, and is that desired?