### PR TITLE
Add BitAnd operator to Matrix

### DIFF
--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -1,7 +1,7 @@
 use num::{One, Zero};
 use std::iter;
 use std::ops::{
-    Add, AddAssign, Div, DivAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub, SubAssign,
+    Add, AddAssign, BitAnd, Div, DivAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub, SubAssign,
 };
 
 use simba::scalar::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub};
@@ -862,5 +862,27 @@ where
 {
     fn product<I: Iterator<Item = &'a MatrixN<N, D>>>(iter: I) -> MatrixN<N, D> {
         iter.fold(Matrix::one(), |acc, x| acc * x)
+    }
+}
+
+impl<N, R, C, S> BitAnd<Matrix<N, R, C, S>> for Matrix<N, R, C, S>
+where
+    R: Dim,
+    C: Dim,
+    N: Scalar + BitAnd<N, Output = N>,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C, Buffer = S>,
+{
+    type Output = Matrix<N, R, C, S>;
+
+    #[inline]
+    fn bitand(self, rhs: Matrix<N, R, C, S>) -> Self::Output {
+        assert_eq!(
+            self.shape(),
+            rhs.shape(),
+            "Matrix bitand dimensions mismatch."
+        );
+        let mut rhs = rhs.into_owned();
+        self.zip_map(&mut rhs, |a, b| a.bitand(b))
     }
 }

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -401,6 +401,17 @@ fn simple_product() {
 }
 
 #[test]
+fn simple_bitand() {
+    type M = Matrix2x3<u8>;
+
+    let a = M::new(0x1, 0x2, 0x3, 0x4, 0x5, 0x6);
+    let b = M::new(0x5, 0x5, 0xF, 0x4, 0x0, 0x3);
+    let expected = M::new(0x1, 0x0, 0x3, 0x4, 0x0, 0x2);
+
+    assert_eq!(a & b, expected);
+}
+
+#[test]
 fn cross_product_vector_and_row_vector() {
     let v1 = Vector3::new(1.0, 2.0, 3.0);
     let v2 = Vector3::new(1.0, 5.0, 7.0);


### PR DESCRIPTION
I'm starting implement bitwise operator (#832), and open this PR to get feadback.
I'm try use `componentwise_binop_impl` macro but simba don't have `ClosedBitAnd`

If is good, I finish implement BitOr and BitXor in the same way