### PR TITLE
Add push_matrix fcn to COO

### DIFF
--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -93,6 +93,9 @@
 //! coo.push(1, 2, 1.3);
 //! coo.push(2, 2, 4.1);
 //!
+//! // ... or add entire dense matrices like so:
+//! // coo.push_matrix(0, 0, &dense);
+//!
 //! // The simplest way to construct a CSR matrix is to first construct a COO matrix, and
 //! // then convert it to CSR. The `From` trait is implemented for conversions between different
 //! // sparse matrix types.


### PR DESCRIPTION
This MR adds a function which allow entire dense matrices to be pushed into a COO matrix. 

I wrote unit tests, but I haven't actually used it enough to recommend merging yet. I'm just hoping for any initial feedback.