### PR TITLE
Add partial `rkyv` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
 abomonation    = { version = "0.7", optional = true }
-rkyv           = { version = "~0.6.3", default-features = false, features = ["const_generics"], optional = true }
+rkyv           = { version = "~0.6.4", default-features = false, features = ["const_generics"], optional = true }
 mint           = { version = "0.5", optional = true }
 glam           = { version = "0.13", optional = true }
 quickcheck     = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ convert-bytemuck = [ "bytemuck" ]
 serde-serialize-no-std = [ "serde", "num-complex/serde" ]
 serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
 abomonation-serialize  = [ "abomonation" ]
+rkyv-serialize-no-std  = [ "rkyv" ]
+rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std" ]
 
 # Randomness
 ## To use rand in a #[no-std] environment, enable the
@@ -74,6 +76,7 @@ rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
 abomonation    = { version = "0.7", optional = true }
+rkyv           = { version = "~0.6.3", default-features = false, features = ["const_generics"], optional = true }
 mint           = { version = "0.5", optional = true }
 glam           = { version = "0.13", optional = true }
 quickcheck     = { version = "1", optional = true }
@@ -81,7 +84,7 @@ pest           = { version = "2", optional = true }
 pest_derive    = { version = "2", optional = true }
 bytemuck       = { version = "1.5", optional = true }
 matrixcompare-core = { version = "0.1", optional = true }
-proptest = { version = "1", optional = true, default-features = false, features = ["std"] }
+proptest           = { version = "1", optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -18,6 +18,9 @@ use std::mem;
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
 use crate::base::dimension::{Const, ToTypenum};
@@ -34,6 +37,7 @@ use crate::base::Scalar;
 /// A array-based statically sized matrix data storage.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct ArrayStorage<T, const R: usize, const C: usize>(pub [[T; R]; C]);
 
 // TODO: remove this once the stdlib implements Default for arrays.

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -11,6 +11,9 @@ use typenum::{self, Diff, Max, Maximum, Min, Minimum, Prod, Quot, Sum, Unsigned}
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 /// Dim of dynamically-sized algebraic entities.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Dynamic {
@@ -197,6 +200,7 @@ dim_ops!(
 );
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Const<const R: usize>;
 
 /// Trait implemented exclusively by type-level integers.

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -200,7 +200,6 @@ dim_ops!(
 );
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Const<const R: usize>;
 
 /// Trait implemented exclusively by type-level integers.
@@ -232,6 +231,29 @@ impl<'de, const D: usize> Deserialize<'de> for Const<D> {
         Des: Deserializer<'de>,
     {
         <()>::deserialize(deserializer).map(|_| Const::<D>)
+    }
+}
+
+#[cfg(feature = "rkyv-serialize-no-std")]
+impl<const R: usize> Archive for Const<R> {
+    type Archived = Self;
+    type Resolver = ();
+
+    fn resolve(&self, _: usize, _: Self::Resolver, _: &mut core::mem::MaybeUninit<Self::Archived>) {
+    }
+}
+
+#[cfg(feature = "rkyv-serialize-no-std")]
+impl<S: rkyv::Fallible + ?Sized, const R: usize> Serialize<S> for Const<R> {
+    fn serialize(&self, _: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "rkyv-serialize-no-std")]
+impl<D: rkyv::Fallible + ?Sized, const R: usize> Deserialize<Self, D> for Const<R> {
+    fn deserialize(&self, _: &mut D) -> Result<Self, D::Error> {
+        Ok(Const)
     }
 }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -16,6 +16,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 use simba::scalar::{ClosedAdd, ClosedMul, ClosedSub, Field, SupersetOf};
 use simba::simd::SimdPartialOrd;
 
@@ -153,6 +156,7 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// some concrete types for `T` and a compatible data storage type `S`).
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Matrix<T, R, C, S> {
     /// The data storage that contains all the matrix components. Disappointed?
     ///

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -6,6 +6,9 @@ use std::ops::Deref;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
@@ -26,6 +29,7 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
 #[derive(Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Unit<T> {
     pub(crate) value: T,
 }

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -7,6 +7,9 @@ use std::io::{Result as IOResult, Write};
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
@@ -68,6 +71,7 @@ use crate::geometry::{AbstractRotation, Point, Translation};
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Serialize, Deserialize))]
 pub struct Isometry<T: Scalar, R, const D: usize> {
     /// The pure rotational part of this isometry.
     pub rotation: R,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -10,6 +10,9 @@ use crate::base::storage::Owned;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
@@ -28,6 +31,7 @@ use crate::geometry::{Point3, Rotation};
 /// that may be used as a rotation.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Quaternion<T> {
     /// This quaternion as a 4D vector of coordinates in the `[ x, y, z, w ]` storage order.
     pub coords: Vector4<T>,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -10,9 +10,6 @@ use crate::base::storage::Owned;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "rkyv-serialize-no-std")]
-use rkyv::{Archive, Deserialize, Serialize};
-
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
@@ -117,35 +114,44 @@ where
 }
 
 #[cfg(feature = "rkyv-serialize-no-std")]
-impl<T: Archive> Archive for Quaternion<T> {
-    type Archived = Quaternion<T::Archived>;
-    type Resolver = <Vector4<T> as Archive>::Resolver;
+mod rkyv_impl {
+    use super::Quaternion;
+    use crate::base::Vector4;
+    use rkyv::{offset_of, project_struct, Archive, Deserialize, Fallible, Serialize};
 
-    fn resolve(&self, pos: usize, resolver: Self::Resolver, out: &mut core::mem::MaybeUninit<Self::Archived>) {
-        self.coords.resolve(
-            pos + rkyv::offset_of!(Self::Archived, coords),
-            resolver,
-            rkyv::project_struct!(out: Self::Archived => coords)
-        );
+    impl<T: Archive> Archive for Quaternion<T> {
+        type Archived = Quaternion<T::Archived>;
+        type Resolver = <Vector4<T> as Archive>::Resolver;
+
+        fn resolve(
+            &self,
+            pos: usize,
+            resolver: Self::Resolver,
+            out: &mut core::mem::MaybeUninit<Self::Archived>,
+        ) {
+            self.coords.resolve(
+                pos + offset_of!(Self::Archived, coords),
+                resolver,
+                project_struct!(out: Self::Archived => coords),
+            );
+        }
     }
-}
 
-#[cfg(feature = "rkyv-serialize-no-std")]
-impl<T: Serialize<S>, S: rkyv::Fallible + ?Sized> Serialize<S> for Quaternion<T> {
-    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
-        Ok(self.coords.serialize(serializer)?)
+    impl<T: Serialize<S>, S: Fallible + ?Sized> Serialize<S> for Quaternion<T> {
+        fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+            Ok(self.coords.serialize(serializer)?)
+        }
     }
-}
 
-#[cfg(feature = "rkyv-serialize-no-std")]
-impl<T: Archive, D: rkyv::Fallible + ?Sized> Deserialize<Quaternion<T>, D> for Quaternion<T::Archived>
-where
-    T::Archived: Deserialize<T, D>,
-{
-    fn deserialize(&self, deserializer: &mut D) -> Result<Quaternion<T>, D::Error> {
-        Ok(Quaternion {
-            coords: self.coords.deserialize(deserializer)?,
-        })
+    impl<T: Archive, D: Fallible + ?Sized> Deserialize<Quaternion<T>, D> for Quaternion<T::Archived>
+    where
+        T::Archived: Deserialize<T, D>,
+    {
+        fn deserialize(&self, deserializer: &mut D) -> Result<Quaternion<T>, D::Error> {
+            Ok(Quaternion {
+                coords: self.coords.deserialize(deserializer)?,
+            })
+        }
     }
 }
 

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -8,6 +8,9 @@ use std::io::{Result as IOResult, Write};
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "rkyv-serialize-no-std")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "abomonation-serialize")]
 use abomonation::Abomonation;
 
@@ -23,6 +26,7 @@ use crate::geometry::Point;
 /// A translation.
 #[repr(C)]
 #[derive(Debug)]
+#[cfg_attr(feature = "rkyv-serialize-no-std", derive(Archive, Deserialize, Serialize))]
 pub struct Translation<T, const D: usize> {
     /// The translation coordinates, i.e., how much is added to a point's coordinates when it is
     /// translated.


### PR DESCRIPTION
This should get nalgebra support started off. It's still missing support for all types as well as tests, but it does have distributive archived types so no logic needs to get rewritten.