### PR TITLE
Make the rand dependency optional.

### DIFF
--- a/.github/Xargo.toml
+++ b/.github/Xargo.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-gnu.dependencies]
 alloc = {}
+
+[target.thumbv7em-none-eabihf.dependencies]
+alloc = {}

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -90,7 +90,11 @@ jobs:
           components: rustfmt
       - name: install xargo
         run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
-      - name: build
+      - name: build x86_64-unknown-linux-gnu
         run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
-      - name: build --feature alloc
+      - name: build x86_64-unknown-linux-gnu --features rand-no-std
+        run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
+      - name: build x86_64-unknown-linux-gnu --features alloc
         run: xargo build --verbose --no-default-features --features alloc --target=x86_64-unknown-linux-gnu;
+      - name: build thumbv7em-none-eabihf
+        run: xargo build --verbose --no-default-features --target=thumbv7em-none-eabihf;

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -49,13 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary --features serde-serialize,abomonation-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
+        run: cargo test --features arbitrary,rand,serde-serialize,abomonation-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: test nalgebra-glm
-        run: cargo test -p nalgebra-glm --features arbitrary,serde-serialize,abomonation-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
+        run: cargo test -p nalgebra-glm --features arbitrary,rand,serde-serialize,abomonation-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
   test-nalgebra-sparse:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,14 @@ path = "src/lib.rs"
 
 [features]
 default         = [ "std" ]
-std             = [ "matrixmultiply", "rand/std", "rand/std_rng", "rand_distr", "simba/std" ]
+std             = [ "matrixmultiply", "simba/std" ]
+rand-no-std     = [ "rand-package" ]
+rand            = [ "rand-no-std", "rand-package/std", "rand-package/std_rng", "rand_distr" ]
 arbitrary       = [ "quickcheck" ]
 serde-serialize = [ "serde", "num-complex/serde" ]
 abomonation-serialize = [ "abomonation" ]
 sparse = [ ]
-debug = [ "approx/num-complex", "rand/std" ]
+debug = [ "approx/num-complex", "rand" ]
 alloc = [ ]
 io = [ "pest", "pest_derive" ]
 compare = [ "matrixcompare-core" ]
@@ -43,8 +45,7 @@ slow-tests = []
 [dependencies]
 typenum        = "1.12"
 generic-array  = "0.14"
-rand           = { version = "0.8", default-features = false }
-getrandom      = { version = "0.2", default-features = false, features = [ "js" ] } # For wasm
+rand-package   = { package = "rand", version = "0.8", optional = true, default-features = false }
 num-traits     = { version = "0.2", default-features = false }
 num-complex    = { version = "0.3", default-features = false }
 num-rational   = { version = "0.3", default-features = false }

--- a/src/base/helper.rs
+++ b/src/base/helper.rs
@@ -1,7 +1,11 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 /// Simple helper function for rejection sampling
 #[cfg(feature = "arbitrary")]
@@ -17,6 +21,7 @@ pub fn reject<F: FnMut(&T) -> bool, T: Arbitrary>(g: &mut Gen, f: F) -> T {
 
 #[doc(hidden)]
 #[inline]
+#[cfg(feature = "rand-no-std")]
 pub fn reject_rand<G: Rng + ?Sized, F: FnMut(&T) -> bool, T>(g: &mut G, f: F) -> T
 where
     Standard: Distribution<T>,

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -4,10 +4,12 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::One;
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
-use simba::scalar::RealField;
 use simba::simd::SimdRealField;
 
 use crate::base::allocator::Allocator;
@@ -80,7 +82,8 @@ where
     }
 }
 
-impl<N: RealField, D: DimName, R> Distribution<Isometry<N, D, R>> for Standard
+#[cfg(feature = "rand-no-std")]
+impl<N: crate::RealField, D: DimName, R> Distribution<Isometry<N, D, R>> for Standard
 where
     R: AbstractRotation<N, D>,
     Standard: Distribution<N> + Distribution<R>,

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -10,7 +13,6 @@ use std::mem;
 use simba::scalar::RealField;
 
 use crate::base::dimension::U3;
-use crate::base::helper;
 use crate::base::storage::Storage;
 use crate::base::{Matrix4, Vector, Vector3};
 
@@ -684,11 +686,13 @@ impl<N: RealField> Orthographic3<N> {
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: RealField> Distribution<Orthographic3<N>> for Standard
 where
     Standard: Distribution<N>,
 {
     fn sample<R: Rng + ?Sized>(&self, r: &mut R) -> Orthographic3<N> {
+        use crate::base::helper;
         let left = r.gen();
         let right = helper::reject_rand(r, |x: &N| *x > left);
         let bottom = r.gen();
@@ -706,6 +710,7 @@ where
     Matrix4<N>: Send,
 {
     fn arbitrary(g: &mut Gen) -> Self {
+        use crate::base::helper;
         let left = Arbitrary::arbitrary(g);
         let right = helper::reject(g, |x: &N| *x > left);
         let bottom = Arbitrary::arbitrary(g);

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -11,7 +14,6 @@ use std::mem;
 use simba::scalar::RealField;
 
 use crate::base::dimension::U3;
-use crate::base::helper;
 use crate::base::storage::Storage;
 use crate::base::{Matrix4, Scalar, Vector, Vector3};
 
@@ -268,11 +270,13 @@ impl<N: RealField> Perspective3<N> {
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: RealField> Distribution<Perspective3<N>> for Standard
 where
     Standard: Distribution<N>,
 {
     fn sample<'a, R: Rng + ?Sized>(&self, r: &'a mut R) -> Perspective3<N> {
+        use crate::base::helper;
         let znear = r.gen();
         let zfar = helper::reject_rand(r, |&x: &N| !(x - znear).is_zero());
         let aspect = helper::reject_rand(r, |&x: &N| !x.is_zero());
@@ -284,6 +288,7 @@ where
 #[cfg(feature = "arbitrary")]
 impl<N: RealField + Arbitrary> Arbitrary for Perspective3<N> {
     fn arbitrary(g: &mut Gen) -> Self {
+        use crate::base::helper;
         let znear = Arbitrary::arbitrary(g);
         let zfar = helper::reject(g, |&x: &N| !(x - znear).is_zero());
         let aspect = helper::reject(g, |&x: &N| !x.is_zero());

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -2,8 +2,11 @@
 use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use crate::base::allocator::Allocator;
 use crate::base::dimension::{DimName, DimNameAdd, DimNameSum, U1};
@@ -138,6 +141,7 @@ where
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: Scalar, D: DimName> Distribution<Point<N, D>> for Standard
 where
     DefaultAllocator: Allocator<N, D>,

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -5,9 +5,13 @@ use crate::base::storage::Owned;
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
+
 use num::{One, Zero};
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
 
 use simba::scalar::RealField;
 use simba::simd::SimdBool;
@@ -144,6 +148,7 @@ where
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: SimdRealField> Distribution<Quaternion<N>> for Standard
 where
     Standard: Distribution<N>,
@@ -812,6 +817,7 @@ where
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: SimdRealField> Distribution<UnitQuaternion<N>> for Standard
 where
     N::Element: SimdRealField,

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -4,8 +4,13 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::Zero;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
+
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
+
 use simba::scalar::RealField;
 use simba::simd::{SimdBool, SimdRealField};
 use std::ops::Neg;
@@ -256,6 +261,7 @@ impl<N: SimdRealField> Rotation2<N> {
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: SimdRealField> Distribution<Rotation2<N>> for Standard
 where
     N::Element: SimdRealField,
@@ -912,6 +918,7 @@ impl<N: SimdRealField> Rotation3<N> {
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: SimdRealField> Distribution<Rotation3<N>> for Standard
 where
     N::Element: SimdRealField,

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -4,10 +4,12 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::One;
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
-use simba::scalar::RealField;
 use simba::simd::SimdRealField;
 
 use crate::base::allocator::Allocator;
@@ -59,7 +61,8 @@ where
     }
 }
 
-impl<N: RealField, D: DimName, R> Distribution<Similarity<N, D, R>> for Standard
+#[cfg(feature = "rand-no-std")]
+impl<N: crate::RealField, D: DimName, R> Distribution<Similarity<N, D, R>> for Standard
 where
     R: AbstractRotation<N, D>,
     DefaultAllocator: Allocator<N, D>,
@@ -107,8 +110,8 @@ where
 #[cfg(feature = "arbitrary")]
 impl<N, D: DimName, R> Arbitrary for Similarity<N, D, R>
 where
-    N: RealField + Arbitrary + Send,
-    N::Element: RealField,
+    N: crate::RealField + Arbitrary + Send,
+    N::Element: crate::RealField,
     R: AbstractRotation<N, D> + Arbitrary + Send,
     DefaultAllocator: Allocator<N, D>,
     Owned<N, D>: Send,

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -4,8 +4,11 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use num::{One, Zero};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use simba::scalar::ClosedAdd;
 
@@ -49,6 +52,7 @@ where
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: Scalar, D: DimName> Distribution<Translation<N, D>> for Standard
 where
     DefaultAllocator: Allocator<N, D>,

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -1,10 +1,14 @@
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 
+#[cfg(feature = "rand-no-std")]
+use rand::{
+    distributions::{Distribution, OpenClosed01, Standard},
+    Rng,
+};
+
 use num::One;
 use num_complex::Complex;
-use rand::distributions::{Distribution, OpenClosed01, Standard};
-use rand::Rng;
 
 use crate::base::dimension::{U1, U2};
 use crate::base::storage::Storage;
@@ -377,6 +381,7 @@ where
     }
 }
 
+#[cfg(feature = "rand-no-std")]
 impl<N: SimdRealField> Distribution<UnitComplex<N>> for Standard
 where
     N::Element: SimdRealField,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,26 +89,16 @@ an optimized set of tools for computer graphics and physics. Those features incl
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "no_unsound_assume_init", allow(unreachable_code))]
 
-#[cfg(feature = "arbitrary")]
-extern crate quickcheck;
-
 #[cfg(feature = "serde-serialize")]
 #[macro_use]
 extern crate serde;
 
-#[cfg(feature = "abomonation-serialize")]
-extern crate abomonation;
-
-#[cfg(feature = "mint")]
-extern crate mint;
+#[cfg(feature = "rand-no-std")]
+extern crate rand_package as rand;
 
 #[macro_use]
 extern crate approx;
-#[cfg(feature = "std")]
-extern crate matrixmultiply;
 extern crate num_traits as num;
-#[cfg(feature = "std")]
-extern crate rand_distr;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,17 +1,20 @@
-#[cfg(any(not(feature = "debug"), not(feature = "compare")))]
+#[cfg(any(
+    not(feature = "debug"),
+    not(feature = "compare"),
+    not(feature = "rand")
+))]
 compile_error!(
-    "Please enable the `debug` and `compare` features in order to compile and run the tests.
-     Example: `cargo test --features debug --features compare`"
+    "Please enable the `debug`, `compare`, and `rand` features in order to compile and run the tests.
+     Example: `cargo test --features debug,compare,rand`"
 );
 
 #[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
 #[macro_use]
 extern crate approx;
-#[cfg(feature = "mint")]
-extern crate mint;
 extern crate nalgebra as na;
 extern crate num_traits as num;
+extern crate rand_package as rand;
 
 mod core;
 mod geometry;


### PR DESCRIPTION
This makes the `rand` dependency of `nalgebra` optional.
The `rand` crate may result in some difficulties when compiling `nalgebra` for `no-std` targets that are not supported by `getrandom`. So it is best to just make it optional so that people that don't need random don't have to take the extra steps to make their stack work.

This PR adds two new cargo features:
- `rand-no-std`: enables `rand` but not `rand/std`. This allows the use of `rand` on `no-std` environments supported by `getrandom`.
- `rand`: enables `rand/std`.

Fix #840 