### PR TITLE
Allow to extract the inner slices of SliceStorage

### DIFF
--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -452,10 +452,22 @@ impl<'a, T: Scalar + Copy> From<&'a [T]> for DVectorSlice<'a, T> {
     }
 }
 
+impl<'a, T: Scalar> From<DVectorSlice<'a, T>> for &'a [T] {
+    fn from(vec: DVectorSlice<'a, T>) -> &'a [T] {
+        vec.data.into_slice()
+    }
+}
+
 impl<'a, T: Scalar + Copy> From<&'a mut [T]> for DVectorSliceMut<'a, T> {
     #[inline]
     fn from(slice: &'a mut [T]) -> Self {
         Self::from_slice(slice, slice.len())
+    }
+}
+
+impl<'a, T: Scalar> From<DVectorSliceMut<'a, T>> for &'a mut [T] {
+    fn from(vec: DVectorSliceMut<'a, T>) -> &'a mut [T] {
+        vec.data.into_slice_mut()
     }
 }
 

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -80,6 +80,8 @@ macro_rules! slice_storage_impl(
 
         impl <'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
             $T<'a, T, R, C, RStride, CStride>
+        where
+            Self: ContiguousStorage<T, R, C>
         {
             /// Extracts the original slice from this storage
             pub fn into_slice(self) -> &'a [T] {
@@ -125,6 +127,8 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> Clone
 
 impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     SliceStorageMut<'a, T, R, C, RStride, CStride>
+where
+    Self: ContiguousStorageMut<T, R, C>,
 {
     /// Extracts the original slice from this storage
     pub fn into_slice_mut(self) -> &'a mut [T] {

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -77,6 +77,21 @@ macro_rules! slice_storage_impl(
                 $T::from_raw_parts(storage.$get_addr(start.0, start.1), shape, strides)
             }
         }
+
+        impl <'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
+            $T<'a, T, R, C, RStride, CStride>
+        {
+            /// Extracts the original slice from this storage
+            pub fn into_slice(self) -> &'a [T] {
+                let (nrows, ncols) = self.shape();
+                if nrows.value() != 0 && ncols.value() != 0 {
+                    let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
+                    unsafe { slice::from_raw_parts(self.ptr, sz + 1) }
+                } else {
+                    unsafe { slice::from_raw_parts(self.ptr, 0) }
+                }
+            }
+        }
     }
 );
 
@@ -104,6 +119,21 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> Clone
             shape: self.shape,
             strides: self.strides,
             _phantoms: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
+    SliceStorageMut<'a, T, R, C, RStride, CStride>
+{
+    /// Extracts the original slice from this storage
+    pub fn into_slice_mut(self) -> &'a mut [T] {
+        let (nrows, ncols) = self.shape();
+        if nrows.value() != 0 && ncols.value() != 0 {
+            let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
+            unsafe { slice::from_raw_parts_mut(self.ptr, sz + 1) }
+        } else {
+            unsafe { slice::from_raw_parts_mut(self.ptr, 0) }
         }
     }
 }


### PR DESCRIPTION
This PR adds an inherent `into_slice` and `into_slice_mut` method to `SliceStorage` and `SliceStorageMut` (the latter gets both). Also, to complement the `From` impls which convert slices to `DVectorSlice` and `DVectorSliceMut`, this PR adds corresponding `From` impls to convert back to the respective slice type.

The implementation is essentially a generalization of [`as_mut_slice_unchecked`](https://github.com/dimforge/nalgebra/blob/38add0b00df2bfba89b8e753e7cb16fcf4ae93c3/src/base/matrix_slice.rs#L190-L198). I just noticed https://github.com/dimforge/nalgebra/pull/905, I'm not sure how this relates to this new functions, but I guess they should be not affected because they consume the respective storage struct entirely.

This would implement #920

_From a consistency point of view, I wonder whether it would make sense to also add an analog method to `VecStorage`._