### PR TITLE
Add workaround for the deserialization of a matrix containing an enum.

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -377,7 +377,7 @@ where
     where
         V: SeqAccess<'a>,
     {
-        let mut out: Self::Value = unsafe { mem::uninitialized() };
+        let mut out: Self::Value = unsafe { mem::MaybeUninit::uninit().assume_init() };
         let mut curr = 0;
 
         while let Some(value) = visitor.next_element()? {

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -257,9 +257,8 @@ macro_rules! impl_from_into_mint_1D(
             #[inline]
             fn into(self) -> mint::$VT<N> {
                 unsafe {
-                    let mut res: mint::$VT<N> = mem::uninitialized();
+                    let mut res: mint::$VT<N> = mem::MaybeUninit::uninit().assume_init();
                     ptr::copy_nonoverlapping(self.data.ptr(), &mut res.x, $SZ);
-
                     res
                 }
             }
@@ -324,7 +323,7 @@ macro_rules! impl_from_into_mint_2D(
             #[inline]
             fn into(self) -> mint::$MV<N> {
                 unsafe {
-                    let mut res: mint::$MV<N> = mem::uninitialized();
+                    let mut res: mint::$MV<N> = mem::MaybeUninit::uninit().assume_init();
                     let mut ptr = self.data.ptr();
                     $(
                         ptr::copy_nonoverlapping(ptr, &mut res.$component.x, $SZRows);

--- a/tests/core/serde.rs
+++ b/tests/core/serde.rs
@@ -3,9 +3,10 @@
 use na::{
     DMatrix, Isometry2, Isometry3, IsometryMatrix2, IsometryMatrix3, Matrix3x4, Point2, Point3,
     Quaternion, Rotation2, Rotation3, Similarity2, Similarity3, SimilarityMatrix2,
-    SimilarityMatrix3, Translation2, Translation3, Unit,
+    SimilarityMatrix3, Translation2, Translation3, Unit, Vector2,
 };
 use rand;
+use serde::{Deserialize, Serialize};
 use serde_json;
 
 macro_rules! test_serde(
@@ -53,4 +54,17 @@ fn serde_flat() {
     let v = Unit::new_normalize(Quaternion::new(0., 0., 0., 1.));
     let serialized = serde_json::to_string(&v).unwrap();
     assert_eq!(serialized, "[0.0,0.0,1.0,0.0]");
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+enum Stuff {
+    A(f64),
+    B(f64),
+}
+
+#[test]
+fn deserialize_enum() {
+    let json = r#"[{"letter":"A", "value":123.4}, {"letter":"B", "value":567.8}]"#;
+    let parsed: Result<Vector2<Stuff>, _> = serde_json::from_str(json);
+    println!("parsed: {:?}", parsed);
 }


### PR DESCRIPTION
Fix #812 