### PR TITLE
`Result<(), ()>` to `bool`

### DIFF
--- a/src/linalg/pow.rs
+++ b/src/linalg/pow.rs
@@ -18,23 +18,22 @@ where
 {
     /// Attempts to raise this matrix to an integral power `e` in-place. If this
     /// matrix is non-invertible and `e` is negative, it leaves this matrix
-    /// untouched and returns `Err(())`. Otherwise, it returns `Ok(())` and
+    /// untouched and returns `false`. Otherwise, it returns `true` and
     /// overwrites this matrix with the result.
-    #[must_use]
-    pub fn pow_mut<I: PrimInt + DivAssign>(&mut self, mut e: I) -> Result<(), ()> {
+    pub fn pow_mut<I: PrimInt + DivAssign>(&mut self, mut e: I) -> bool {
         let zero = I::zero();
 
         // A matrix raised to the zeroth power is just the identity.
         if e == zero {
             self.fill_with_identity();
-            return Ok(());
+            return true;
         }
 
         // If e is negative, we compute the inverse matrix, then raise it to the
         // power of -e.
         if e < zero {
             if !self.try_inverse_mut() {
-                return Err(());
+                return false;
             }
         }
 
@@ -58,7 +57,7 @@ where
             multiplier.copy_from(&buf);
 
             if e == zero {
-                return Ok(());
+                return true;
             }
         }
     }
@@ -77,9 +76,10 @@ where
     pub fn pow<I: PrimInt + DivAssign>(&self, e: I) -> Option<OMatrix<T, D, D>> {
         let mut clone = self.clone_owned();
 
-        match clone.pow_mut(e) {
-            Ok(()) => Some(clone),
-            Err(()) => None,
+        if clone.pow_mut(e) {
+            Some(clone)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
All other methods in `nalgebra` that mutate an argument and may possibly fail, return a boolean. Furthermore, ever since writing the pow code I've learned that it's actually bad practice to use unit structs as error types. 

This change would be breaking.