### PR TITLE
Don't enable serde by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,17 @@ convert-glam-unchecked = [ "convert-glam" ] # Enable edgy conversions like Mat4 
 convert-bytemuck = [ "bytemuck" ]
 
 # Serialization
+## To use serde in a #[no-std] environment, enable the
+## `serde-serialize-no-std` feature instead of `serde-serialize`.
+## Serialization of dynamically-sized matrices/vectors require
+## `serde-serialize`.
 serde-serialize-no-std = [ "serde", "num-complex/serde" ]
 serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
 abomonation-serialize  = [ "abomonation" ]
 
 # Randomness
+## To use rand in a #[no-std] environment, enable the
+## `rand-no-std` feature instead of `rand`.
 rand-no-std = [ "rand-package" ]
 rand        = [ "rand-no-std", "rand-package/std", "rand-package/std_rng", "rand_distr" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ name = "nalgebra"
 path = "src/lib.rs"
 
 [features]
-default         = [ "std" ]
-std             = [ "matrixmultiply", "simba/std", "serde/std" ]
-sparse = [ ]
-debug = [ "approx/num-complex", "rand" ]
-alloc = [ ]
-io = [ "pest", "pest_derive" ]
+default = [ "std" ]
+std     = [ "matrixmultiply", "simba/std" ]
+sparse  = [ ]
+debug   = [ "approx/num-complex", "rand" ]
+alloc   = [ ]
+io      = [ "pest", "pest_derive" ]
 compare = [ "matrixcompare-core" ]
-libm = [ "simba/libm" ]
+libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 no_unsound_assume_init = [ ]
 
@@ -40,8 +40,9 @@ convert-glam-unchecked = [ "convert-glam" ] # Enable edgy conversions like Mat4 
 convert-bytemuck = [ "bytemuck" ]
 
 # Serialization
-serde-serialize = [ "serde", "num-complex/serde" ]
-abomonation-serialize = [ "abomonation" ]
+serde-serialize-no-std = [ "serde", "num-complex/serde" ]
+serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
+abomonation-serialize  = [ "abomonation" ]
 
 # Randomness
 rand-no-std = [ "rand-package" ]

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-default         = [ "std" ]
-std             = [ "nalgebra/std", "simba/std" ]
-arbitrary       = [ "nalgebra/arbitrary" ]
-serde-serialize = [ "nalgebra/serde-serialize" ]
+default               = [ "std" ]
+std                   = [ "nalgebra/std", "simba/std" ]
+arbitrary             = [ "nalgebra/arbitrary" ]
+serde-serialize       = [ "nalgebra/serde-serialize-no-std" ]
 abomonation-serialize = [ "nalgebra/abomonation-serialize" ]
 
 [dependencies]

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-serde-serialize = [ "serde", "serde_derive" ]
+serde-serialize  = [ "serde", "nalgebra/serde-serialize" ]
 proptest-support = [ "nalgebra/proptest-support" ]
-arbitrary = [ "nalgebra/arbitrary" ]
+arbitrary        = [ "nalgebra/arbitrary" ]
 
 # For BLAS/LAPACK
 default    = ["netlib"]
@@ -33,8 +33,7 @@ nalgebra      = { version = "0.25", path = ".." }
 num-traits    = "0.2"
 num-complex   = { version = "0.3", default-features = false }
 simba         = "0.4"
-serde         = { version = "1.0", optional = true }
-serde_derive  = { version = "1.0", optional = true }
+serde         = { version = "1.0", features = [ "derive" ], optional = true }
 lapack        = { version = "0.17", default-features = false }
 lapack-src    = { version = "0.6", default-features = false }
 # clippy = "*"

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -4,15 +4,15 @@ use std::fmt::{self, Debug, Formatter};
 use std::io::{Result as IOResult, Write};
 use std::ops::Mul;
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::de::{Error, SeqAccess, Visitor};
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::ser::SerializeSeq;
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use std::marker::PhantomData;
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use std::mem;
 
 #[cfg(feature = "abomonation-serialize")]
@@ -173,7 +173,7 @@ where
  *
  */
 // XXX: open an issue for serde so that it allows the serialization/deserialization of all arrays?
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T, const R: usize, const C: usize> Serialize for ArrayStorage<T, R, C>
 where
     T: Scalar + Serialize,
@@ -192,7 +192,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T, const R: usize, const C: usize> Deserialize<'a> for ArrayStorage<T, R, C>
 where
     T: Scalar + Deserialize<'a>,
@@ -205,13 +205,13 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 /// A visitor that produces a matrix array.
 struct ArrayStorageVisitor<T, const R: usize, const C: usize> {
     marker: PhantomData<T>,
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T, const R: usize, const C: usize> ArrayStorageVisitor<T, R, C>
 where
     T: Scalar,
@@ -224,7 +224,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T, const R: usize, const C: usize> Visitor<'a> for ArrayStorageVisitor<T, R, C>
 where
     T: Scalar + Deserialize<'a>,

--- a/src/base/coordinates.rs
+++ b/src/base/coordinates.rs
@@ -23,7 +23,7 @@ macro_rules! coords_impl(
         /// notation, e.g., `v.x` is the same as `v[0]` for a vector.
         #[repr(C)]
         #[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
-        #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+        #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
         pub struct $T<T: Scalar> {
             $(pub $comps: T),*
         }

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Sub};
 use typenum::{self, Diff, Max, Maximum, Min, Minimum, Prod, Quot, Sum, Unsigned};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Dim of dynamically-sized algebraic entities.
@@ -25,7 +25,7 @@ impl Dynamic {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl Serialize for Dynamic {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -35,7 +35,7 @@ impl Serialize for Dynamic {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'de> Deserialize<'de> for Dynamic {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -10,7 +10,7 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem;
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -213,7 +213,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T, R, C, S> Serialize for Matrix<T, R, C, S>
 where
     T: Scalar,
@@ -229,7 +229,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'de, T, R, C, S> Deserialize<'de> for Matrix<T, R, C, S>
 where
     T: Scalar,

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -3,7 +3,7 @@ use std::io::{Result as IOResult, Write};
 use std::mem;
 use std::ops::Deref;
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -36,7 +36,7 @@ unsafe impl<T> bytemuck::Zeroable for Unit<T> where T: bytemuck::Zeroable {}
 #[cfg(feature = "bytemuck")]
 unsafe impl<T> bytemuck::Pod for Unit<T> where T: bytemuck::Pod {}
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: Serialize> Serialize for Unit<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -46,7 +46,7 @@ impl<T: Serialize> Serialize for Unit<T> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Unit<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -3,7 +3,7 @@ use crate::{
     Unit, UnitQuaternion, Vector3, Zero, U8,
 };
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
@@ -237,7 +237,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: SimdRealField> Serialize for DualQuaternion<T>
 where
     T: Serialize,
@@ -250,7 +250,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: SimdRealField> Deserialize<'a> for DualQuaternion<T>
 where
     T: Deserialize<'a>,

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -4,7 +4,7 @@ use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -55,15 +55,15 @@ use crate::geometry::{AbstractRotation, Point, Translation};
 ///
 #[repr(C)]
 #[derive(Debug)]
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "R: Serialize,
                      DefaultAllocator: Allocator<T, Const<D>>,
                      Owned<T, Const<D>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "R: Deserialize<'de>,
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -5,7 +5,7 @@ use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::mem;
@@ -45,7 +45,7 @@ impl<T: RealField> PartialEq for Orthographic3<T> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Orthographic3<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -55,7 +55,7 @@ impl<T: RealField + Serialize> Serialize for Orthographic3<T> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: RealField + Deserialize<'a>> Deserialize<'a> for Orthographic3<T> {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -6,7 +6,7 @@ use rand::{
     Rng,
 };
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::mem;
@@ -46,7 +46,7 @@ impl<T: RealField> PartialEq for Perspective3<T> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Perspective3<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -56,7 +56,7 @@ impl<T: RealField + Serialize> Serialize for Perspective3<T> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: RealField + Deserialize<'a>> Deserialize<'a> for Perspective3<T> {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -6,7 +6,7 @@ use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -67,7 +67,7 @@ where
 {
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: Scalar + Serialize, const D: usize> Serialize for Point<T, D> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -77,7 +77,7 @@ impl<T: Scalar + Serialize, const D: usize> Serialize for Point<T, D> {
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: Scalar + Deserialize<'a>, const D: usize> Deserialize<'a> for Point<T, D> {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -5,9 +5,9 @@ use std::hash::{Hash, Hasher};
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use crate::base::storage::Owned;
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -85,7 +85,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: Scalar> Serialize for Quaternion<T>
 where
     Owned<T, U4>: Serialize,
@@ -98,7 +98,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: Scalar> Deserialize<'a> for Quaternion<T>
 where
     Owned<T, U4>: Deserialize<'a>,

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -5,10 +5,10 @@ use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use crate::base::storage::Owned;
 
 #[cfg(feature = "abomonation-serialize")]
@@ -102,7 +102,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: Scalar, const D: usize> Serialize for Rotation<T, D>
 where
     Owned<T, Const<D>, Const<D>>: Serialize,
@@ -115,7 +115,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: Scalar, const D: usize> Deserialize<'a> for Rotation<T, D>
 where
     Owned<T, Const<D>, Const<D>>: Deserialize<'a>,

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -6,7 +6,7 @@ use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -24,16 +24,16 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
 /// A similarity, i.e., an uniform scaling, followed by a rotation, followed by a translation.
 #[repr(C)]
 #[derive(Debug)]
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "T: Serialize,
                      R: Serialize,
                      DefaultAllocator: Allocator<T, Const<D>>,
                      Owned<T, Const<D>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "T: Deserialize<'de>,
                        R: Deserialize<'de>,
                        DefaultAllocator: Allocator<T, Const<D>>,

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use simba::scalar::RealField;
@@ -194,7 +194,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField, C: TCategory, const D: usize> Serialize for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
@@ -209,7 +209,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: RealField, C: TCategory, const D: usize> Deserialize<'a> for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -5,7 +5,7 @@ use std::hash;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "abomonation-serialize")]
@@ -69,7 +69,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<T: Scalar, const D: usize> Serialize for Translation<T, D>
 where
     Owned<T, Const<D>>: Serialize,
@@ -82,7 +82,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: Scalar, const D: usize> Deserialize<'a> for Translation<T, D>
 where
     Owned<T, Const<D>>: Deserialize<'a>,

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -397,7 +397,7 @@ where
     }
 }
 
-#[cfg(feature = "rand-no-std")]
+#[cfg(feature = "rand")]
 impl<T: SimdRealField> Distribution<UnitComplex<T>> for Standard
 where
     T::Element: SimdRealField,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,12 @@ an optimized set of tools for computer graphics and physics. Those features incl
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "no_unsound_assume_init", allow(unreachable_code))]
 
-#[cfg(feature = "serde-serialize")]
-#[macro_use]
-extern crate serde;
-
 #[cfg(feature = "rand-no-std")]
 extern crate rand_package as rand;
+
+#[cfg(feature = "serde-serialize-no-std")]
+#[macro_use]
+extern crate serde;
 
 #[macro_use]
 extern crate approx;

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
@@ -11,9 +11,9 @@ use crate::geometry::Reflection;
 use crate::linalg::householder;
 
 /// The bidiagonalization of a general matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DimMinimum<R, C>: DimSub<U1>,
          DefaultAllocator: Allocator<T, R, C>             +
                            Allocator<T, DimMinimum<R, C>> +
@@ -23,7 +23,7 @@ use crate::linalg::householder;
          OVector<T, DimDiff<DimMinimum<R, C>, U1>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DimMinimum<R, C>: DimSub<U1>,
          DefaultAllocator: Allocator<T, R, C>             +
                            Allocator<T, DimMinimum<R, C>> +

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use num::One;
@@ -12,14 +12,14 @@ use crate::dimension::{Dim, DimAdd, DimDiff, DimSub, DimSum, U1};
 use crate::storage::{Storage, StorageMut};
 
 /// The Cholesky decomposition of a symmetric-definite-positive matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D>,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]

--- a/src/linalg/col_piv_qr.rs
+++ b/src/linalg/col_piv_qr.rs
@@ -1,5 +1,5 @@
 use num::Zero;
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::{Allocator, Reallocator};
@@ -13,9 +13,9 @@ use crate::geometry::Reflection;
 use crate::linalg::{householder, PermutationSequence};
 
 /// The QR decomposition (with column pivoting) of a general matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<T, DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
@@ -23,7 +23,7 @@ use crate::linalg::{householder, PermutationSequence};
          OVector<T, DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<T, DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,

--- a/src/linalg/eigen.rs
+++ b/src/linalg/eigen.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use num_complex::Complex;
@@ -20,15 +20,15 @@ use crate::linalg::householder;
 use crate::linalg::Schur;
 
 /// Eigendecomposition of a real matrix with real eigenvalues (or complex eigen values for complex matrices).
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D>,
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D>,
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Deserialize<'de>"))

--- a/src/linalg/full_piv_lu.rs
+++ b/src/linalg/full_piv_lu.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
@@ -12,16 +12,16 @@ use crate::linalg::lu;
 use crate::linalg::PermutationSequence;
 
 /// LU decomposition with full row and column pivoting.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<(usize, usize), DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<(usize, usize), DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
@@ -10,16 +10,16 @@ use simba::scalar::ComplexField;
 use crate::linalg::householder;
 
 /// Hessenberg decomposition of a general matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T, DimDiff<D, U1>>,
          OMatrix<T, D, D>: Serialize,
          OVector<T, DimDiff<D, U1>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T, DimDiff<D, U1>>,
          OMatrix<T, D, D>: Deserialize<'de>,

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::{Allocator, Reallocator};
@@ -12,16 +12,16 @@ use std::mem;
 use crate::linalg::PermutationSequence;
 
 /// LU decomposition with partial (row) pivoting.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<(usize, usize), DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<(usize, usize), DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use num::One;
@@ -12,14 +12,14 @@ use crate::dimension::{Const, Dim, DimName};
 use crate::storage::StorageMut;
 
 /// A sequence of row or column permutations.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<(usize, usize), D>,
          OVector<(usize, usize), D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<(usize, usize), D>,
          OVector<(usize, usize), D>: Deserialize<'de>"))
 )]

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -1,5 +1,5 @@
 use num::Zero;
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::{Allocator, Reallocator};
@@ -13,16 +13,16 @@ use crate::geometry::Reflection;
 use crate::linalg::householder;
 
 /// The QR decomposition of a general matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<T, DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          OVector<T, DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
                            Allocator<T, DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use approx::AbsDiffEq;
@@ -19,14 +19,14 @@ use crate::linalg::Hessenberg;
 /// Schur decomposition of a square matrix.
 ///
 /// If this is a real matrix, this will be a RealField Schur decomposition.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D>,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use approx::AbsDiffEq;
@@ -16,9 +16,9 @@ use crate::linalg::symmetric_eigen;
 use crate::linalg::Bidiagonal;
 
 /// Singular Value Decomposition of a general matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(
         serialize = "DefaultAllocator: Allocator<T::RealField, DimMinimum<R, C>>    +
                            Allocator<T, DimMinimum<R, C>, C> +
@@ -29,7 +29,7 @@ use crate::linalg::Bidiagonal;
     ))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(
         deserialize = "DefaultAllocator: Allocator<T::RealField, DimMinimum<R, C>>    +
                            Allocator<T, DimMinimum<R, C>, C> +

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use approx::AbsDiffEq;
@@ -14,16 +14,16 @@ use crate::linalg::givens::GivensRotation;
 use crate::linalg::SymmetricTridiagonal;
 
 /// Eigendecomposition of a symmetric matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T::RealField, D>,
          OVector<T::RealField, D>: Serialize,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T::RealField, D>,
          OVector<T::RealField, D>: Deserialize<'de>,

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
@@ -10,16 +10,16 @@ use simba::scalar::ComplexField;
 use crate::linalg::householder;
 
 /// Tridiagonalization of a symmetric matrix.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T, DimDiff<D, U1>>,
          OMatrix<T, D, D>: Serialize,
          OVector<T, DimDiff<D, U1>>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
                            Allocator<T, DimDiff<D, U1>>,
          OMatrix<T, D, D>: Deserialize<'de>,

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-serialize")]
+#[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
 use crate::allocator::Allocator;
@@ -8,13 +8,13 @@ use crate::storage::Storage;
 use simba::scalar::RealField;
 
 /// UDU factorization.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(serialize = "OVector<T, D>: Serialize, OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde-serialize",
+    feature = "serde-serialize-no-std",
     serde(bound(
         deserialize = "OVector<T, D>: Deserialize<'de>, OMatrix<T, D, D>: Deserialize<'de>"
     ))


### PR DESCRIPTION
- Don't enable `serde/std` by default.
- Add a `serde-serialize-no-std` feature to enable serde without its default features.

At first I wantetd to rename `serde-serialize` to just `serde`, just like I did with the `rand` dependency. However this doesn't work because of the way serde serives operate: https://github.com/serde-rs/serde/issues/953