### PR TITLE
Fix potential undoundness with Storage::as_slice and StorageMut::as_mut_slice

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -79,7 +79,7 @@ where
     }
 
     #[inline]
-    fn is_contiguous(&self) -> bool {
+    unsafe fn is_contiguous(&self) -> bool {
         true
     }
 
@@ -101,8 +101,8 @@ where
     }
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        unsafe { std::slice::from_raw_parts(self.ptr(), R * C) }
+    unsafe fn as_slice_unchecked(&self) -> &[T] {
+        std::slice::from_raw_parts(self.ptr(), R * C)
     }
 }
 
@@ -118,8 +118,8 @@ where
     }
 
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr_mut(), R * C) }
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
+        std::slice::from_raw_parts_mut(self.ptr_mut(), R * C)
     }
 }
 

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -341,13 +341,17 @@ where
         let rstride1 = self.strides().0;
         let rstride2 = x.strides().0;
 
-        let y = self.data.as_mut_slice();
-        let x = x.data.as_slice();
+        unsafe {
+            // SAFETY: the conversion to slices is OK because we access the
+            //         elements taking the strides into account.
+            let y = self.data.as_mut_slice_unchecked();
+            let x = x.data.as_slice_unchecked();
 
-        if !b.is_zero() {
-            array_axcpy(y, a, x, c, b, rstride1, rstride2, x.len());
-        } else {
-            array_axc(y, a, x, c, rstride1, rstride2, x.len());
+            if !b.is_zero() {
+                array_axcpy(y, a, x, c, b, rstride1, rstride2, x.len());
+            } else {
+                array_axc(y, a, x, c, rstride1, rstride2, x.len());
+            }
         }
     }
 

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -16,7 +16,7 @@ use crate::base::array_storage::ArrayStorage;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::base::dimension::Dynamic;
 use crate::base::dimension::{Dim, DimName};
-use crate::base::storage::{Storage, StorageMut};
+use crate::base::storage::{ContiguousStorageMut, Storage, StorageMut};
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::base::vec_storage::VecStorage;
 use crate::base::Scalar;

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -11,7 +11,7 @@ use crate::base::constraint::{DimEq, SameNumberOfColumns, SameNumberOfRows, Shap
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::base::dimension::Dynamic;
 use crate::base::dimension::{Const, Dim, DimAdd, DimDiff, DimMin, DimMinimum, DimSub, DimSum, U1};
-use crate::base::storage::{ReshapableStorage, Storage, StorageMut};
+use crate::base::storage::{ContiguousStorageMut, ReshapableStorage, Storage, StorageMut};
 use crate::base::{DefaultAllocator, Matrix, OMatrix, RowVector, Scalar, Vector};
 
 /// # Rows and columns extraction

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -132,7 +132,7 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-            fn is_contiguous(&self) -> bool {
+            unsafe fn is_contiguous(&self) -> bool {
                 // Common cases that can be deduced at compile-time even if one of the dimensions
                 // is Dynamic.
                 if (RStride::is::<U1>() && C::is::<U1>()) || // Column vector.
@@ -162,14 +162,14 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-            fn as_slice(&self) -> &[T] {
+            unsafe fn as_slice_unchecked(&self) -> &[T] {
                 let (nrows, ncols) = self.shape();
                 if nrows.value() != 0 && ncols.value() != 0 {
                     let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
-                    unsafe { slice::from_raw_parts(self.ptr, sz + 1) }
+                    slice::from_raw_parts(self.ptr, sz + 1)
                 }
                 else {
-                    unsafe { slice::from_raw_parts(self.ptr, 0) }
+                    slice::from_raw_parts(self.ptr, 0)
                 }
             }
         }
@@ -187,13 +187,13 @@ unsafe impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> StorageMu
     }
 
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
         let (nrows, ncols) = self.shape();
         if nrows.value() != 0 && ncols.value() != 0 {
             let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
-            unsafe { slice::from_raw_parts_mut(self.ptr, sz + 1) }
+            slice::from_raw_parts_mut(self.ptr, sz + 1)
         } else {
-            unsafe { slice::from_raw_parts_mut(self.ptr, 0) }
+            slice::from_raw_parts_mut(self.ptr, 0)
         }
     }
 }

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -158,20 +158,17 @@ macro_rules! componentwise_binop_impl(
 
                 // This is the most common case and should be deduced at compile-time.
                 // TODO: use specialization instead?
-                if self.data.is_contiguous() && rhs.data.is_contiguous() && out.data.is_contiguous() {
-                    let arr1 = self.data.as_slice();
-                    let arr2 = rhs.data.as_slice();
-                    let out  = out.data.as_mut_slice();
-                    for i in 0 .. arr1.len() {
-                        unsafe {
+                unsafe {
+                    if self.data.is_contiguous() && rhs.data.is_contiguous() && out.data.is_contiguous() {
+                        let arr1 = self.data.as_slice_unchecked();
+                        let arr2 = rhs.data.as_slice_unchecked();
+                        let out  = out.data.as_mut_slice_unchecked();
+                        for i in 0 .. arr1.len() {
                             *out.get_unchecked_mut(i) = arr1.get_unchecked(i).inlined_clone().$method(arr2.get_unchecked(i).inlined_clone());
                         }
-                    }
-                }
-                else {
-                    for j in 0 .. self.ncols() {
-                        for i in 0 .. self.nrows() {
-                            unsafe {
+                    } else {
+                        for j in 0 .. self.ncols() {
+                            for i in 0 .. self.nrows() {
                                 let val = self.get_unchecked((i, j)).inlined_clone().$method(rhs.get_unchecked((i, j)).inlined_clone());
                                 *out.get_unchecked_mut((i, j)) = val;
                             }
@@ -191,19 +188,17 @@ macro_rules! componentwise_binop_impl(
 
                 // This is the most common case and should be deduced at compile-time.
                 // TODO: use specialization instead?
-                if self.data.is_contiguous() && rhs.data.is_contiguous() {
-                    let arr1 = self.data.as_mut_slice();
-                    let arr2 = rhs.data.as_slice();
-                    for i in 0 .. arr2.len() {
-                        unsafe {
+                unsafe {
+                    if self.data.is_contiguous() && rhs.data.is_contiguous() {
+                        let arr1 = self.data.as_mut_slice_unchecked();
+                        let arr2 = rhs.data.as_slice_unchecked();
+
+                        for i in 0 .. arr2.len() {
                             arr1.get_unchecked_mut(i).$method_assign(arr2.get_unchecked(i).inlined_clone());
                         }
-                    }
-                }
-                else {
-                    for j in 0 .. rhs.ncols() {
-                        for i in 0 .. rhs.nrows() {
-                            unsafe {
+                    } else {
+                        for j in 0 .. rhs.ncols() {
+                            for i in 0 .. rhs.nrows() {
                                 self.get_unchecked_mut((i, j)).$method_assign(rhs.get_unchecked((i, j)).inlined_clone())
                             }
                         }
@@ -221,20 +216,18 @@ macro_rules! componentwise_binop_impl(
 
                 // This is the most common case and should be deduced at compile-time.
                 // TODO: use specialization instead?
-                if self.data.is_contiguous() && rhs.data.is_contiguous() {
-                    let arr1 = self.data.as_slice();
-                    let arr2 = rhs.data.as_mut_slice();
-                    for i in 0 .. arr1.len() {
-                        unsafe {
+                unsafe {
+                    if self.data.is_contiguous() && rhs.data.is_contiguous() {
+                        let arr1 = self.data.as_slice_unchecked();
+                        let arr2 = rhs.data.as_mut_slice_unchecked();
+
+                        for i in 0 .. arr1.len() {
                             let res = arr1.get_unchecked(i).inlined_clone().$method(arr2.get_unchecked(i).inlined_clone());
                             *arr2.get_unchecked_mut(i) = res;
                         }
-                    }
-                }
-                else {
-                    for j in 0 .. self.ncols() {
-                        for i in 0 .. self.nrows() {
-                            unsafe {
+                    } else {
+                        for j in 0 .. self.ncols() {
+                            for i in 0 .. self.nrows() {
                                 let r = rhs.get_unchecked_mut((i, j));
                                 *r = self.get_unchecked((i, j)).inlined_clone().$method(r.inlined_clone())
                             }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -175,7 +175,7 @@ where
     }
 
     #[inline]
-    fn is_contiguous(&self) -> bool {
+    unsafe fn is_contiguous(&self) -> bool {
         true
     }
 
@@ -196,7 +196,7 @@ where
     }
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
+    unsafe fn as_slice_unchecked(&self) -> &[T] {
         &self.data
     }
 }
@@ -224,7 +224,7 @@ where
     }
 
     #[inline]
-    fn is_contiguous(&self) -> bool {
+    unsafe fn is_contiguous(&self) -> bool {
         true
     }
 
@@ -245,7 +245,7 @@ where
     }
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
+    unsafe fn as_slice_unchecked(&self) -> &[T] {
         &self.data
     }
 }
@@ -265,7 +265,7 @@ where
     }
 
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
         &mut self.data[..]
     }
 }
@@ -326,7 +326,7 @@ where
     }
 
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
         &mut self.data[..]
     }
 }

--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -127,7 +127,7 @@ fn do_inverse4<T: ComplexField, D: Dim, S: StorageMut<T, D, D>>(
 where
     DefaultAllocator: Allocator<T, D, D>,
 {
-    let m = m.data.as_slice();
+    let m = m.as_slice();
 
     out[(0, 0)] = m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15]
         + m[9] * m[7] * m[14]


### PR DESCRIPTION
Fix #828 

- Add the safe methods: `ContiguousStorage::as_slice` and `ContiguousStorage::as_mut_slice`.
- The trait methods: `Storage::as_slice`, `StorageMut::as_mut_slice` have been renamed to `Storage::as_slice_unchecked` and `StorageMut::as_mut_slice_unchecked` and are marked as `unsafe`.
- The trait method `Storage::is_contiguous` is now marked as `unsafe`.

Not marking them as `unsafe` was invalid because they could result in invalid aliasing when calling `as_mut_slice` on two matrix slices obtained from the same matrix, but with overlapping (but non-contiguous) internal storage. For example, the following was allowed, but is actually unsound:

```rust
let (mut slice1, mut slice2) = matrix.rows_range_pair_mut(0, 1)
// Unsound because both mutable references point to the same element.
some_function(&mut slice1.data.as_mut_slice[1], &mut slice2.data.as_mut_slice[0]);
```