### PR TITLE
Make serde no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ simba          = { version = "0.3", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.3", optional = true }
 matrixmultiply = { version = "0.2", optional = true }
-serde          = { version = "1.0", features = [ "derive" ], optional = true }
+serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
 abomonation    = { version = "0.7", optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "0.9", optional = true }


### PR DESCRIPTION
This removes `serde` default features (std) and allows `nalgebra` to be compiled with `serde-serialize` in a `no_std` environment.