### PR TITLE
Propagate `mem::MaybeUninit` through the return types of `Allocator::…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ compare = [ "matrixcompare-core" ]
 libm = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 proptest-support = [ "proptest" ]
+no_unsound_assume_init = [ ]
 
 # This feature is only used for tests, and enables tests that require more time to run
 slow-tests = []

--- a/nalgebra-lapack/src/eigen.rs
+++ b/nalgebra-lapack/src/eigen.rs
@@ -78,9 +78,9 @@ where
 
         let lda = n as i32;
 
-        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
+        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
         // TODO: Tap into the workspace.
-        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
+        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
 
         let mut info = 0;
         let mut placeholder1 = [N::zero()];
@@ -107,8 +107,10 @@ where
 
         match (left_eigenvectors, eigenvectors) {
             (true, true) => {
-                let mut vl = unsafe { Matrix::new_uninitialized_generic(nrows, ncols) };
-                let mut vr = unsafe { Matrix::new_uninitialized_generic(nrows, ncols) };
+                let mut vl =
+                    unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
+                let mut vr =
+                    unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
 
                 N::xgeev(
                     ljob,
@@ -137,7 +139,8 @@ where
                 }
             }
             (true, false) => {
-                let mut vl = unsafe { Matrix::new_uninitialized_generic(nrows, ncols) };
+                let mut vl =
+                    unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
 
                 N::xgeev(
                     ljob,
@@ -166,7 +169,8 @@ where
                 }
             }
             (false, true) => {
-                let mut vr = unsafe { Matrix::new_uninitialized_generic(nrows, ncols) };
+                let mut vr =
+                    unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
 
                 N::xgeev(
                     ljob,
@@ -243,8 +247,8 @@ where
 
         let lda = n as i32;
 
-        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
-        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
+        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
+        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
 
         let mut info = 0;
         let mut placeholder1 = [N::zero()];
@@ -287,7 +291,7 @@ where
         );
         lapack_panic!(info);
 
-        let mut res = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
+        let mut res = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
 
         for i in 0..res.len() {
             res[i] = Complex::new(wr[i], wi[i]);

--- a/nalgebra-lapack/src/hessenberg.rs
+++ b/nalgebra-lapack/src/hessenberg.rs
@@ -60,7 +60,7 @@ where
             "Unable to compute the hessenberg decomposition of an empty matrix."
         );
 
-        let mut tau = unsafe { Matrix::new_uninitialized_generic(nrows.sub(U1), U1) };
+        let mut tau = unsafe { Matrix::new_uninitialized_generic(nrows.sub(U1), U1).assume_init() };
 
         let mut info = 0;
         let lwork =

--- a/nalgebra-lapack/src/qr.rs
+++ b/nalgebra-lapack/src/qr.rs
@@ -57,7 +57,8 @@ where
         let (nrows, ncols) = m.data.shape();
 
         let mut info = 0;
-        let mut tau = unsafe { Matrix::new_uninitialized_generic(nrows.min(ncols), U1) };
+        let mut tau =
+            unsafe { Matrix::new_uninitialized_generic(nrows.min(ncols), U1).assume_init() };
 
         if nrows.value() == 0 || ncols.value() == 0 {
             return Self { qr: m, tau: tau };

--- a/nalgebra-lapack/src/schur.rs
+++ b/nalgebra-lapack/src/schur.rs
@@ -78,9 +78,9 @@ where
 
         let mut info = 0;
 
-        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
-        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
-        let mut q = unsafe { Matrix::new_uninitialized_generic(nrows, ncols) };
+        let mut wr = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
+        let mut wi = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
+        let mut q = unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
         // Placeholders:
         let mut bwork = [0i32];
         let mut unused = 0;
@@ -151,7 +151,8 @@ where
     where
         DefaultAllocator: Allocator<Complex<N>, D>,
     {
-        let mut out = unsafe { VectorN::new_uninitialized_generic(self.t.data.shape().0, U1) };
+        let mut out =
+            unsafe { VectorN::new_uninitialized_generic(self.t.data.shape().0, U1).assume_init() };
 
         for i in 0..out.len() {
             out[i] = Complex::new(self.re[i], self.im[i])

--- a/nalgebra-lapack/src/svd.rs
+++ b/nalgebra-lapack/src/svd.rs
@@ -99,9 +99,9 @@ macro_rules! svd_impl(
 
                 let lda = nrows.value() as i32;
 
-                let mut u  = unsafe { Matrix::new_uninitialized_generic(nrows, nrows) };
-                let mut s  = unsafe { Matrix::new_uninitialized_generic(nrows.min(ncols), U1) };
-                let mut vt = unsafe { Matrix::new_uninitialized_generic(ncols, ncols) };
+                let mut u  = unsafe { Matrix::new_uninitialized_generic(nrows, nrows).assume_init() };
+                let mut s  = unsafe { Matrix::new_uninitialized_generic(nrows.min(ncols), U1).assume_init() };
+                let mut vt = unsafe { Matrix::new_uninitialized_generic(ncols, ncols).assume_init() };
 
                 let ldu  = nrows.value();
                 let ldvt = ncols.value();

--- a/nalgebra-lapack/src/symmetric_eigen.rs
+++ b/nalgebra-lapack/src/symmetric_eigen.rs
@@ -94,7 +94,7 @@ where
 
         let lda = n as i32;
 
-        let mut values = unsafe { Matrix::new_uninitialized_generic(nrows, U1) };
+        let mut values = unsafe { Matrix::new_uninitialized_generic(nrows, U1).assume_init() };
         let mut info = 0;
 
         let lwork = N::xsyev_work_size(jobz, b'L', n as i32, m.as_mut_slice(), lda, &mut info);

--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -1,6 +1,7 @@
 //! Abstract definition of a matrix data storage allocator.
 
 use std::any::Any;
+use std::mem;
 
 use crate::base::constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
 use crate::base::dimension::{Dim, U1};
@@ -21,7 +22,7 @@ pub trait Allocator<N: Scalar, R: Dim, C: Dim = U1>: Any + Sized {
     type Buffer: ContiguousStorageMut<N, R, C> + Clone;
 
     /// Allocates a buffer with the given number of rows and columns without initializing its content.
-    unsafe fn allocate_uninitialized(nrows: R, ncols: C) -> Self::Buffer;
+    unsafe fn allocate_uninitialized(nrows: R, ncols: C) -> mem::MaybeUninit<Self::Buffer>;
 
     /// Allocates a buffer initialized with the content of the given iterator.
     fn allocate_from_iterator<I: IntoIterator<Item = N>>(

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -1328,7 +1328,8 @@ where
         ShapeConstraint: DimEq<D1, D1> + DimEq<D1, R3> + DimEq<C3, D4>,
         DefaultAllocator: Allocator<N, D1>,
     {
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
         self.quadform_tr_with_workspace(&mut work, alpha, lhs, mid, beta)
     }
 
@@ -1421,7 +1422,8 @@ where
         ShapeConstraint: DimEq<D2, R3> + DimEq<D1, C3> + AreMultipliable<C3, R3, D2, U1>,
         DefaultAllocator: Allocator<N, D2>,
     {
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(mid.data.shape().0, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(mid.data.shape().0, U1) };
         self.quadform_with_workspace(&mut work, alpha, mid, rhs, beta)
     }
 }

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -1328,10 +1328,7 @@ where
         ShapeConstraint: DimEq<D1, D1> + DimEq<D1, R3> + DimEq<C3, D4>,
         DefaultAllocator: Allocator<N, D1>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut work = Vector::zeros_generic(self.data.shape().0, U1);
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut work = unsafe { Vector::new_uninitialized_generic(self.data.shape().0, U1).assume_init() };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
         self.quadform_tr_with_workspace(&mut work, alpha, lhs, mid, beta)
     }
 
@@ -1424,10 +1421,7 @@ where
         ShapeConstraint: DimEq<D2, R3> + DimEq<D1, C3> + AreMultipliable<C3, R3, D2, U1>,
         DefaultAllocator: Allocator<N, D2>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut work = Vector::zeros_generic(mid.data.shape().0, U1);
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut work = unsafe { Vector::new_uninitialized_generic(mid.data.shape().0, U1).assume_init() };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(mid.data.shape().0, U1) };
         self.quadform_with_workspace(&mut work, alpha, mid, rhs, beta)
     }
 }

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -1328,7 +1328,10 @@ where
         ShapeConstraint: DimEq<D1, D1> + DimEq<D1, R3> + DimEq<C3, D4>,
         DefaultAllocator: Allocator<N, D1>,
     {
-        let mut work = unsafe { Vector::new_uninitialized_generic(self.data.shape().0, U1) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut work = Vector::zeros_generic(self.data.shape().0, U1);
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut work = unsafe { Vector::new_uninitialized_generic(self.data.shape().0, U1).assume_init() };
         self.quadform_tr_with_workspace(&mut work, alpha, lhs, mid, beta)
     }
 
@@ -1421,7 +1424,10 @@ where
         ShapeConstraint: DimEq<D2, R3> + DimEq<D1, C3> + AreMultipliable<C3, R3, D2, U1>,
         DefaultAllocator: Allocator<N, D2>,
     {
-        let mut work = unsafe { Vector::new_uninitialized_generic(mid.data.shape().0, U1) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut work = Vector::zeros_generic(mid.data.shape().0, U1);
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut work = unsafe { Vector::new_uninitialized_generic(mid.data.shape().0, U1).assume_init() };
         self.quadform_with_workspace(&mut work, alpha, mid, rhs, beta)
     }
 }

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -50,7 +50,8 @@ where
         let nrows2 = R2::from_usize(nrows);
         let ncols2 = C2::from_usize(ncols);
 
-        let mut res: MatrixMN<N2, R2, C2> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows2, ncols2) };
+        let mut res: MatrixMN<N2, R2, C2> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows2, ncols2) };
         for i in 0..nrows {
             for j in 0..ncols {
                 unsafe {

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -245,9 +245,9 @@ macro_rules! impl_from_into_mint_1D(
             fn from(v: mint::$VT<N>) -> Self {
                 unsafe {
                     let mut res = Self::new_uninitialized();
-                    ptr::copy_nonoverlapping(&v.x, res.data.ptr_mut(), $SZ);
+                    ptr::copy_nonoverlapping(&v.x, (*res.as_mut_ptr()).data.ptr_mut(), $SZ);
 
-                    res
+                    res.assume_init()
                 }
             }
         }
@@ -307,7 +307,7 @@ macro_rules! impl_from_into_mint_2D(
             fn from(m: mint::$MV<N>) -> Self {
                 unsafe {
                     let mut res = Self::new_uninitialized();
-                    let mut ptr = (*res).data.ptr_mut();
+                    let mut ptr = (*res.as_mut_ptr()).data.ptr_mut();
                     $(
                         ptr::copy_nonoverlapping(&m.$component.x, ptr, $SZRows);
                         ptr = ptr.offset($SZRows);

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -50,10 +50,7 @@ where
         let nrows2 = R2::from_usize(nrows);
         let ncols2 = C2::from_usize(ncols);
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixMN<N2, R2, C2> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { MatrixMN::<N2, R2, C2>::new_uninitialized_generic(nrows2, ncols2).assume_init() };
+        let mut res: MatrixMN<N2, R2, C2> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows2, ncols2) };
         for i in 0..nrows {
             for j in 0..ncols {
                 unsafe {
@@ -76,10 +73,7 @@ where
         let nrows = R1::from_usize(nrows2);
         let ncols = C1::from_usize(ncols2);
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: Self = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { Self::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: Self = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
         for i in 0..nrows2 {
             for j in 0..ncols2 {
                 unsafe {

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -50,7 +50,10 @@ where
         let nrows2 = R2::from_usize(nrows);
         let ncols2 = C2::from_usize(ncols);
 
-        let mut res = unsafe { MatrixMN::<N2, R2, C2>::new_uninitialized_generic(nrows2, ncols2) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: MatrixMN<N2, R2, C2> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { MatrixMN::<N2, R2, C2>::new_uninitialized_generic(nrows2, ncols2).assume_init() };
         for i in 0..nrows {
             for j in 0..ncols {
                 unsafe {
@@ -73,7 +76,10 @@ where
         let nrows = R1::from_usize(nrows2);
         let ncols = C1::from_usize(ncols2);
 
-        let mut res = unsafe { Self::new_uninitialized_generic(nrows, ncols) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: Self = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { Self::new_uninitialized_generic(nrows, ncols).assume_init() };
         for i in 0..nrows2 {
             for j in 0..ncols2 {
                 unsafe {
@@ -117,9 +123,9 @@ macro_rules! impl_from_into_asref_1D(
             fn from(arr: [N; $SZ]) -> Self {
                 unsafe {
                     let mut res = Self::new_uninitialized();
-                    ptr::copy_nonoverlapping(&arr[0], res.data.ptr_mut(), $SZ);
+                    ptr::copy_nonoverlapping(&arr[0], (*res.as_mut_ptr()).data.ptr_mut(), $SZ);
 
-                    res
+                    res.assume_init()
                 }
             }
         }
@@ -184,9 +190,9 @@ macro_rules! impl_from_into_asref_2D(
             fn from(arr: [[N; $SZRows]; $SZCols]) -> Self {
                 unsafe {
                     let mut res = Self::new_uninitialized();
-                    ptr::copy_nonoverlapping(&arr[0][0], res.data.ptr_mut(), $SZRows * $SZCols);
+                    ptr::copy_nonoverlapping(&arr[0][0], (*res.as_mut_ptr()).data.ptr_mut(), $SZRows * $SZCols);
 
-                    res
+                    res.assume_init()
                 }
             }
         }
@@ -306,13 +312,13 @@ macro_rules! impl_from_into_mint_2D(
             fn from(m: mint::$MV<N>) -> Self {
                 unsafe {
                     let mut res = Self::new_uninitialized();
-                    let mut ptr = res.data.ptr_mut();
+                    let mut ptr = (*res).data.ptr_mut();
                     $(
                         ptr::copy_nonoverlapping(&m.$component.x, ptr, $SZRows);
                         ptr = ptr.offset($SZRows);
                     )*
                     let _ = ptr;
-                    res
+                    res.assume_init()
                 }
             }
         }

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -45,9 +45,8 @@ where
     type Buffer = ArrayStorage<N, R, C>;
 
     #[inline]
-    unsafe fn allocate_uninitialized(_: R, _: C) -> Self::Buffer {
-        // TODO: Undefined behavior, see #556
-        mem::MaybeUninit::<Self::Buffer>::uninit().assume_init()
+    unsafe fn allocate_uninitialized(_: R, _: C) -> mem::MaybeUninit<Self::Buffer> {
+        mem::MaybeUninit::<Self::Buffer>::uninit()
     }
 
     #[inline]
@@ -56,7 +55,10 @@ where
         ncols: C,
         iter: I,
     ) -> Self::Buffer {
-        let mut res = unsafe { Self::allocate_uninitialized(nrows, ncols) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: Self::Buffer = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { Self::allocate_uninitialized(nrows, ncols).assume_init() };
         let mut count = 0;
 
         for (res, e) in res.iter_mut().zip(iter.into_iter()) {
@@ -80,13 +82,13 @@ impl<N: Scalar, C: Dim> Allocator<N, Dynamic, C> for DefaultAllocator {
     type Buffer = VecStorage<N, Dynamic, C>;
 
     #[inline]
-    unsafe fn allocate_uninitialized(nrows: Dynamic, ncols: C) -> Self::Buffer {
+    unsafe fn allocate_uninitialized(nrows: Dynamic, ncols: C) -> mem::MaybeUninit<Self::Buffer> {
         let mut res = Vec::new();
         let length = nrows.value() * ncols.value();
         res.reserve_exact(length);
         res.set_len(length);
 
-        VecStorage::new(nrows, ncols, res)
+        mem::MaybeUninit::new(VecStorage::new(nrows, ncols, res))
     }
 
     #[inline]
@@ -110,13 +112,13 @@ impl<N: Scalar, R: DimName> Allocator<N, R, Dynamic> for DefaultAllocator {
     type Buffer = VecStorage<N, R, Dynamic>;
 
     #[inline]
-    unsafe fn allocate_uninitialized(nrows: R, ncols: Dynamic) -> Self::Buffer {
+    unsafe fn allocate_uninitialized(nrows: R, ncols: Dynamic) -> mem::MaybeUninit<Self::Buffer> {
         let mut res = Vec::new();
         let length = nrows.value() * ncols.value();
         res.reserve_exact(length);
         res.set_len(length);
 
-        VecStorage::new(nrows, ncols, res)
+        mem::MaybeUninit::new(VecStorage::new(nrows, ncols, res))
     }
 
     #[inline]
@@ -156,7 +158,10 @@ where
         cto: CTo,
         buf: <Self as Allocator<N, RFrom, CFrom>>::Buffer,
     ) -> ArrayStorage<N, RTo, CTo> {
-        let mut res = <Self as Allocator<N, RTo, CTo>>::allocate_uninitialized(rto, cto);
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: ArrayStorage<N, RTo, CTo> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = <Self as Allocator<N, RTo, CTo>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 
@@ -184,7 +189,10 @@ where
         cto: CTo,
         buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> VecStorage<N, Dynamic, CTo> {
-        let mut res = <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto);
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: VecStorage<N, Dynamic, CTo> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 
@@ -212,7 +220,10 @@ where
         cto: Dynamic,
         buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> VecStorage<N, RTo, Dynamic> {
-        let mut res = <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto);
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: VecStorage<N, RTo, Dynamic> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -55,9 +55,9 @@ where
         ncols: C,
         iter: I,
     ) -> Self::Buffer {
-        #[cfg(feature="no_unsound_assume_init")]
+        #[cfg(feature = "no_unsound_assume_init")]
         let mut res: Self::Buffer = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
+        #[cfg(not(feature = "no_unsound_assume_init"))]
         let mut res = unsafe { Self::allocate_uninitialized(nrows, ncols).assume_init() };
         let mut count = 0;
 
@@ -158,10 +158,11 @@ where
         cto: CTo,
         buf: <Self as Allocator<N, RFrom, CFrom>>::Buffer,
     ) -> ArrayStorage<N, RTo, CTo> {
-        #[cfg(feature="no_unsound_assume_init")]
+        #[cfg(feature = "no_unsound_assume_init")]
         let mut res: ArrayStorage<N, RTo, CTo> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = <Self as Allocator<N, RTo, CTo>>::allocate_uninitialized(rto, cto).assume_init();
+        #[cfg(not(feature = "no_unsound_assume_init"))]
+        let mut res =
+            <Self as Allocator<N, RTo, CTo>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 
@@ -189,10 +190,11 @@ where
         cto: CTo,
         buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> VecStorage<N, Dynamic, CTo> {
-        #[cfg(feature="no_unsound_assume_init")]
+        #[cfg(feature = "no_unsound_assume_init")]
         let mut res: VecStorage<N, Dynamic, CTo> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto).assume_init();
+        #[cfg(not(feature = "no_unsound_assume_init"))]
+        let mut res =
+            <Self as Allocator<N, Dynamic, CTo>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 
@@ -220,10 +222,11 @@ where
         cto: Dynamic,
         buf: ArrayStorage<N, RFrom, CFrom>,
     ) -> VecStorage<N, RTo, Dynamic> {
-        #[cfg(feature="no_unsound_assume_init")]
+        #[cfg(feature = "no_unsound_assume_init")]
         let mut res: VecStorage<N, RTo, Dynamic> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto).assume_init();
+        #[cfg(not(feature = "no_unsound_assume_init"))]
+        let mut res =
+            <Self as Allocator<N, RTo, Dynamic>>::allocate_uninitialized(rto, cto).assume_init();
 
         let (rfrom, cfrom) = buf.shape();
 

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -54,7 +54,9 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let irows = irows.into_iter();
         let ncols = self.data.shape().1;
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(irows.len()), ncols) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(Dynamic::new(irows.len()), ncols)
+        };
 
         // First, check that all the indices from irows are valid.
         // This will allow us to use unchecked access in the inner loop.
@@ -88,8 +90,9 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let icols = icols.into_iter();
         let nrows = self.data.shape().0;
-        let mut res =
-            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, Dynamic::new(icols.len())) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(nrows, Dynamic::new(icols.len()))
+        };
 
         for (destination, source) in icols.enumerate() {
             res.column_mut(destination).copy_from(&self.column(*source))
@@ -895,7 +898,9 @@ impl<N: Scalar> DMatrix<N> {
     where
         DefaultAllocator: Reallocator<N, Dynamic, Dynamic, Dynamic, Dynamic>,
     {
-        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), Dynamic::new(0)) };
+        let placeholder = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), Dynamic::new(0))
+        };
         let old = mem::replace(self, placeholder);
         let new = old.resize(new_nrows, new_ncols, val);
         let _ = mem::replace(self, new);
@@ -918,7 +923,9 @@ where
     where
         DefaultAllocator: Reallocator<N, Dynamic, C, Dynamic, C>,
     {
-        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), self.data.shape().1) };
+        let placeholder = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), self.data.shape().1)
+        };
         let old = mem::replace(self, placeholder);
         let new = old.resize_vertically(new_nrows, val);
         let _ = mem::replace(self, new);
@@ -941,7 +948,9 @@ where
     where
         DefaultAllocator: Reallocator<N, R, Dynamic, R, Dynamic>,
     {
-        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, Dynamic::new(0)) };
+        let placeholder = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, Dynamic::new(0))
+        };
         let old = mem::replace(self, placeholder);
         let new = old.resize_horizontally(new_ncols, val);
         let _ = mem::replace(self, new);

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -54,8 +54,7 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let irows = irows.into_iter();
         let ncols = self.data.shape().1;
-        let mut res =
-            unsafe { MatrixMN::new_uninitialized_generic(Dynamic::new(irows.len()), ncols) };
+        let mut res = unsafe { crate::zero_or_uninitialized_generic!(Dynamic::new(irows.len()), ncols) };
 
         // First, check that all the indices from irows are valid.
         // This will allow us to use unchecked access in the inner loop.
@@ -90,7 +89,7 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         let icols = icols.into_iter();
         let nrows = self.data.shape().0;
         let mut res =
-            unsafe { MatrixMN::new_uninitialized_generic(nrows, Dynamic::new(icols.len())) };
+            unsafe { crate::zero_or_uninitialized_generic!(nrows, Dynamic::new(icols.len())) };
 
         for (destination, source) in icols.enumerate() {
             res.column_mut(destination).copy_from(&self.column(*source))
@@ -896,7 +895,10 @@ impl<N: Scalar> DMatrix<N> {
     where
         DefaultAllocator: Reallocator<N, Dynamic, Dynamic, Dynamic, Dynamic>,
     {
-        let placeholder = unsafe { Self::new_uninitialized(0, 0) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let placeholder = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let placeholder = unsafe { Self::new_uninitialized(0, 0).assume_init() };
         let old = mem::replace(self, placeholder);
         let new = old.resize(new_nrows, new_ncols, val);
         let _ = mem::replace(self, new);
@@ -919,8 +921,10 @@ where
     where
         DefaultAllocator: Reallocator<N, Dynamic, C, Dynamic, C>,
     {
-        let placeholder =
-            unsafe { Self::new_uninitialized_generic(Dynamic::new(0), self.data.shape().1) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let placeholder = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let placeholder = unsafe { Self::new_uninitialized_generic(Dynamic::new(0), self.data.shape().1).assume_init() };
         let old = mem::replace(self, placeholder);
         let new = old.resize_vertically(new_nrows, val);
         let _ = mem::replace(self, new);
@@ -943,8 +947,10 @@ where
     where
         DefaultAllocator: Reallocator<N, R, Dynamic, R, Dynamic>,
     {
-        let placeholder =
-            unsafe { Self::new_uninitialized_generic(self.data.shape().0, Dynamic::new(0)) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let placeholder = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let placeholder = unsafe { Self::new_uninitialized_generic(self.data.shape().0, Dynamic::new(0)).assume_init() };
         let old = mem::replace(self, placeholder);
         let new = old.resize_horizontally(new_ncols, val);
         let _ = mem::replace(self, new);

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -54,7 +54,7 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let irows = irows.into_iter();
         let ncols = self.data.shape().1;
-        let mut res = unsafe { crate::zero_or_uninitialized_generic!(Dynamic::new(irows.len()), ncols) };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(irows.len()), ncols) };
 
         // First, check that all the indices from irows are valid.
         // This will allow us to use unchecked access in the inner loop.
@@ -89,7 +89,7 @@ impl<N: Scalar + Zero, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         let icols = icols.into_iter();
         let nrows = self.data.shape().0;
         let mut res =
-            unsafe { crate::zero_or_uninitialized_generic!(nrows, Dynamic::new(icols.len())) };
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, Dynamic::new(icols.len())) };
 
         for (destination, source) in icols.enumerate() {
             res.column_mut(destination).copy_from(&self.column(*source))
@@ -895,10 +895,7 @@ impl<N: Scalar> DMatrix<N> {
     where
         DefaultAllocator: Reallocator<N, Dynamic, Dynamic, Dynamic, Dynamic>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let placeholder = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let placeholder = unsafe { Self::new_uninitialized(0, 0).assume_init() };
+        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), Dynamic::new(0)) };
         let old = mem::replace(self, placeholder);
         let new = old.resize(new_nrows, new_ncols, val);
         let _ = mem::replace(self, new);
@@ -921,10 +918,7 @@ where
     where
         DefaultAllocator: Reallocator<N, Dynamic, C, Dynamic, C>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let placeholder = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let placeholder = unsafe { Self::new_uninitialized_generic(Dynamic::new(0), self.data.shape().1).assume_init() };
+        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(Dynamic::new(0), self.data.shape().1) };
         let old = mem::replace(self, placeholder);
         let new = old.resize_vertically(new_nrows, val);
         let _ = mem::replace(self, new);
@@ -947,10 +941,7 @@ where
     where
         DefaultAllocator: Reallocator<N, R, Dynamic, R, Dynamic>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let placeholder = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let placeholder = unsafe { Self::new_uninitialized_generic(self.data.shape().0, Dynamic::new(0)).assume_init() };
+        let placeholder = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, Dynamic::new(0)) };
         let old = mem::replace(self, placeholder);
         let new = old.resize_horizontally(new_ncols, val);
         let _ = mem::replace(self, new);

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -300,8 +300,12 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
 
     /// Creates a new uninitialized matrix with the given uninitialized data
     pub unsafe fn from_uninitialized_data(data: mem::MaybeUninit<S>) -> mem::MaybeUninit<Self> {
-        let res: Matrix<N, R, C, mem::MaybeUninit<S>> = Matrix { data, _phantoms: PhantomData };
-        let res: mem::MaybeUninit<Matrix<N, R, C, mem::MaybeUninit<S>>> = mem::MaybeUninit::new(res);
+        let res: Matrix<N, R, C, mem::MaybeUninit<S>> = Matrix {
+            data,
+            _phantoms: PhantomData,
+        };
+        let res: mem::MaybeUninit<Matrix<N, R, C, mem::MaybeUninit<S>>> =
+            mem::MaybeUninit::new(res);
         // safety: since we wrap the inner MaybeUninit in an outer MaybeUninit above, the fact that the `data` field is partially-uninitialized is still opaque.
         // with s/transmute_copy/transmute/, rustc claims that `MaybeUninit<Matrix<N, R, C, MaybeUninit<S>>>` may be of a different size from `MaybeUninit<Matrix<N, R, C, S>>`
         // but MaybeUninit's documentation says "MaybeUninit<T> is guaranteed to have the same size, alignment, and ABI as T", which implies those types should be the same size
@@ -507,7 +511,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         let nrows: SameShapeR<R, R2> = Dim::from_usize(nrows);
         let ncols: SameShapeC<C, C2> = Dim::from_usize(ncols);
 
-        let mut res: MatrixSum<N, R, C, R2, C2> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
+        let mut res: MatrixSum<N, R, C, R2, C2> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         // TODO: use copy_from
         for j in 0..res.ncols() {
@@ -574,7 +579,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        let mut res: MatrixMN<N2, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
+        let mut res: MatrixMN<N2, R, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
@@ -618,7 +624,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        let mut res: MatrixMN<N2, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
+        let mut res: MatrixMN<N2, R, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
@@ -645,7 +652,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        let mut res: MatrixMN<N3, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
+        let mut res: MatrixMN<N3, R, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         assert_eq!(
             (nrows.value(), ncols.value()),
@@ -686,7 +694,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        let mut res: MatrixMN<N4, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
+        let mut res: MatrixMN<N4, R, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         assert_eq!(
             (nrows.value(), ncols.value()),
@@ -1180,7 +1189,8 @@ impl<N: SimdComplexField, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S
         let (nrows, ncols) = self.data.shape();
 
         unsafe {
-            let mut res: MatrixMN<_, C, R> = crate::unimplemented_or_uninitialized_generic!(ncols, nrows);
+            let mut res: MatrixMN<_, C, R> =
+                crate::unimplemented_or_uninitialized_generic!(ncols, nrows);
             self.adjoint_to(&mut res);
 
             res
@@ -1321,7 +1331,8 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         );
 
         let dim = self.data.shape().0;
-        let mut res: VectorN<N2, D> = unsafe { crate::unimplemented_or_uninitialized_generic!(dim, U1) };
+        let mut res: VectorN<N2, D> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(dim, U1) };
 
         for i in 0..dim.value() {
             unsafe {
@@ -1448,7 +1459,8 @@ impl<N: Scalar + Zero, D: DimAdd<U1>, S: Storage<N, D>> Vector<N, D, S> {
     {
         let len = self.len();
         let hnrows = DimSum::<D, U1>::from_usize(len + 1);
-        let mut res: VectorN::<N, _> = unsafe { crate::unimplemented_or_uninitialized_generic!(hnrows, U1) };
+        let mut res: VectorN<N, _> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(hnrows, U1) };
         res.generic_slice_mut((0, 0), self.data.shape())
             .copy_from(self);
         res[(len, 0)] = element;
@@ -1793,7 +1805,8 @@ impl<N: Scalar + ClosedAdd + ClosedSub + ClosedMul, R: Dim, C: Dim, S: Storage<N
                 // TODO: soooo ugly!
                 let nrows = SameShapeR::<R, R2>::from_usize(3);
                 let ncols = SameShapeC::<C, C2>::from_usize(1);
-                let mut res: MatrixCross<N, R, C, R2, C2> = crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
+                let mut res: MatrixCross<N, R, C, R2, C2> =
+                    crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
 
                 let ax = self.get_unchecked((0, 0));
                 let ay = self.get_unchecked((1, 0));
@@ -1817,7 +1830,8 @@ impl<N: Scalar + ClosedAdd + ClosedSub + ClosedMul, R: Dim, C: Dim, S: Storage<N
                 // TODO: ugly!
                 let nrows = SameShapeR::<R, R2>::from_usize(1);
                 let ncols = SameShapeC::<C, C2>::from_usize(3);
-                let mut res: MatrixCross<N, R, C, R2, C2> = crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
+                let mut res: MatrixCross<N, R, C, R2, C2> =
+                    crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
 
                 let ax = self.get_unchecked((0, 0));
                 let ay = self.get_unchecked((0, 1));

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -507,10 +507,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         let nrows: SameShapeR<R, R2> = Dim::from_usize(nrows);
         let ncols: SameShapeC<C, C2> = Dim::from_usize(ncols);
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixSum<N, R, C, R2, C2> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res: MatrixSum<N, R, C, R2, C2> = unsafe { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: MatrixSum<N, R, C, R2, C2> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         // TODO: use copy_from
         for j in 0..res.ncols() {
@@ -559,10 +556,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         let (nrows, ncols) = self.data.shape();
 
         unsafe {
-            #[cfg(feature="no_unsound_assume_init")]
-            let mut res = unimplemented!();
-            #[cfg(not(feature="no_unsound_assume_init"))]
-            let mut res = Matrix::new_uninitialized_generic(ncols, nrows).assume_init();
+            let mut res = crate::unimplemented_or_uninitialized_generic!(ncols, nrows);
             self.transpose_to(&mut res);
 
             res
@@ -580,10 +574,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixMN<N2, R, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { MatrixMN::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: MatrixMN<N2, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
@@ -627,10 +618,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixMN<N2, R, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { MatrixMN::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: MatrixMN<N2, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         for j in 0..ncols.value() {
             for i in 0..nrows.value() {
@@ -657,10 +645,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixMN<N3, R, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { MatrixMN::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: MatrixMN<N3, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         assert_eq!(
             (nrows.value(), ncols.value()),
@@ -701,10 +686,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
     {
         let (nrows, ncols) = self.data.shape();
 
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: MatrixMN<N4, R, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { MatrixMN::new_uninitialized_generic(nrows, ncols).assume_init() };
+        let mut res: MatrixMN<N4, R, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, ncols) };
 
         assert_eq!(
             (nrows.value(), ncols.value()),
@@ -1198,10 +1180,7 @@ impl<N: SimdComplexField, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S
         let (nrows, ncols) = self.data.shape();
 
         unsafe {
-            #[cfg(feature="no_unsound_assume_init")]
-            let mut res = unimplemented!();
-            #[cfg(not(feature="no_unsound_assume_init"))]
-            let mut res: MatrixMN<_, C, R> = Matrix::new_uninitialized_generic(ncols, nrows).assume_init();
+            let mut res: MatrixMN<_, C, R> = crate::unimplemented_or_uninitialized_generic!(ncols, nrows);
             self.adjoint_to(&mut res);
 
             res
@@ -1342,10 +1321,7 @@ impl<N: Scalar, D: Dim, S: Storage<N, D, D>> SquareMatrix<N, D, S> {
         );
 
         let dim = self.data.shape().0;
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: VectorN<N2, D> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { VectorN::new_uninitialized_generic(dim, U1).assume_init() };
+        let mut res: VectorN<N2, D> = unsafe { crate::unimplemented_or_uninitialized_generic!(dim, U1) };
 
         for i in 0..dim.value() {
             unsafe {
@@ -1472,7 +1448,7 @@ impl<N: Scalar + Zero, D: DimAdd<U1>, S: Storage<N, D>> Vector<N, D, S> {
     {
         let len = self.len();
         let hnrows = DimSum::<D, U1>::from_usize(len + 1);
-        let mut res: VectorN::<N, _> = unsafe { crate::zero_or_uninitialized_generic!(hnrows, U1) };
+        let mut res: VectorN::<N, _> = unsafe { crate::unimplemented_or_uninitialized_generic!(hnrows, U1) };
         res.generic_slice_mut((0, 0), self.data.shape())
             .copy_from(self);
         res[(len, 0)] = element;
@@ -1817,10 +1793,7 @@ impl<N: Scalar + ClosedAdd + ClosedSub + ClosedMul, R: Dim, C: Dim, S: Storage<N
                 // TODO: soooo ugly!
                 let nrows = SameShapeR::<R, R2>::from_usize(3);
                 let ncols = SameShapeC::<C, C2>::from_usize(1);
-                #[cfg(feature="no_unsound_assume_init")]
-                let mut res: MatrixCross<N, R, C, R2, C2> = unimplemented!();
-                #[cfg(not(feature="no_unsound_assume_init"))]
-                let mut res = Matrix::new_uninitialized_generic(nrows, ncols).assume_init();
+                let mut res: MatrixCross<N, R, C, R2, C2> = crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
 
                 let ax = self.get_unchecked((0, 0));
                 let ay = self.get_unchecked((1, 0));
@@ -1844,10 +1817,7 @@ impl<N: Scalar + ClosedAdd + ClosedSub + ClosedMul, R: Dim, C: Dim, S: Storage<N
                 // TODO: ugly!
                 let nrows = SameShapeR::<R, R2>::from_usize(1);
                 let ncols = SameShapeC::<C, C2>::from_usize(3);
-                #[cfg(feature="no_unsound_assume_init")]
-                let mut res: MatrixCross<N, R, C, R2, C2> = unimplemented!();
-                #[cfg(not(feature="no_unsound_assume_init"))]
-                let mut res = Matrix::new_uninitialized_generic(nrows, ncols).assume_init();
+                let mut res: MatrixCross<N, R, C, R2, C2> = crate::unimplemented_or_uninitialized_generic!(nrows, ncols);
 
                 let ax = self.get_unchecked((0, 0));
                 let ay = self.get_unchecked((0, 1));

--- a/src/base/matrix_alga.rs
+++ b/src/base/matrix_alga.rs
@@ -433,8 +433,8 @@ where
             "Matrix meet/join error: mismatched dimensions."
         );
 
-        let mut mres = unsafe { Self::new_uninitialized_generic(shape.0, shape.1) };
-        let mut jres = unsafe { Self::new_uninitialized_generic(shape.0, shape.1) };
+        let mut mres = unsafe { crate::unimplemented_or_uninitialized_generic!(shape.0, shape.1) };
+        let mut jres = unsafe { crate::unimplemented_or_uninitialized_generic!(shape.0, shape.1) };
 
         for i in 0..shape.0.value() * shape.1.value() {
             unsafe {

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -15,7 +15,7 @@ mod alias_slice;
 mod array_storage;
 mod cg;
 mod componentwise;
-mod construction;
+#[macro_use] mod construction;
 mod construction_slice;
 mod conversion;
 mod edition;

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -15,7 +15,8 @@ mod alias_slice;
 mod array_storage;
 mod cg;
 mod componentwise;
-#[macro_use] mod construction;
+#[macro_use]
+mod construction;
 mod construction_slice;
 mod conversion;
 mod edition;

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -331,10 +331,7 @@ macro_rules! componentwise_binop_impl(
                     let (nrows, ncols) = self.shape();
                     let nrows: SameShapeR<R1, R2> = Dim::from_usize(nrows);
                     let ncols: SameShapeC<C1, C2> = Dim::from_usize(ncols);
-                    #[cfg(feature="no_unsound_assume_init")]
-                    { unimplemented!() }
-                    #[cfg(not(feature="no_unsound_assume_init"))]
-                    { Matrix::new_uninitialized_generic(nrows, ncols).assume_init() }
+                    crate::unimplemented_or_uninitialized_generic!(nrows, ncols)
                 };
 
                 self.$method_to_statically_unchecked(rhs, &mut res);
@@ -576,7 +573,7 @@ where
 
     #[inline]
     fn mul(self, rhs: &'b Matrix<N, R2, C2, SB>) -> Self::Output {
-        let mut res = unsafe { crate::zero_or_uninitialized_generic!(self.data.shape().0, rhs.data.shape().1) };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, rhs.data.shape().1) };
         self.mul_to(rhs, &mut res);
         res
     }
@@ -685,7 +682,7 @@ where
         DefaultAllocator: Allocator<N, C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
-        let mut res = unsafe { crate::zero_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
 
         self.tr_mul_to(rhs, &mut res);
         res
@@ -700,7 +697,7 @@ where
         DefaultAllocator: Allocator<N, C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
-        let mut res = unsafe { crate::zero_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
 
         self.ad_mul_to(rhs, &mut res);
         res
@@ -814,7 +811,7 @@ where
         let (nrows1, ncols1) = self.data.shape();
         let (nrows2, ncols2) = rhs.data.shape();
 
-        let mut res = unsafe { crate::zero_or_uninitialized_generic!(nrows1.mul(nrows2), ncols1.mul(ncols2)) };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows1.mul(nrows2), ncols1.mul(ncols2)) };
 
         {
             let mut data_res = res.data.ptr_mut();

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -573,7 +573,9 @@ where
 
     #[inline]
     fn mul(self, rhs: &'b Matrix<N, R2, C2, SB>) -> Self::Output {
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, rhs.data.shape().1) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, rhs.data.shape().1)
+        };
         self.mul_to(rhs, &mut res);
         res
     }
@@ -682,7 +684,9 @@ where
         DefaultAllocator: Allocator<N, C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1)
+        };
 
         self.tr_mul_to(rhs, &mut res);
         res
@@ -697,7 +701,9 @@ where
         DefaultAllocator: Allocator<N, C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(self.data.shape().1, rhs.data.shape().1)
+        };
 
         self.ad_mul_to(rhs, &mut res);
         res
@@ -811,7 +817,9 @@ where
         let (nrows1, ncols1) = self.data.shape();
         let (nrows2, ncols2) = rhs.data.shape();
 
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows1.mul(nrows2), ncols1.mul(ncols2)) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(nrows1.mul(nrows2), ncols1.mul(ncols2))
+        };
 
         {
             let mut data_res = res.data.ptr_mut();

--- a/src/base/statistics.rs
+++ b/src/base/statistics.rs
@@ -17,10 +17,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, U1, C>,
     {
         let ncols = self.data.shape().1;
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: RowVectorN<N, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { RowVectorN::new_uninitialized_generic(U1, ncols).assume_init() };
+        let mut res: RowVectorN<N, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(U1, ncols) };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.
@@ -45,10 +42,7 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, C>,
     {
         let ncols = self.data.shape().1;
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: VectorN<N, C> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { VectorN::new_uninitialized_generic(ncols, U1).assume_init() };
+        let mut res: VectorN<N, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.

--- a/src/base/statistics.rs
+++ b/src/base/statistics.rs
@@ -17,7 +17,10 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, U1, C>,
     {
         let ncols = self.data.shape().1;
-        let mut res = unsafe { RowVectorN::new_uninitialized_generic(U1, ncols) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: RowVectorN<N, C> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { RowVectorN::new_uninitialized_generic(U1, ncols).assume_init() };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.
@@ -42,7 +45,10 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, C>,
     {
         let ncols = self.data.shape().1;
-        let mut res = unsafe { VectorN::new_uninitialized_generic(ncols, U1) };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: VectorN<N, C> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { VectorN::new_uninitialized_generic(ncols, U1).assume_init() };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.

--- a/src/base/statistics.rs
+++ b/src/base/statistics.rs
@@ -17,7 +17,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, U1, C>,
     {
         let ncols = self.data.shape().1;
-        let mut res: RowVectorN<N, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(U1, ncols) };
+        let mut res: RowVectorN<N, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(U1, ncols) };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.
@@ -42,7 +43,8 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         DefaultAllocator: Allocator<N, C>,
     {
         let ncols = self.data.shape().1;
-        let mut res: VectorN<N, C> = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
+        let mut res: VectorN<N, C> =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
 
         for i in 0..ncols.value() {
             // TODO: avoid bound checking of column.

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -181,10 +181,7 @@ where
         D: DimNameAdd<U1>,
         DefaultAllocator: Allocator<N, DimNameSum<D, U1>>,
     {
-        #[cfg(feature="no_unsound_assume_init")]
-        let mut res: VectorN<N, DimNameSum<D, U1>> = unimplemented!();
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        let mut res = unsafe { VectorN::<_, DimNameSum<D, U1>>::new_uninitialized().assume_init() };
+        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(<DimNameSum<D, U1> as DimName>::name(), U1) };
         res.fixed_slice_mut::<D, U1>(0, 0).copy_from(&self.coords);
         res[(D::dim(), 0)] = N::one();
 

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -181,7 +181,12 @@ where
         D: DimNameAdd<U1>,
         DefaultAllocator: Allocator<N, DimNameSum<D, U1>>,
     {
-        let mut res = unsafe { crate::unimplemented_or_uninitialized_generic!(<DimNameSum<D, U1> as DimName>::name(), U1) };
+        let mut res = unsafe {
+            crate::unimplemented_or_uninitialized_generic!(
+                <DimNameSum<D, U1> as DimName>::name(),
+                U1
+            )
+        };
         res.fixed_slice_mut::<D, U1>(0, 0).copy_from(&self.coords);
         res[(D::dim(), 0)] = N::one();
 

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -181,7 +181,10 @@ where
         D: DimNameAdd<U1>,
         DefaultAllocator: Allocator<N, DimNameSum<D, U1>>,
     {
-        let mut res = unsafe { VectorN::<_, DimNameSum<D, U1>>::new_uninitialized() };
+        #[cfg(feature="no_unsound_assume_init")]
+        let mut res: VectorN<N, DimNameSum<D, U1>> = unimplemented!();
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        let mut res = unsafe { VectorN::<_, DimNameSum<D, U1>>::new_uninitialized().assume_init() };
         res.fixed_slice_mut::<D, U1>(0, 0).copy_from(&self.coords);
         res[(D::dim(), 0)] = N::one();
 

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -24,7 +24,10 @@ where
     /// Creates a new point with uninitialized coordinates.
     #[inline]
     pub unsafe fn new_uninitialized() -> Self {
-        Self::from(crate::unimplemented_or_uninitialized_generic!(D::name(), U1))
+        Self::from(crate::unimplemented_or_uninitialized_generic!(
+            D::name(),
+            U1
+        ))
     }
 
     /// Creates a new point with all coordinates equal to zero.

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -24,10 +24,7 @@ where
     /// Creates a new point with uninitialized coordinates.
     #[inline]
     pub unsafe fn new_uninitialized() -> Self {
-        #[cfg(feature="no_unsound_assume_init")]
-        { unimplemented!() }
-        #[cfg(not(feature="no_unsound_assume_init"))]
-        { Self::from(VectorN::new_uninitialized().assume_init()) }
+        Self::from(crate::unimplemented_or_uninitialized_generic!(D::name(), U1))
     }
 
     /// Creates a new point with all coordinates equal to zero.

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -24,7 +24,10 @@ where
     /// Creates a new point with uninitialized coordinates.
     #[inline]
     pub unsafe fn new_uninitialized() -> Self {
-        Self::from(VectorN::new_uninitialized())
+        #[cfg(feature="no_unsound_assume_init")]
+        { unimplemented!() }
+        #[cfg(not(feature="no_unsound_assume_init"))]
+        { Self::from(VectorN::new_uninitialized().assume_init()) }
     }
 
     /// Creates a new point with all coordinates equal to zero.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ an optimized set of tools for computer graphics and physics. Those features incl
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+#![cfg_attr(feature = "no_unsound_assume_init", allow(unreachable_code))]
 
 #[cfg(feature = "arbitrary")]
 extern crate quickcheck;

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -81,7 +81,8 @@ where
             "Cannot compute the bidiagonalization of an empty matrix."
         );
 
-        let mut diagonal = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut diagonal =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
         let mut off_diagonal =
             unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols.sub(U1), U1) };
         let mut axis_packed = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
@@ -239,7 +240,8 @@ where
         let min_nrows_ncols = nrows.min(ncols);
 
         let mut res = Matrix::identity_generic(min_nrows_ncols, ncols);
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
         let mut axis_packed = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
 
         let shift = self.axis_shift().1;

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -81,11 +81,11 @@ where
             "Cannot compute the bidiagonalization of an empty matrix."
         );
 
-        let mut diagonal = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut diagonal = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
         let mut off_diagonal =
-            unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols.sub(U1), U1) };
-        let mut axis_packed = unsafe { crate::zero_or_uninitialized_generic!(ncols, U1) };
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(nrows, U1) };
+            unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols.sub(U1), U1) };
+        let mut axis_packed = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, U1) };
 
         let upper_diagonal = nrows.value() >= ncols.value();
         if upper_diagonal {
@@ -239,8 +239,8 @@ where
         let min_nrows_ncols = nrows.min(ncols);
 
         let mut res = Matrix::identity_generic(min_nrows_ncols, ncols);
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
-        let mut axis_packed = unsafe { crate::zero_or_uninitialized_generic!(ncols, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut axis_packed = unsafe { crate::unimplemented_or_uninitialized_generic!(ncols, U1) };
 
         let shift = self.axis_shift().1;
 

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -81,11 +81,11 @@ where
             "Cannot compute the bidiagonalization of an empty matrix."
         );
 
-        let mut diagonal = unsafe { MatrixMN::new_uninitialized_generic(min_nrows_ncols, U1) };
+        let mut diagonal = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
         let mut off_diagonal =
-            unsafe { MatrixMN::new_uninitialized_generic(min_nrows_ncols.sub(U1), U1) };
-        let mut axis_packed = unsafe { MatrixMN::new_uninitialized_generic(ncols, U1) };
-        let mut work = unsafe { MatrixMN::new_uninitialized_generic(nrows, U1) };
+            unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols.sub(U1), U1) };
+        let mut axis_packed = unsafe { crate::zero_or_uninitialized_generic!(ncols, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(nrows, U1) };
 
         let upper_diagonal = nrows.value() >= ncols.value();
         if upper_diagonal {
@@ -239,8 +239,8 @@ where
         let min_nrows_ncols = nrows.min(ncols);
 
         let mut res = Matrix::identity_generic(min_nrows_ncols, ncols);
-        let mut work = unsafe { MatrixMN::new_uninitialized_generic(min_nrows_ncols, U1) };
-        let mut axis_packed = unsafe { MatrixMN::new_uninitialized_generic(ncols, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut axis_packed = unsafe { crate::zero_or_uninitialized_generic!(ncols, U1) };
 
         let shift = self.axis_shift().1;
 

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -223,9 +223,9 @@ where
 
         // loads the data into a new matrix with an additional jth row/column
         let mut chol = unsafe {
-            Matrix::new_uninitialized_generic(
+            crate::zero_or_uninitialized_generic!(
                 self.chol.data.shape().0.add(U1),
-                self.chol.data.shape().1.add(U1),
+                self.chol.data.shape().1.add(U1)
             )
         };
         chol.slice_range_mut(..j, ..j)
@@ -288,9 +288,9 @@ where
 
         // loads the data into a new matrix except for the jth row/column
         let mut chol = unsafe {
-            Matrix::new_uninitialized_generic(
+            crate::zero_or_uninitialized_generic!(
                 self.chol.data.shape().0.sub(U1),
-                self.chol.data.shape().1.sub(U1),
+                self.chol.data.shape().1.sub(U1)
             )
         };
         chol.slice_range_mut(..j, ..j)

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -223,7 +223,7 @@ where
 
         // loads the data into a new matrix with an additional jth row/column
         let mut chol = unsafe {
-            crate::zero_or_uninitialized_generic!(
+            crate::unimplemented_or_uninitialized_generic!(
                 self.chol.data.shape().0.add(U1),
                 self.chol.data.shape().1.add(U1)
             )
@@ -288,7 +288,7 @@ where
 
         // loads the data into a new matrix except for the jth row/column
         let mut chol = unsafe {
-            crate::zero_or_uninitialized_generic!(
+            crate::unimplemented_or_uninitialized_generic!(
                 self.chol.data.shape().0.sub(U1),
                 self.chol.data.shape().1.sub(U1)
             )

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -48,7 +48,8 @@ where
 {
     /// Computes the Hessenberg decomposition using householder reflections.
     pub fn new(hess: MatrixN<N, D>) -> Self {
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(hess.data.shape().0, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(hess.data.shape().0, U1) };
         Self::new_with_workspace(hess, &mut work)
     }
 
@@ -74,7 +75,8 @@ where
             "Hessenberg: invalid workspace size."
         );
 
-        let mut subdiag = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut subdiag =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         if dim.value() == 0 {
             return Hessenberg { hess, subdiag };

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -48,7 +48,7 @@ where
 {
     /// Computes the Hessenberg decomposition using householder reflections.
     pub fn new(hess: MatrixN<N, D>) -> Self {
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(hess.data.shape().0, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(hess.data.shape().0, U1) };
         Self::new_with_workspace(hess, &mut work)
     }
 
@@ -74,7 +74,7 @@ where
             "Hessenberg: invalid workspace size."
         );
 
-        let mut subdiag = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut subdiag = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         if dim.value() == 0 {
             return Hessenberg { hess, subdiag };

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
-use crate::base::{DefaultAllocator, MatrixMN, MatrixN, VectorN};
+use crate::base::{DefaultAllocator, MatrixN, VectorN};
 use crate::dimension::{DimDiff, DimSub, U1};
 use crate::storage::Storage;
 use simba::scalar::ComplexField;
@@ -48,7 +48,7 @@ where
 {
     /// Computes the Hessenberg decomposition using householder reflections.
     pub fn new(hess: MatrixN<N, D>) -> Self {
-        let mut work = unsafe { MatrixMN::new_uninitialized_generic(hess.data.shape().0, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(hess.data.shape().0, U1) };
         Self::new_with_workspace(hess, &mut work)
     }
 
@@ -74,7 +74,7 @@ where
             "Hessenberg: invalid workspace size."
         );
 
-        let mut subdiag = unsafe { MatrixMN::new_uninitialized_generic(dim.sub(U1), U1) };
+        let mut subdiag = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         if dim.value() == 0 {
             return Hessenberg { hess, subdiag };

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -70,12 +70,9 @@ where
     #[inline]
     pub fn identity_generic(dim: D) -> Self {
         unsafe {
-            #[cfg(feature="no_unsound_assume_init")]
-            unimplemented!();
-            #[cfg(not(feature="no_unsound_assume_init"))]
             Self {
                 len: 0,
-                ipiv: VectorN::new_uninitialized_generic(dim, U1).assume_init(),
+                ipiv: crate::unimplemented_or_uninitialized_generic!(dim, U1),
             }
         }
     }

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -70,9 +70,12 @@ where
     #[inline]
     pub fn identity_generic(dim: D) -> Self {
         unsafe {
+            #[cfg(feature="no_unsound_assume_init")]
+            unimplemented!();
+            #[cfg(not(feature="no_unsound_assume_init"))]
             Self {
                 len: 0,
-                ipiv: VectorN::new_uninitialized_generic(dim, U1),
+                ipiv: VectorN::new_uninitialized_generic(dim, U1).assume_init(),
             }
         }
     }

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -54,7 +54,7 @@ where
         let (nrows, ncols) = matrix.data.shape();
         let min_nrows_ncols = nrows.min(ncols);
 
-        let mut diag = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut diag = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
 
         if min_nrows_ncols.value() == 0 {
             return QR { qr: matrix, diag };

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -54,7 +54,8 @@ where
         let (nrows, ncols) = matrix.data.shape();
         let min_nrows_ncols = nrows.min(ncols);
 
-        let mut diag = unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
+        let mut diag =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(min_nrows_ncols, U1) };
 
         if min_nrows_ncols.value() == 0 {
             return QR { qr: matrix, diag };

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -54,7 +54,7 @@ where
         let (nrows, ncols) = matrix.data.shape();
         let min_nrows_ncols = nrows.min(ncols);
 
-        let mut diag = unsafe { MatrixMN::new_uninitialized_generic(min_nrows_ncols, U1) };
+        let mut diag = unsafe { crate::zero_or_uninitialized_generic!(min_nrows_ncols, U1) };
 
         if min_nrows_ncols.value() == 0 {
             return QR { qr: matrix, diag };

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -71,7 +71,7 @@ where
     /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
     /// continues indefinitely until convergence.
     pub fn try_new(m: MatrixN<N, D>, eps: N::RealField, max_niter: usize) -> Option<Self> {
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(m.data.shape().0, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().0, U1) };
 
         Self::do_decompose(m, &mut work, eps, max_niter, true)
             .map(|(q, t)| Schur { q: q.unwrap(), t })
@@ -378,7 +378,7 @@ where
     ///
     /// Return `None` if some eigenvalues are complex.
     pub fn eigenvalues(&self) -> Option<VectorN<N, D>> {
-        let mut out = unsafe { crate::zero_or_uninitialized_generic!(self.t.data.shape().0, U1) };
+        let mut out = unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         if Self::do_eigenvalues(&self.t, &mut out) {
             Some(out)
         } else {
@@ -392,7 +392,7 @@ where
         N: RealField,
         DefaultAllocator: Allocator<NumComplex<N>, D>,
     {
-        let mut out = unsafe { crate::zero_or_uninitialized_generic!(self.t.data.shape().0, U1) };
+        let mut out = unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         Self::do_complex_eigenvalues(&self.t, &mut out);
         out
     }
@@ -503,7 +503,7 @@ where
             "Unable to compute eigenvalues of a non-square matrix."
         );
 
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(self.data.shape().0, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
 
         // Special case for 2x2 matrices.
         if self.nrows() == 2 {
@@ -544,7 +544,7 @@ where
         DefaultAllocator: Allocator<NumComplex<N>, D>,
     {
         let dim = self.data.shape().0;
-        let mut work = unsafe { crate::zero_or_uninitialized_generic!(dim, U1) };
+        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(dim, U1) };
 
         let schur = Schur::do_decompose(
             self.clone_owned(),
@@ -554,7 +554,7 @@ where
             false,
         )
         .unwrap();
-        let mut eig = unsafe { crate::zero_or_uninitialized_generic!(dim, U1) };
+        let mut eig = unsafe { crate::unimplemented_or_uninitialized_generic!(dim, U1) };
         Schur::do_complex_eigenvalues(&schur.1, &mut eig);
         eig
     }

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -71,7 +71,7 @@ where
     /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
     /// continues indefinitely until convergence.
     pub fn try_new(m: MatrixN<N, D>, eps: N::RealField, max_niter: usize) -> Option<Self> {
-        let mut work = unsafe { VectorN::new_uninitialized_generic(m.data.shape().0, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(m.data.shape().0, U1) };
 
         Self::do_decompose(m, &mut work, eps, max_niter, true)
             .map(|(q, t)| Schur { q: q.unwrap(), t })
@@ -378,7 +378,7 @@ where
     ///
     /// Return `None` if some eigenvalues are complex.
     pub fn eigenvalues(&self) -> Option<VectorN<N, D>> {
-        let mut out = unsafe { VectorN::new_uninitialized_generic(self.t.data.shape().0, U1) };
+        let mut out = unsafe { crate::zero_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         if Self::do_eigenvalues(&self.t, &mut out) {
             Some(out)
         } else {
@@ -392,7 +392,7 @@ where
         N: RealField,
         DefaultAllocator: Allocator<NumComplex<N>, D>,
     {
-        let mut out = unsafe { VectorN::new_uninitialized_generic(self.t.data.shape().0, U1) };
+        let mut out = unsafe { crate::zero_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         Self::do_complex_eigenvalues(&self.t, &mut out);
         out
     }
@@ -503,7 +503,7 @@ where
             "Unable to compute eigenvalues of a non-square matrix."
         );
 
-        let mut work = unsafe { VectorN::new_uninitialized_generic(self.data.shape().0, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(self.data.shape().0, U1) };
 
         // Special case for 2x2 matrices.
         if self.nrows() == 2 {
@@ -544,7 +544,7 @@ where
         DefaultAllocator: Allocator<NumComplex<N>, D>,
     {
         let dim = self.data.shape().0;
-        let mut work = unsafe { VectorN::new_uninitialized_generic(dim, U1) };
+        let mut work = unsafe { crate::zero_or_uninitialized_generic!(dim, U1) };
 
         let schur = Schur::do_decompose(
             self.clone_owned(),
@@ -554,7 +554,7 @@ where
             false,
         )
         .unwrap();
-        let mut eig = unsafe { VectorN::new_uninitialized_generic(dim, U1) };
+        let mut eig = unsafe { crate::zero_or_uninitialized_generic!(dim, U1) };
         Schur::do_complex_eigenvalues(&schur.1, &mut eig);
         eig
     }

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -71,7 +71,8 @@ where
     /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
     /// continues indefinitely until convergence.
     pub fn try_new(m: MatrixN<N, D>, eps: N::RealField, max_niter: usize) -> Option<Self> {
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().0, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().0, U1) };
 
         Self::do_decompose(m, &mut work, eps, max_niter, true)
             .map(|(q, t)| Schur { q: q.unwrap(), t })
@@ -378,7 +379,8 @@ where
     ///
     /// Return `None` if some eigenvalues are complex.
     pub fn eigenvalues(&self) -> Option<VectorN<N, D>> {
-        let mut out = unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
+        let mut out =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         if Self::do_eigenvalues(&self.t, &mut out) {
             Some(out)
         } else {
@@ -392,7 +394,8 @@ where
         N: RealField,
         DefaultAllocator: Allocator<NumComplex<N>, D>,
     {
-        let mut out = unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
+        let mut out =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(self.t.data.shape().0, U1) };
         Self::do_complex_eigenvalues(&self.t, &mut out);
         out
     }
@@ -503,7 +506,8 @@ where
             "Unable to compute eigenvalues of a non-square matrix."
         );
 
-        let mut work = unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
+        let mut work =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(self.data.shape().0, U1) };
 
         // Special case for 2x2 matrices.
         if self.nrows() == 2 {

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -61,7 +61,8 @@ where
             "Unable to compute the symmetric tridiagonal decomposition of an empty matrix."
         );
 
-        let mut off_diagonal = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut off_diagonal =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
         let mut p = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         for i in 0..dim.value() - 1 {

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -61,8 +61,8 @@ where
             "Unable to compute the symmetric tridiagonal decomposition of an empty matrix."
         );
 
-        let mut off_diagonal = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
-        let mut p = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut off_diagonal = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut p = unsafe { crate::unimplemented_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         for i in 0..dim.value() - 1 {
             let mut m = m.rows_range_mut(i + 1..);

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
-use crate::base::{DefaultAllocator, MatrixMN, MatrixN, VectorN};
+use crate::base::{DefaultAllocator, MatrixN, VectorN};
 use crate::dimension::{DimDiff, DimSub, U1};
 use crate::storage::Storage;
 use simba::scalar::ComplexField;
@@ -61,8 +61,8 @@ where
             "Unable to compute the symmetric tridiagonal decomposition of an empty matrix."
         );
 
-        let mut off_diagonal = unsafe { MatrixMN::new_uninitialized_generic(dim.sub(U1), U1) };
-        let mut p = unsafe { MatrixMN::new_uninitialized_generic(dim.sub(U1), U1) };
+        let mut off_diagonal = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
+        let mut p = unsafe { crate::zero_or_uninitialized_generic!(dim.sub(U1), U1) };
 
         for i in 0..dim.value() - 1 {
             let mut m = m.rows_range_mut(i + 1..);

--- a/src/sparse/cs_matrix.rs
+++ b/src/sparse/cs_matrix.rs
@@ -460,7 +460,7 @@ where
     {
         // Size = R
         let nrows = self.data.shape().0;
-        let mut workspace = unsafe { VectorN::new_uninitialized_generic(nrows, U1) };
+        let mut workspace = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows, U1) };
         self.sort_with_workspace(workspace.as_mut_slice());
     }
 

--- a/src/sparse/cs_matrix_cholesky.rs
+++ b/src/sparse/cs_matrix_cholesky.rs
@@ -48,8 +48,10 @@ where
         let (l, u) = Self::nonzero_pattern(m);
 
         // Workspaces.
-        let work_x = unsafe { VectorN::new_uninitialized_generic(m.data.shape().0, U1) };
-        let work_c = unsafe { VectorN::new_uninitialized_generic(m.data.shape().1, U1) };
+        let work_x =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().0, U1) };
+        let work_c =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().1, U1) };
         let mut original_p = m.data.p.as_slice().to_vec();
         original_p.push(m.data.i.len());
 
@@ -291,7 +293,8 @@ where
         let etree = Self::elimination_tree(m);
         let (nrows, ncols) = m.data.shape();
         let mut rows = Vec::with_capacity(m.len());
-        let mut cols = unsafe { VectorN::new_uninitialized_generic(m.data.shape().0, U1) };
+        let mut cols =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(m.data.shape().0, U1) };
         let mut marks = Vec::new();
 
         // NOTE: the following will actually compute the non-zero pattern of

--- a/src/sparse/cs_matrix_ops.rs
+++ b/src/sparse/cs_matrix_ops.rs
@@ -242,7 +242,7 @@ where
 
         let mut res = CsMatrix::new_uninitialized_generic(nrows1, ncols2, self.len() + rhs.len());
         let mut timestamps = VectorN::zeros_generic(nrows1, U1);
-        let mut workspace = unsafe { VectorN::new_uninitialized_generic(nrows1, U1) };
+        let mut workspace = unsafe { crate::unimplemented_or_uninitialized_generic!(nrows1, U1) };
         let mut nz = 0;
 
         for j in 0..ncols2.value() {

--- a/src/sparse/cs_matrix_solve.rs
+++ b/src/sparse/cs_matrix_solve.rs
@@ -149,7 +149,8 @@ impl<N: RealField, D: Dim, S: CsStorage<N, D, D>> CsMatrix<N, D, D, S> {
         self.lower_triangular_reach(b, &mut reach);
         // We sort the reach so the result matrix has sorted indices.
         reach.sort();
-        let mut workspace = unsafe { VectorN::new_uninitialized_generic(b.data.shape().0, U1) };
+        let mut workspace =
+            unsafe { crate::unimplemented_or_uninitialized_generic!(b.data.shape().0, U1) };
 
         for i in reach.iter().cloned() {
             workspace[i] = N::zero();


### PR DESCRIPTION
…allocate_uninitialized` and `Matrix::new_uninitialized_generic`.

Most call sites still invoke UB through `assume_init`. Said call sites instead invoke `unimplemented!()` if the `no_unsound_assume_init` feature is enabled, to make it easier to gradually fix them.

Progress towards #556.