### PR TITLE
Re-add conversion between arrays and row vectors.

### DIFF
--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -23,9 +23,9 @@ use crate::base::{
 use crate::base::{DVector, VecStorage};
 use crate::base::{SliceStorage, SliceStorageMut};
 use crate::constraint::DimEq;
-use crate::{SMatrix, SVector};
+use crate::{IsNotStaticOne, RowSVector, SMatrix, SVector};
 
-// TODO: too bad this won't work allo slice conversions.
+// TODO: too bad this won't work for slice conversions.
 impl<T1, T2, R1, C1, R2, C2> SubsetOf<OMatrix<T2, R2, C2>> for OMatrix<T1, R1, C1>
 where
     R1: Dim,
@@ -115,6 +115,26 @@ impl<T: Scalar, const D: usize> Into<[T; D]> for SVector<T, D> {
     fn into(self) -> [T; D] {
         // TODO: unfortunately, we must clone because we can move out of an array.
         self.data.0[0].clone()
+    }
+}
+
+impl<T: Scalar, const D: usize> From<[T; D]> for RowSVector<T, D>
+where
+    Const<D>: IsNotStaticOne,
+{
+    #[inline]
+    fn from(arr: [T; D]) -> Self {
+        SVector::<T, D>::from(arr).transpose()
+    }
+}
+
+impl<T: Scalar, const D: usize> Into<[T; D]> for RowSVector<T, D>
+where
+    Const<D>: IsNotStaticOne,
+{
+    #[inline]
+    fn into(self) -> [T; D] {
+        self.transpose().into()
     }
 }
 

--- a/tests/core/conversion.rs
+++ b/tests/core/conversion.rs
@@ -1,5 +1,4 @@
-#![cfg(all(feature = "proptest-support", feature = "alga"))]
-use alga::linear::Transformation;
+#![cfg(all(feature = "proptest-support"))]
 use na::{
     self, Affine3, Isometry3, Matrix2, Matrix2x3, Matrix2x4, Matrix2x5, Matrix2x6, Matrix3,
     Matrix3x2, Matrix3x4, Matrix3x5, Matrix3x6, Matrix4, Matrix4x2, Matrix4x3, Matrix4x5,
@@ -16,7 +15,7 @@ use proptest::{prop_assert, prop_assert_eq, proptest};
 
 proptest! {
     #[test]
-    fn translation_conversion(t in translation3(), v in vector3(), p in point3()) {
+    fn translation_conversion(t in translation3(), p in point3()) {
         let iso: Isometry3<f64>   = na::convert(t);
         let sim: Similarity3<f64> = na::convert(t);
         let aff: Affine3<f64>     = na::convert(t);
@@ -28,12 +27,6 @@ proptest! {
         prop_assert_eq!(t, na::try_convert(aff).unwrap());
         prop_assert_eq!(t, na::try_convert(prj).unwrap());
         prop_assert_eq!(t, na::try_convert(tr).unwrap() );
-
-        prop_assert_eq!(t.transform_vector(&v), iso * v);
-        prop_assert_eq!(t.transform_vector(&v), sim * v);
-        prop_assert_eq!(t.transform_vector(&v), aff * v);
-        prop_assert_eq!(t.transform_vector(&v), prj * v);
-        prop_assert_eq!(t.transform_vector(&v), tr  * v);
 
         prop_assert_eq!(t * p, iso * p);
         prop_assert_eq!(t * p, sim * p);


### PR DESCRIPTION
Looks like the conversion between row-vectors and `[T; D]` disappeared unexpectedly in one of the recent `nalgebra` releases.
This PRs re-adds them.