### PR TITLE
Ensure Isometry implements Copy when targeting no-std.

### DIFF
--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -82,21 +82,23 @@ where
     }
 }
 
-impl<N: Scalar + Copy, D: DimName + Copy, R: AbstractRotation<N, D> + Copy> Copy
-    for Isometry<N, D, R>
+impl<N: Scalar + Copy, D: DimName + Copy, R: Copy> Copy for Isometry<N, D, R>
 where
     DefaultAllocator: Allocator<N, D>,
     Owned<N, D>: Copy,
 {
 }
 
-impl<N: Scalar, D: DimName, R: AbstractRotation<N, D> + Clone> Clone for Isometry<N, D, R>
+impl<N: Scalar, D: DimName, R: Clone> Clone for Isometry<N, D, R>
 where
     DefaultAllocator: Allocator<N, D>,
 {
     #[inline]
     fn clone(&self) -> Self {
-        Self::from_parts(self.translation.clone(), self.rotation.clone())
+        Self {
+            rotation: self.rotation.clone(),
+            translation: self.translation.clone(),
+        }
     }
 }
 

--- a/src/geometry/isometry_alias.rs
+++ b/src/geometry/isometry_alias.rs
@@ -13,3 +13,15 @@ pub type IsometryMatrix2<N> = Isometry<N, U2, Rotation2<N>>;
 
 /// A 3-dimensional direct isometry using a rotation matrix for its rotational part. Also known as a rigid-body motion, or as an element of SE(3).
 pub type IsometryMatrix3<N> = Isometry<N, U3, Rotation3<N>>;
+
+// This tests that the types correctly implement `Copy`, without having to run tests
+// (when targeting no-std for example).
+#[allow(dead_code)]
+fn ensure_copy() {
+    fn is_copy<T: Copy>() {}
+
+    is_copy::<IsometryMatrix2<f32>>();
+    is_copy::<IsometryMatrix3<f32>>();
+    is_copy::<Isometry2<f32>>();
+    is_copy::<Isometry3<f32>>();
+}


### PR DESCRIPTION
Fix #774.