### PR TITLE
impl DoubleEndedIterator for {MatrixIter, MatrixIterMut}

### DIFF
--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -136,6 +136,30 @@ fn mat500_mul_mat500(bench: &mut criterion::Criterion) {
     bench.bench_function("mat500_mul_mat500", move |bh| bh.iter(|| &a * &b));
 }
 
+fn iter(bench: &mut criterion::Criterion) {
+    let a = DMatrix::<f64>::new_random(1000, 1000);
+
+    bench.bench_function("iter", move |bh| {
+        bh.iter(|| {
+            for value in a.iter() {
+                criterion::black_box(value);
+            }
+        })
+    });
+}
+
+fn iter_rev(bench: &mut criterion::Criterion) {
+    let a = DMatrix::<f64>::new_random(1000, 1000);
+
+    bench.bench_function("iter_rev", move |bh| {
+        bh.iter(|| {
+            for value in a.iter().rev() {
+                criterion::black_box(value);
+            }
+        })
+    });
+}
+
 fn copy_from(bench: &mut criterion::Criterion) {
     let a = DMatrix::<f64>::new_random(1000, 1000);
     let mut b = DMatrix::<f64>::new_random(1000, 1000);
@@ -235,6 +259,8 @@ criterion_group!(
     mat10_mul_mat10_static,
     mat100_mul_mat100,
     mat500_mul_mat500,
+    iter,
+    iter_rev,
     copy_from,
     axpy,
     tr_mul_to,

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -125,16 +125,18 @@ macro_rules! iterator {
                         // element we want to return.
                         self.size -= 1;
 
+                        // Fetch strides
+                        let inner_stride = self.strides.0.value();
+                        let outer_stride = self.strides.1.value();
+
                         // Compute number of rows
-                        let inner_size = self.inner_end.offset_from(self.inner_ptr) as usize;
+                        // Division should be exact
+                        let inner_raw_size = self.inner_end.offset_from(self.inner_ptr) as usize;
+                        let inner_size = inner_raw_size / inner_stride;
 
                         // Compute rows and cols remaining
                         let outer_remaining = self.size / inner_size;
                         let inner_remaining = self.size % inner_size;
-
-                        // Fetch strides
-                        let inner_stride = self.strides.0.value();
-                        let outer_stride = self.strides.1.value();
 
                         // Compute pointer to last element
                         let last = self.ptr.offset(

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -119,6 +119,15 @@ macro_rules! iterator {
                 self.size
             }
         }
+
+        impl<'a, N: Scalar, R: Dim, C: Dim, S: 'a + $Storage<N, R, C>> DoubleEndedIterator
+            for $Name<'a, N, R, C, S>
+        {
+            #[inline]
+            fn next_back(&mut self) -> Option<$Ref> {
+                todo!()
+            }
+        }
     };
 }
 

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -1,5 +1,6 @@
 //! Matrix iterators.
 
+use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::mem;
 
@@ -111,15 +112,6 @@ macro_rules! iterator {
             }
         }
 
-        impl<'a, N: Scalar, R: Dim, C: Dim, S: 'a + $Storage<N, R, C>> ExactSizeIterator
-            for $Name<'a, N, R, C, S>
-        {
-            #[inline]
-            fn len(&self) -> usize {
-                self.size
-            }
-        }
-
         impl<'a, N: Scalar, R: Dim, C: Dim, S: 'a + $Storage<N, R, C>> DoubleEndedIterator
             for $Name<'a, N, R, C, S>
         {
@@ -156,6 +148,20 @@ macro_rules! iterator {
                     }
                 }
             }
+        }
+
+        impl<'a, N: Scalar, R: Dim, C: Dim, S: 'a + $Storage<N, R, C>> ExactSizeIterator
+            for $Name<'a, N, R, C, S>
+        {
+            #[inline]
+            fn len(&self) -> usize {
+                self.size
+            }
+        }
+
+        impl<'a, N: Scalar, R: Dim, C: Dim, S: 'a + $Storage<N, R, C>> FusedIterator
+            for $Name<'a, N, R, C, S>
+        {
         }
     };
 }

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -133,15 +133,16 @@ macro_rules! iterator {
                         // element we want to return.
                         self.size -= 1;
 
+                        // Compute number of rows
+                        let inner_size = self.inner_end.offset_from(self.inner_ptr) as usize;
+
+                        // Compute rows and cols remaining
+                        let outer_remaining = self.size / inner_size;
+                        let inner_remaining = self.size % inner_size;
+
                         // Fetch strides
                         let inner_stride = self.strides.0.value();
                         let outer_stride = self.strides.1.value();
-                        debug_assert_eq!(outer_stride % inner_stride, 0);
-                        let num_rows = outer_stride / inner_stride;
-
-                        // Compute rows and cols remaining
-                        let outer_remaining = self.size / num_rows;
-                        let inner_remaining = self.size % num_rows;
 
                         // Compute pointer to last element
                         let last = self.ptr.offset(

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -21,6 +21,15 @@ fn iter() {
     assert_eq!(*it.next().unwrap(), 6.0);
     assert!(it.next().is_none());
 
+    let mut it = a.iter();
+    assert_eq!(*it.next().unwrap(), 1.0);
+    assert_eq!(*it.next_back().unwrap(), 6.0);
+    assert_eq!(*it.next_back().unwrap(), 3.0);
+    assert_eq!(*it.next_back().unwrap(), 5.0);
+    assert_eq!(*it.next().unwrap(), 4.0);
+    assert_eq!(*it.next().unwrap(), 2.0);
+    assert!(it.next().is_none());
+
     let row = a.row(0);
     let mut it = row.iter();
     assert_eq!(*it.next().unwrap(), 1.0);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -11,6 +11,7 @@ use na::{
 #[test]
 fn iter() {
     let a = Matrix2x3::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+    dbg!(a);
 
     let mut it = a.iter();
     assert_eq!(*it.next().unwrap(), 1.0);
@@ -28,6 +29,15 @@ fn iter() {
     assert_eq!(*it.next_back().unwrap(), 5.0);
     assert_eq!(*it.next().unwrap(), 4.0);
     assert_eq!(*it.next().unwrap(), 2.0);
+    assert!(it.next().is_none());
+
+    let mut it = a.iter().rev();
+    assert_eq!(*it.next().unwrap(), 6.0);
+    assert_eq!(*it.next().unwrap(), 3.0);
+    assert_eq!(*it.next().unwrap(), 5.0);
+    assert_eq!(*it.next().unwrap(), 2.0);
+    assert_eq!(*it.next().unwrap(), 4.0);
+    assert_eq!(*it.next().unwrap(), 1.0);
     assert!(it.next().is_none());
 
     let row = a.row(0);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -11,7 +11,6 @@ use na::{
 #[test]
 fn iter() {
     let a = Matrix2x3::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-    dbg!(a);
 
     let mut it = a.iter();
     assert_eq!(*it.next().unwrap(), 1.0);


### PR DESCRIPTION
Implements #794.

Also implements the [`FusedIterator`](https://doc.rust-lang.org/stable/core/iter/trait.FusedIterator.html) marker since it applies.