### PR TITLE
Update the glam 0.14 optional dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde          = { version = "1.0", default-features = false, features = [ "deri
 abomonation    = { version = "0.7", optional = true }
 rkyv           = { version = "~0.6.4", default-features = false, features = ["const_generics"], optional = true }
 mint           = { version = "0.5", optional = true }
-glam           = { version = "0.13", optional = true }
+glam           = { version = "0.14", optional = true }
 quickcheck     = { version = "1", optional = true }
 pest           = { version = "2", optional = true }
 pest_derive    = { version = "2", optional = true }


### PR DESCRIPTION
Update `glam` to its version 0.14. I'll merge this at the end of this month since this is considered a breaking change.