### PR TITLE
More idiomatic use of Rand

### DIFF
--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -853,6 +853,7 @@ where
     }
 }
 
+// TODO(specialization): faster impls possible for D≤4 (see rand_distr::{UnitCircle, UnitSphere})
 #[cfg(feature = "rand")]
 impl<N: crate::RealField, D: DimName> Distribution<Unit<VectorN<N, D>>> for Standard
 where

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -284,7 +284,8 @@ where
     where
         Standard: Distribution<N>,
     {
-        Self::from_fn_generic(nrows, ncols, |_, _| rand::random())
+        let mut rng = rand::thread_rng();
+        Self::from_fn_generic(nrows, ncols, |_, _| rng.gen())
     }
 
     /// Creates a matrix filled with random values from the given distribution.

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -691,6 +691,7 @@ impl<N: RealField> Distribution<Orthographic3<N>> for Standard
 where
     Standard: Distribution<N>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     fn sample<R: Rng + ?Sized>(&self, r: &mut R) -> Orthographic3<N> {
         use crate::base::helper;
         let left = r.gen();

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -275,6 +275,7 @@ impl<N: RealField> Distribution<Perspective3<N>> for Standard
 where
     Standard: Distribution<N>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     fn sample<'a, R: Rng + ?Sized>(&self, r: &'a mut R) -> Perspective3<N> {
         use crate::base::helper;
         let znear = r.gen();

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -164,6 +164,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N>,
 {
+     /// Generate a `Point` where each coordinate is an independent variate from `[0, 1)`.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> Point<N, D> {
         Point::from(rng.gen::<VectorN<N, D>>())

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -7,7 +7,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, OpenClosed01, Standard},
+    distributions::{Distribution, OpenClosed01, Standard, Uniform, uniform::SampleUniform},
     Rng,
 };
 
@@ -855,6 +855,7 @@ impl<N: SimdRealField> Distribution<UnitQuaternion<N>> for Standard
 where
     N::Element: SimdRealField,
     OpenClosed01: Distribution<N>,
+    N: SampleUniform,
 {
     /// Generate a uniformly distributed random rotation quaternion.
     #[inline]
@@ -863,10 +864,9 @@ where
         // Uniform random rotations.
         // In D. Kirk, editor, Graphics Gems III, pages 124-132. Academic, New York, 1992.
         let x0 = rng.sample(OpenClosed01);
-        let x1 = rng.sample(OpenClosed01);
-        let x2 = rng.sample(OpenClosed01);
-        let theta1 = N::simd_two_pi() * x1;
-        let theta2 = N::simd_two_pi() * x2;
+        let twopi = Uniform::new(N::zero(), N::simd_two_pi());
+        let theta1 = rng.sample(&twopi);
+        let theta2 = rng.sample(&twopi);
         let s1 = theta1.simd_sin();
         let c1 = theta1.simd_cos();
         let s2 = theta2.simd_sin();

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -69,6 +69,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N> + Distribution<R>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> Similarity<N, D, R> {
         let mut s = rng.gen();

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -78,6 +78,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     Standard: Distribution<N>,
 {
+    /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> Translation<N, D> {
         Translation::from(rng.gen::<VectorN<N, D>>())

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, OpenClosed01, Standard},
+    distributions::{Distribution, Uniform, uniform::SampleUniform, Standard},
     Rng,
 };
 
@@ -401,12 +401,13 @@ where
 impl<N: SimdRealField> Distribution<UnitComplex<N>> for Standard
 where
     N::Element: SimdRealField,
-    OpenClosed01: Distribution<N>,
+    N: SampleUniform,
 {
     /// Generate a uniformly distributed random `UnitComplex`.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> UnitComplex<N> {
-        UnitComplex::from_angle(rng.sample(OpenClosed01) * N::simd_two_pi())
+        let twopi = Uniform::new(N::zero(), N::simd_two_pi());
+        UnitComplex::from_angle(rng.sample(twopi))
     }
 }
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -2,10 +2,7 @@
 use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
-use rand::{
-    distributions::{Distribution, Uniform, uniform::SampleUniform, Standard},
-    Rng,
-};
+use rand::{distributions::{Distribution, Standard}, Rng};
 
 use num::One;
 use num_complex::Complex;
@@ -401,13 +398,13 @@ where
 impl<N: SimdRealField> Distribution<UnitComplex<N>> for Standard
 where
     N::Element: SimdRealField,
-    N: SampleUniform,
+    rand_distr::UnitCircle: Distribution<[N; 2]>,
 {
     /// Generate a uniformly distributed random `UnitComplex`.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> UnitComplex<N> {
-        let twopi = Uniform::new(N::zero(), N::simd_two_pi());
-        UnitComplex::from_angle(rng.sample(twopi))
+        let x = rng.sample(rand_distr::UnitCircle);
+        UnitComplex::new_unchecked(Complex::new(x[0], x[1]))
     }
 }
 

--- a/tests/core/helper.rs
+++ b/tests/core/helper.rs
@@ -33,6 +33,8 @@ where
 
 // This is a wrapper similar to RandComplex, but for non-complex.
 // This exists only to make generic tests easier to write.
+//
+// Generates variates in the range [0, 1).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RandScalar<N>(pub N);
 


### PR DESCRIPTION
This include the Rand-related changes from #622. It does not include any of the reworked Cargo features or removed `extern crate ...` statements from #622.