### PR TITLE
CooMatrix::reserve added

### DIFF
--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -133,18 +133,18 @@ impl<T> CooMatrix<T> {
     /// Reserves capacity for COO matrix by at least `additional` elements.
     ///
     /// This increase the capacities of triplet holding arrays by reserving more space to avoid
-    /// frequent reallocations, in `push` operations.
+    /// frequent reallocations in `push` operations.
     ///
     /// ## Panics
     ///
-    /// Panics if any of the individual allocation of triplet arrays fail.
+    /// Panics if any of the individual allocation of triplet arrays fails.
     ///
     /// ## Example
     ///
     /// ```
     /// # use nalgebra_sparse::coo::CooMatrix;
     /// let mut coo = CooMatrix::new(4, 4);
-    /// // Reserver capacity in advance
+    /// // Reserve capacity in advance
     /// coo.reserve(10);
     /// coo.push(1, 0, 3.0);
     /// ```

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -130,6 +130,30 @@ impl<T> CooMatrix<T> {
             .map(|((i, j), v)| (*i, *j, v))
     }
 
+    /// Reserves capacity for COO matrix by at least `additional` elements.
+    ///
+    /// This increase the capacities of triplet holding arrays by reserving more space to avoid
+    /// frequent reallocations, in `push` operations.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if any of the individual allocation of triplet arrays fail.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use nalgebra_sparse::coo::CooMatrix;
+    /// let mut coo = CooMatrix::new(4, 4);
+    /// // Reserver capacity in advance
+    /// coo.reserve(10);
+    /// coo.push(1, 0, 3.0);
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.row_indices.reserve(additional);
+        self.col_indices.reserve(additional);
+        self.values.reserve(additional);
+    }
+
     /// Push a single triplet to the matrix.
     ///
     /// This adds the value `v` to the `i`th row and `j`th column in the matrix.


### PR DESCRIPTION
PR for  #881
- Added doc tests as well. 

Note: I've noticed missing doc-tests in some of the APIs. Can add them in future PRs if it helps the documentation.