### PR TITLE
Owned row/column iterators

### DIFF
--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -18,7 +18,7 @@ use crate::base::{DefaultAllocator, Scalar};
 /// same `Buffer` type.
 pub trait Allocator<N: Scalar, R: Dim, C: Dim = U1>: Any + Sized {
     /// The type of buffer this allocator can instanciate.
-    type Buffer: ContiguousStorageMut<N, R, C> + Clone;
+    type Buffer: ContiguousStorageMut<N, R, C> + Clone + IntoIterator<Item=N>;
 
     /// Allocates a buffer with the given number of rows and columns without initializing its content.
     unsafe fn allocate_uninitialized(nrows: R, ncols: C) -> Self::Buffer;

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -46,6 +46,20 @@ where
     data: GenericArray<N, Prod<R::Value, C::Value>>,
 }
 
+impl<N, R, C> IntoIterator for ArrayStorage<N, R, C>
+where
+    R: DimName,
+    C: DimName,
+    R::Value: Mul<C::Value>,
+    Prod<R::Value, C::Value>: ArrayLength<N>,
+{
+    type Item = N;
+    type IntoIter = <GenericArray<N, Prod<R::Value, C::Value>> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
 #[deprecated(note = "renamed to `ArrayStorage`")]
 /// Renamed to [ArrayStorage].
 pub type MatrixArray<N, R, C> = ArrayStorage<N, R, C>;

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -21,7 +21,7 @@ use crate::base::dimension::{
     Dim, DimName, U1, U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9,
 };
 use crate::base::iter::{MatrixIter, MatrixIterMut};
-use crate::base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut};
+use crate::base::storage::{ContiguousStorage, ContiguousStorageMut, Storage, StorageMut, Owned};
 use crate::base::{
     ArrayStorage, DVectorSlice, DVectorSliceMut, DefaultAllocator, Matrix, MatrixMN, MatrixSlice,
     MatrixSliceMut, Scalar,
@@ -86,6 +86,17 @@ where
     }
 }
 
+impl<N: Scalar, R: Dim, C: Dim> IntoIterator for Matrix<N, R, C, Owned<N, R, C>>
+    where DefaultAllocator: Allocator<N, R, C>
+{
+    type Item = N;
+    type IntoIter = <Owned<N, R, C> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        <Owned<N, R, C> as IntoIterator>::into_iter(self.data)
+    }
+}
 impl<'a, N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> IntoIterator for &'a Matrix<N, R, C, S> {
     type Item = &'a N;
     type IntoIter = MatrixIter<'a, N, R, C, S>;

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -21,12 +21,12 @@ use simba::simd::SimdPartialOrd;
 
 use crate::base::allocator::{Allocator, SameShapeAllocator, SameShapeC, SameShapeR};
 use crate::base::constraint::{DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
-use crate::base::dimension::{Dim, DimAdd, DimSum, IsNotStaticOne, U1, U2, U3};
+use crate::base::dimension::{Dim, DimAdd, DimSum, IsNotStaticOne, U1, U2, U3, Dynamic};
 use crate::base::iter::{
-    ColumnIter, ColumnIterMut, MatrixIter, MatrixIterMut, RowIter, RowIterMut,
+    ColumnIter, ColumnIterMut, OwnedColumnIter, MatrixIter, MatrixIterMut, RowIter, RowIterMut, OwnedRowIter,
 };
 use crate::base::storage::{
-    ContiguousStorage, ContiguousStorageMut, Owned, SameShapeStorage, Storage, StorageMut,
+    ContiguousStorage, ContiguousStorageMut, SameShapeStorage, Storage, StorageMut, Owned
 };
 use crate::base::{DefaultAllocator, MatrixMN, MatrixN, Scalar, Unit, VectorN};
 use crate::SimdComplexField;
@@ -856,6 +856,45 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
                 }
             }
         }
+    }
+}
+
+impl<N: Scalar> Matrix<N, Dynamic, Dynamic, Owned<N, Dynamic, Dynamic>> {
+    /// Move rows of this matrix into an owned iterator.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::DMatrix;
+    /// let values = vec![1, 4, 2, 5, 3, 6].into_iter();
+    /// let mut a = DMatrix::from_iterator(2, 3, values);
+    /// let c = a.clone();
+    /// for (i, row) in a.into_row_iter().enumerate() {
+    ///     for (v1, &v2) in row.into_iter().zip(c.row(i).iter()) {
+    ///         assert_eq!(v1, v2)
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    pub fn into_row_iter(self) -> OwnedRowIter<N> {
+        OwnedRowIter::new(self)
+    }
+
+    /// Move columns of this matrix into an owned iterator.
+    /// # Example
+    /// ```
+    /// # use nalgebra::DMatrix;
+    /// let values = vec![1, 4, 2, 5, 3, 6].into_iter();
+    /// let mut a = DMatrix::from_iterator(2, 3, values);
+    /// let c = a.clone();
+    /// for (i, column) in a.into_column_iter().enumerate() {
+    ///     for (v1, &v2) in column.into_iter().zip(c.column(i).iter()) {
+    ///         assert_eq!(v1, v2)
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    pub fn into_column_iter(self) -> OwnedColumnIter<N> {
+        OwnedColumnIter::new(self)
     }
 }
 

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -31,6 +31,18 @@ pub struct VecStorage<N, R: Dim, C: Dim> {
     ncols: C,
 }
 
+impl<N, R, C> IntoIterator for VecStorage<N, R, C>
+where
+    R: Dim,
+    C: Dim,
+{
+    type Item = N;
+    type IntoIter = <Vec<N> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
 #[deprecated(note = "renamed to `VecStorage`")]
 /// Renamed to [VecStorage].
 pub type MatrixVec<N, R, C> = VecStorage<N, R, C>;


### PR DESCRIPTION
https://github.com/dimforge/nalgebra/issues/834

This is an initial draft for this implementation. I only managed to implement `into_row_iter` and `into_column_iter` for `DMatrix` I think because I could not use `Owned<N, R, C> where R: Dim and C: Dim` (i.e. `R` and `C` were either static or dynamic) because of the implementations of `Allocator` on `DefaultAllocator`, which [defines `Owned`](https://docs.rs/nalgebra/0.24.1/nalgebra/base/storage/type.Owned.html):
```rust
type Owned<N, R, C> = <DefaultAllocator as Allocator<N, R, C>::Buffer;
```
So to use `Owned<N, R, C>`, `R` and `C` have to satisfy the trait bounds for any of the `impl Allocator<N, R, C> for DefaultAllocator`, but there is [no implementation](https://docs.rs/nalgebra/0.24.1/nalgebra/base/default_allocator/struct.DefaultAllocator.html) for `R: Dim` and `C: Dim`.

There are only
- `R = Dynamic, C: Dim` (dynamic, either)
- `R: DimName, C: DimName` (static, static)
- `R: Dim, C = Dynamic` (either, dynamic)

Maybe there is a way to implement this for `R: Dim, C: Dim`, but this is the current state.

I would be glad if someone could review this and help me improve this implementation.