### PR TITLE
Use the new Cargo resolver from Rust 1.50

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test nalgebra-glm
-        run: cargo test -p nalgebra-glm --features arbitrary,rand,serde-serialize,abomonation-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
+        run: cargo test -p nalgebra-glm --features arbitrary,serde-serialize,abomonation-serialize;
   test-nalgebra-sparse:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,11 +79,7 @@ proptest = { version = "1", optional = true, default-features = false, features 
 serde_json = "1.0"
 rand_xorshift = "0.3"
 rand_isaac = "0.3"
-### Uncomment this line before running benchmarks.
-### We can't just let this uncommented because that would break
-### compilation for #[no-std] because of the terrible Cargo bug
-### https://github.com/rust-lang/cargo/issues/4866
-#criterion = "0.2.10"
+criterion = "0.2.10"
 
 # For matrix comparison macro
 matrixcompare = "0.2.0"
@@ -91,6 +87,7 @@ itertools = "0.10"
 
 [workspace]
 members = [ "nalgebra-lapack", "nalgebra-glm", "nalgebra-sparse" ]
+resolver = "2"
 
 [[bench]]
 name = "nalgebra_bench"


### PR DESCRIPTION
This should make it possible to add the dev-dependency on criterion
without breaking `no_std` builds.