### PR TITLE
Fail test compilation if mandatory features are missing

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(any(not(feature = "debug"), not(feature = "compare")))]
 compile_error!(
-    "Please enable the `debug` and `compare` features \
-                in order to compile and run the tests."
+    "Please enable the `debug` and `compare` features in order to compile and run the tests.
+     Example: `cargo test --features debug --features compare`"
 );
 
 #[cfg(feature = "abomonation-serialize")]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,9 @@
+#[cfg(any(not(feature = "debug"), not(feature = "compare")))]
+compile_error!(
+    "Please enable the `debug` and `compare` features \
+                in order to compile and run the tests."
+);
+
 #[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
 #[macro_use]


### PR DESCRIPTION
The `nalgebra` test suite at a minimum requires the `compare` and `debug` features. However, if these features are not passed in, the compilation fails with a bunch of errors from which it's very hard to discern what features are missing.

As discussed on Discord, this simple addition will give a compile-time error message if any of these two mandatory features are missing.