### PR TITLE
Change `Result<(), ()>` return type into `bool`

### DIFF
--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo};
 use std::slice;
 
 use crate::base::allocator::Allocator;
@@ -803,6 +803,25 @@ impl<D: Dim> SliceRange<D> for RangeFull {
     #[inline(always)]
     fn size(&self, dim: D) -> Self::Size {
         dim
+    }
+}
+
+impl<D: Dim> SliceRange<D> for RangeInclusive<usize> {
+    type Size = Dynamic;
+
+    #[inline(always)]
+    fn begin(&self, _: D) -> usize {
+        *self.start()
+    }
+
+    #[inline(always)]
+    fn end(&self, _: D) -> usize {
+        *self.end() + 1
+    }
+
+    #[inline(always)]
+    fn size(&self, _: D) -> Self::Size {
+        Dynamic::new(*self.end() + 1 - *self.start())
     }
 }
 

--- a/src/linalg/pow.rs
+++ b/src/linalg/pow.rs
@@ -18,23 +18,22 @@ where
 {
     /// Attempts to raise this matrix to an integral power `e` in-place. If this
     /// matrix is non-invertible and `e` is negative, it leaves this matrix
-    /// untouched and returns `Err(())`. Otherwise, it returns `Ok(())` and
+    /// untouched and returns `false`. Otherwise, it returns `true` and
     /// overwrites this matrix with the result.
-    #[must_use]
-    pub fn pow_mut<I: PrimInt + DivAssign>(&mut self, mut e: I) -> Result<(), ()> {
+    pub fn pow_mut<I: PrimInt + DivAssign>(&mut self, mut e: I) -> bool {
         let zero = I::zero();
 
         // A matrix raised to the zeroth power is just the identity.
         if e == zero {
             self.fill_with_identity();
-            return Ok(());
+            return true;
         }
 
         // If e is negative, we compute the inverse matrix, then raise it to the
         // power of -e.
         if e < zero {
             if !self.try_inverse_mut() {
-                return Err(());
+                return false;
             }
         }
 
@@ -58,7 +57,7 @@ where
             multiplier.copy_from(&buf);
 
             if e == zero {
-                return Ok(());
+                return true;
             }
         }
     }
@@ -77,9 +76,10 @@ where
     pub fn pow<I: PrimInt + DivAssign>(&self, e: I) -> Option<OMatrix<T, D, D>> {
         let mut clone = self.clone_owned();
 
-        match clone.pow_mut(e) {
-            Ok(()) => Some(clone),
-            Err(()) => None,
+        if clone.pow_mut(e) {
+            Some(clone)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
All other methods in `nalgebra` that mutate an argument and may possibly fail, return a boolean. Furthermore, ever since writing the pow code I've learned that it's actually bad practice to use unit structs as error types. 

This change would be breaking.