### PR TITLE
 @sebcrozet Add "cast" methods to cast the type component types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.25.2] - WIP
+### Added
+- A `cast` method has been added to most types. This can be used to change the
+  type of the components of a given entity. Example: `vector.cast::<f32>()`.
+
 ## [0.25.1]
 This release replaces the version 0.25.0 which has been yanked. The 0.25.0 version
 added significant complication to build `nalgebra` targeting a `#[no-std]` platform

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
-use simba::scalar::{ClosedAdd, ClosedMul, ClosedSub, Field};
+use simba::scalar::{ClosedAdd, ClosedMul, ClosedSub, Field, SupersetOf};
 use simba::simd::SimdPartialOrd;
 
 use crate::base::allocator::{Allocator, SameShapeAllocator, SameShapeC, SameShapeR};
@@ -608,6 +608,23 @@ impl<N: Scalar, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S> {
         }
 
         res
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Vector3;
+    /// let q = Vector3::new(1.0f64, 2.0, 3.0);
+    /// let q2 = q.cast::<f32>();
+    /// assert_eq!(q2, Vector3::new(1.0f32, 2.0, 3.0));
+    /// ```
+    pub fn cast<N2: Scalar>(self) -> MatrixMN<N2, R, C>
+    where
+        MatrixMN<N2, R, C>: SupersetOf<Self>,
+        DefaultAllocator: Allocator<N2, R, C>,
+    {
+        crate::convert(self)
     }
 
     /// Similar to `self.iter().fold(init, f)` except that `init` is replaced by a closure.

--- a/src/geometry/dual_quaternion_construction.rs
+++ b/src/geometry/dual_quaternion_construction.rs
@@ -5,6 +5,7 @@ use crate::{
 use num::{One, Zero};
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
+use simba::scalar::SupersetOf;
 
 impl<N: Scalar> DualQuaternion<N> {
     /// Creates a dual quaternion from its rotation and translation components.
@@ -48,6 +49,22 @@ impl<N: Scalar> DualQuaternion<N> {
             Quaternion::from_real(N::one()),
             Quaternion::from_real(N::zero()),
         )
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{Quaternion, DualQuaternion};
+    /// let q = DualQuaternion::from_real(Quaternion::new(1.0f64, 2.0, 3.0, 4.0));
+    /// let q2 = q.cast::<f32>();
+    /// assert_eq!(q2, DualQuaternion::from_real(Quaternion::new(1.0f32, 2.0, 3.0, 4.0)));
+    /// ```
+    pub fn cast<To: Scalar>(self) -> DualQuaternion<To>
+    where
+        DualQuaternion<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
     }
 }
 
@@ -128,6 +145,22 @@ impl<N: SimdRealField> UnitDualQuaternion<N> {
     #[inline]
     pub fn identity() -> Self {
         Self::new_unchecked(DualQuaternion::identity())
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::UnitDualQuaternion;
+    /// let q = UnitDualQuaternion::<f64>::identity();
+    /// let q2 = q.cast::<f32>();
+    /// assert_eq!(q2, UnitDualQuaternion::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> UnitDualQuaternion<To>
+    where
+        UnitDualQuaternion<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
     }
 }
 

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -10,15 +10,16 @@ use rand::{
     Rng,
 };
 
+use simba::scalar::SupersetOf;
 use simba::simd::SimdRealField;
 
 use crate::base::allocator::Allocator;
 use crate::base::dimension::{DimName, U2};
 use crate::base::{DefaultAllocator, Vector2, Vector3};
 
-use crate::geometry::{
+use crate::{
     AbstractRotation, Isometry, Isometry2, Isometry3, IsometryMatrix2, IsometryMatrix3, Point,
-    Point3, Rotation, Rotation3, Translation, Translation2, Translation3, UnitComplex,
+    Point3, Rotation, Rotation3, Scalar, Translation, Translation2, Translation3, UnitComplex,
     UnitQuaternion,
 };
 
@@ -153,6 +154,22 @@ where
     pub fn rotation(angle: N) -> Self {
         Self::new(Vector2::zeros(), angle)
     }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::IsometryMatrix2;
+    /// let iso = IsometryMatrix2::<f64>::identity();
+    /// let iso2 = iso.cast::<f32>();
+    /// assert_eq!(iso2, IsometryMatrix2::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> IsometryMatrix2<To>
+    where
+        IsometryMatrix2<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
+    }
 }
 
 impl<N: SimdRealField> Isometry2<N>
@@ -190,6 +207,22 @@ where
     #[inline]
     pub fn rotation(angle: N) -> Self {
         Self::new(Vector2::zeros(), angle)
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Isometry2;
+    /// let iso = Isometry2::<f64>::identity();
+    /// let iso2 = iso.cast::<f32>();
+    /// assert_eq!(iso2, Isometry2::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Isometry2<To>
+    where
+        Isometry2<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
     }
 }
 
@@ -387,6 +420,22 @@ where
     N::Element: SimdRealField,
 {
     basic_isometry_construction_impl!(UnitQuaternion<N>);
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Isometry3;
+    /// let iso = Isometry3::<f64>::identity();
+    /// let iso2 = iso.cast::<f32>();
+    /// assert_eq!(iso2, Isometry3::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Isometry3<To>
+    where
+        Isometry3<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
+    }
 }
 
 impl<N: SimdRealField> IsometryMatrix3<N>
@@ -394,6 +443,22 @@ where
     N::Element: SimdRealField,
 {
     basic_isometry_construction_impl!(Rotation3<N>);
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::IsometryMatrix3;
+    /// let iso = IsometryMatrix3::<f64>::identity();
+    /// let iso2 = iso.cast::<f32>();
+    /// assert_eq!(iso2, IsometryMatrix3::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> IsometryMatrix3<To>
+    where
+        IsometryMatrix3<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
+    }
 }
 
 /// # Construction from a 3D eye position and target point

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -15,7 +15,7 @@ use crate::{
     Point1, Point2, Point3, Point4, Point5, Point6, Vector1, Vector2, Vector3, Vector4, Vector5,
     Vector6,
 };
-use simba::scalar::ClosedDiv;
+use simba::scalar::{ClosedDiv, SupersetOf};
 
 use crate::geometry::Point;
 
@@ -118,6 +118,23 @@ where
         } else {
             None
         }
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Point2;
+    /// let pt = Point2::new(1.0f64, 2.0);
+    /// let pt2 = pt.cast::<f32>();
+    /// assert_eq!(pt2, Point2::new(1.0f32, 2.0));
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Point<To, D>
+    where
+        Point<To, D>: SupersetOf<Self>,
+        DefaultAllocator: Allocator<To, D>,
+    {
+        crate::convert(self)
     }
 }
 

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -13,7 +13,7 @@ use rand::{
 
 use num::{One, Zero};
 
-use simba::scalar::RealField;
+use simba::scalar::{RealField, SupersetOf};
 use simba::simd::SimdBool;
 
 use crate::base::dimension::U3;
@@ -48,6 +48,22 @@ impl<N: Scalar> Quaternion<N> {
     #[inline]
     pub fn new(w: N, i: N, j: N, k: N) -> Self {
         Self::from(Vector4::new(i, j, k, w))
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Quaternion;
+    /// let q = Quaternion::new(1.0f64, 2.0, 3.0, 4.0);
+    /// let q2 = q.cast::<f32>();
+    /// assert_eq!(q2, Quaternion::new(1.0f32, 2.0, 3.0, 4.0));
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Quaternion<To>
+    where
+        To: SupersetOf<N>,
+    {
+        crate::convert(self)
     }
 }
 
@@ -197,6 +213,23 @@ where
     #[inline]
     pub fn identity() -> Self {
         Self::new_unchecked(Quaternion::identity())
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::UnitQuaternion;
+    /// # use approx::assert_relative_eq;
+    /// let q = UnitQuaternion::from_euler_angles(1.0f64, 2.0, 3.0);
+    /// let q2 = q.cast::<f32>();
+    /// assert_relative_eq!(q2, UnitQuaternion::from_euler_angles(1.0f32, 2.0, 3.0), epsilon = 1.0e-6);
+    /// ```
+    pub fn cast<To: Scalar>(self) -> UnitQuaternion<To>
+    where
+        To: SupersetOf<N>,
+    {
+        crate::convert(self)
     }
 
     /// Creates a new quaternion from a unit vector (the rotation axis) and an angle

--- a/src/geometry/quaternion_conversion.rs
+++ b/src/geometry/quaternion_conversion.rs
@@ -35,8 +35,8 @@ use crate::geometry::{
 
 impl<N1, N2> SubsetOf<Quaternion<N2>> for Quaternion<N1>
 where
-    N1: SimdRealField,
-    N2: SimdRealField + SupersetOf<N1>,
+    N1: Scalar,
+    N2: Scalar + SupersetOf<N1>,
 {
     #[inline]
     fn to_superset(&self) -> Quaternion<N2> {
@@ -58,8 +58,8 @@ where
 
 impl<N1, N2> SubsetOf<UnitQuaternion<N2>> for UnitQuaternion<N1>
 where
-    N1: SimdRealField,
-    N2: SimdRealField + SupersetOf<N1>,
+    N1: Scalar,
+    N2: Scalar + SupersetOf<N1>,
 {
     #[inline]
     fn to_superset(&self) -> UnitQuaternion<N2> {

--- a/src/geometry/rotation_construction.rs
+++ b/src/geometry/rotation_construction.rs
@@ -1,6 +1,6 @@
 use num::{One, Zero};
 
-use simba::scalar::{ClosedAdd, ClosedMul};
+use simba::scalar::{ClosedAdd, ClosedMul, SupersetOf};
 
 use crate::base::allocator::Allocator;
 use crate::base::dimension::DimName;
@@ -28,6 +28,28 @@ where
     #[inline]
     pub fn identity() -> Rotation<N, D> {
         Self::from_matrix_unchecked(MatrixN::<N, D>::identity())
+    }
+}
+
+impl<N: Scalar, D: DimName> Rotation<N, D>
+where
+    DefaultAllocator: Allocator<N, D, D>,
+{
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Rotation2;
+    /// let rot = Rotation2::<f64>::identity();
+    /// let rot2 = rot.cast::<f32>();
+    /// assert_eq!(rot2, Rotation2::<f32>::identity());
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Rotation<To, D>
+    where
+        Rotation<To, D>: SupersetOf<Self>,
+        DefaultAllocator: Allocator<To, D, D>,
+    {
+        crate::convert(self)
     }
 }
 

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -10,7 +10,7 @@ use rand::{
     Rng,
 };
 
-use simba::scalar::ClosedAdd;
+use simba::scalar::{ClosedAdd, SupersetOf};
 
 use crate::base::allocator::Allocator;
 use crate::base::dimension::{DimName, U1, U2, U3, U4, U5, U6};
@@ -18,7 +18,7 @@ use crate::base::{DefaultAllocator, Scalar, VectorN};
 
 use crate::geometry::Translation;
 
-impl<N: Scalar + Zero, D: DimName> Translation<N, D>
+impl<N: Scalar, D: DimName> Translation<N, D>
 where
     DefaultAllocator: Allocator<N, D>,
 {
@@ -37,8 +37,28 @@ where
     /// assert_eq!(t * p, p);
     /// ```
     #[inline]
-    pub fn identity() -> Translation<N, D> {
+    pub fn identity() -> Translation<N, D>
+    where
+        N: Zero,
+    {
         Self::from(VectorN::<N, D>::from_element(N::zero()))
+    }
+
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Translation2;
+    /// let tra = Translation2::new(1.0f64, 2.0);
+    /// let tra2 = tra.cast::<f32>();
+    /// assert_eq!(tra2, Translation2::new(1.0f32, 2.0));
+    /// ```
+    pub fn cast<To: Scalar>(self) -> Translation<To, D>
+    where
+        Translation<To, D>: SupersetOf<Self>,
+        DefaultAllocator: Allocator<To, D>,
+    {
+        crate::convert(self)
     }
 }
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -12,9 +12,9 @@ use num_complex::Complex;
 
 use crate::base::dimension::{U1, U2};
 use crate::base::storage::Storage;
-use crate::base::{Matrix2, Unit, Vector, Vector2};
+use crate::base::{Matrix2, Scalar, Unit, Vector, Vector2};
 use crate::geometry::{Rotation2, UnitComplex};
-use simba::scalar::RealField;
+use simba::scalar::{RealField, SupersetOf};
 use simba::simd::SimdRealField;
 
 /// # Identity
@@ -118,6 +118,22 @@ impl<N: SimdRealField> UnitComplex<N>
 where
     N::Element: SimdRealField,
 {
+    /// Cast the components of `self` to another type.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::UnitComplex;
+    /// let c = UnitComplex::new(1.0f64);
+    /// let c2 = c.cast::<f32>();
+    /// assert_eq!(c2, UnitComplex::new(1.0f32));
+    /// ```
+    pub fn cast<To: Scalar>(self) -> UnitComplex<To>
+    where
+        UnitComplex<To>: SupersetOf<Self>,
+    {
+        crate::convert(self)
+    }
+
     /// The underlying complex number.
     ///
     /// Same as `self.as_ref()`.


### PR DESCRIPTION
This adds `cast` methods to most types. This can be used to change the type of the components of a given entity:

```rust
let vector = Vector3::new(1.0f64, 2.0, 3.0);
let vector_f32 = vector.cast::<f32>()`.
```