### PR TITLE
Better error message when running `cargo test`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ itertools = "0.10"
 [workspace]
 members = [ "nalgebra-lapack", "nalgebra-glm", "nalgebra-sparse" ]
 
+[[example]]
+name = "matrixcompare"
+required-features = ["compare"]
+
 [[bench]]
 name = "nalgebra_bench"
 harness = false

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -891,6 +891,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(feature = "rand")]
 mod tests {
     extern crate rand_xorshift;
     use super::*;

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -337,6 +337,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "rand")]
     #[test]
     fn wilkinson_shift_random() {
         for _ in 0..1000 {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,4 @@
-#[cfg(any(
-    not(feature = "debug"),
-    not(feature = "compare"),
-    not(feature = "rand")
-))]
+#[cfg(not(all(feature = "debug", feature = "compare", feature = "rand")))]
 compile_error!(
     "Please enable the `debug`, `compare`, and `rand` features in order to compile and run the tests.
      Example: `cargo test --features debug,compare,rand`"
@@ -10,18 +6,25 @@ compile_error!(
 
 #[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
+#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]
 extern crate approx;
 extern crate nalgebra as na;
 extern crate num_traits as num;
+#[cfg(feature = "rand")]
 extern crate rand_package as rand;
 
+#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 mod core;
+#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 mod geometry;
+#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 mod linalg;
 
+#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[cfg(feature = "proptest-support")]
 mod proptest;
 
+//#[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 //#[cfg(feature = "sparse")]
 //mod sparse;


### PR DESCRIPTION
The `nalgebra` tests are designed to require the "compare", "debug" and "rand" features. Due to this, running `cargo test` fails.

To hint users at this behavior, there is a custom compile error. However, this error is not shown in practice due to other compilation failures. This PR tries to rectify this by making some compilations conditional and using Cargo's `required-features` key.