### PR TITLE
Update matrixcompare version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ rand_isaac = "0.3"
 criterion = "0.2.10"
 
 # For matrix comparison macro
-matrixcompare = "0.2.0"
+matrixcompare = "0.3.0"
 itertools = "0.10"
 
 [workspace]

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -27,7 +27,7 @@ matrixcompare-core = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.10"
-matrixcompare = { version = "0.2.0", features = [ "proptest-support" ] }
+matrixcompare = { version = "0.3.0", features = [ "proptest-support" ] }
 nalgebra = { version="0.26", path = "../", features = ["compare"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Fixes some warnings produced by earlier versions since Rust 1.51.
See https://github.com/Andlon/matrixcompare/pull/5 for more details.

Note that we only update dev-dependencies, so there is no API breakage.