### PR TITLE
Impl bytemuck traits for geometry types

### DIFF
--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -242,10 +242,20 @@ where
 }
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Zeroable for DualQuaternion<T> where Quaternion<T>: bytemuck::Zeroable {}
+unsafe impl<T> bytemuck::Zeroable for DualQuaternion<T>
+where
+    T: Scalar + bytemuck::Zeroable,
+    Quaternion<T>: bytemuck::Zeroable,
+{
+}
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Pod for DualQuaternion<T> where Quaternion<T>: bytemuck::Pod {}
+unsafe impl<T> bytemuck::Pod for DualQuaternion<T>
+where
+    T: Scalar + bytemuck::Pod,
+    Quaternion<T>: bytemuck::Pod,
+{
+}
 
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: SimdRealField> Serialize for DualQuaternion<T>

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -241,6 +241,12 @@ where
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Zeroable for DualQuaternion<T> where Quaternion<T>: bytemuck::Zeroable {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Pod for DualQuaternion<T> where Quaternion<T>: bytemuck::Pod {}
+
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: SimdRealField> Serialize for DualQuaternion<T>
 where

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -44,6 +44,12 @@ impl<T: RealField> PartialEq for Orthographic3<T> {
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Zeroable for Orthographic3<T> where Matrix4<T>: bytemuck::Zeroable {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Pod for Orthographic3<T> where Matrix4<T>: bytemuck::Pod {}
+
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Orthographic3<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -18,6 +18,7 @@ use crate::base::{Matrix4, Vector, Vector3};
 use crate::geometry::{Point3, Projective3};
 
 /// A 3D orthographic projection stored as a homogeneous 4x4 matrix.
+#[repr(C)]
 pub struct Orthographic3<T: RealField> {
     matrix: Matrix4<T>,
 }

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -46,10 +46,20 @@ impl<T: RealField> PartialEq for Orthographic3<T> {
 }
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Zeroable for Orthographic3<T> where Matrix4<T>: bytemuck::Zeroable {}
+unsafe impl<T> bytemuck::Zeroable for Orthographic3<T>
+where
+    T: RealField + bytemuck::Zeroable,
+    Matrix4<T>: bytemuck::Zeroable,
+{
+}
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Pod for Orthographic3<T> where Matrix4<T>: bytemuck::Pod {}
+unsafe impl<T> bytemuck::Pod for Orthographic3<T>
+where
+    T: RealField + bytemuck::Pod,
+    Matrix4<T>: bytemuck::Pod,
+{
+}
 
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Orthographic3<T> {

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -19,6 +19,7 @@ use crate::base::{Matrix4, Scalar, Vector, Vector3};
 use crate::geometry::{Point3, Projective3};
 
 /// A 3D perspective projection stored as a homogeneous 4x4 matrix.
+#[repr(C)]
 pub struct Perspective3<T: Scalar> {
     matrix: Matrix4<T>,
 }

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -47,10 +47,20 @@ impl<T: RealField> PartialEq for Perspective3<T> {
 }
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Zeroable for Perspective3<T> where Matrix4<T>: bytemuck::Zeroable {}
+unsafe impl<T> bytemuck::Zeroable for Perspective3<T>
+where
+    T: RealField + bytemuck::Zeroable,
+    Matrix4<T>: bytemuck::Zeroable,
+{
+}
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T> bytemuck::Pod for Perspective3<T> where Matrix4<T>: bytemuck::Pod {}
+unsafe impl<T> bytemuck::Pod for Perspective3<T>
+where
+    T: RealField + bytemuck::Pod,
+    Matrix4<T>: bytemuck::Pod,
+{
+}
 
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Perspective3<T> {

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -45,6 +45,12 @@ impl<T: RealField> PartialEq for Perspective3<T> {
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Zeroable for Perspective3<T> where Matrix4<T>: bytemuck::Zeroable {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Pod for Perspective3<T> where Matrix4<T>: bytemuck::Pod {}
+
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField + Serialize> Serialize for Perspective3<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -86,7 +86,7 @@ where
 #[cfg(feature = "bytemuck")]
 unsafe impl<T, const D: usize> bytemuck::Zeroable for Rotation<T, D>
 where
-    T: Scalar,
+    T: Scalar + bytemuck::Zeroable,
     SMatrix<T, D, D>: bytemuck::Zeroable,
 {
 }
@@ -94,7 +94,7 @@ where
 #[cfg(feature = "bytemuck")]
 unsafe impl<T, const D: usize> bytemuck::Pod for Rotation<T, D>
 where
-    T: Scalar,
+    T: Scalar + bytemuck::Pod,
     SMatrix<T, D, D>: bytemuck::Pod,
 {
 }

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -83,6 +83,22 @@ where
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, const D: usize> bytemuck::Zeroable for Rotation<T, D>
+where
+    T: Scalar,
+    SMatrix<T, D, D>: bytemuck::Zeroable,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, const D: usize> bytemuck::Pod for Rotation<T, D>
+where
+    T: Scalar,
+    SMatrix<T, D, D>: bytemuck::Pod,
+{
+}
+
 #[cfg(feature = "abomonation-serialize")]
 impl<T, const D: usize> Abomonation for Rotation<T, D>
 where

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -195,8 +195,9 @@ where
 }
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T: RealField, C: TCategory, const D: usize> bytemuck::Zeroable for Transform<T, C, D>
+unsafe impl<T, C: TCategory, const D: usize> bytemuck::Zeroable for Transform<T, C, D>
 where
+    T: RealField + bytemuck::Zeroable,
     Const<D>: DimNameAdd<U1>,
     DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Zeroable,
@@ -204,11 +205,13 @@ where
 }
 
 #[cfg(feature = "bytemuck")]
-unsafe impl<T: RealField, C: TCategory, const D: usize> bytemuck::Pod for Transform<T, C, D>
+unsafe impl<T, C: TCategory, const D: usize> bytemuck::Pod for Transform<T, C, D>
 where
+    T: RealField + bytemuck::Pod,
     Const<D>: DimNameAdd<U1>,
     DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Pod,
+    Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: Copy,
 {
 }
 

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -194,6 +194,24 @@ where
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: RealField, C: TCategory, const D: usize> bytemuck::Zeroable for Transform<T, C, D>
+where
+    Const<D>: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Zeroable,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: RealField, C: TCategory, const D: usize> bytemuck::Pod for Transform<T, C, D>
+where
+    Const<D>: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Pod,
+{
+}
+
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: RealField, C: TCategory, const D: usize> Serialize for Transform<T, C, D>
 where

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -53,7 +53,7 @@ where
 #[cfg(feature = "bytemuck")]
 unsafe impl<T, const D: usize> bytemuck::Zeroable for Translation<T, D>
 where
-    T: Scalar,
+    T: Scalar + bytemuck::Zeroable,
     SVector<T, D>: bytemuck::Zeroable,
 {
 }
@@ -61,7 +61,7 @@ where
 #[cfg(feature = "bytemuck")]
 unsafe impl<T, const D: usize> bytemuck::Pod for Translation<T, D>
 where
-    T: Scalar,
+    T: Scalar + bytemuck::Pod,
     SVector<T, D>: bytemuck::Pod,
 {
 }

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -50,6 +50,22 @@ where
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, const D: usize> bytemuck::Zeroable for Translation<T, D>
+where
+    T: Scalar,
+    SVector<T, D>: bytemuck::Zeroable,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, const D: usize> bytemuck::Pod for Translation<T, D>
+where
+    T: Scalar,
+    SVector<T, D>: bytemuck::Pod,
+{
+}
+
 #[cfg(feature = "abomonation-serialize")]
 impl<T, const D: usize> Abomonation for Translation<T, D>
 where


### PR DESCRIPTION
Adds impls for `bytemuck::Zeroable` and `bytemuck::Pod` to the `na::geometry::*` types that don't already have them. All added impls just fully gate themselves on the fields' impls for these traits, so they should all be sound, unless I missed one of the following conditions:

- The type has invalid values (semantically, in which case the traits shouldn't be impl'd); or
- The type is not stable layout (`#[repr(C)]` or `#[repr(transparent)]`; or
- The type is stable layout but may have padding (for _any_ value of `T` or other type parameters)

I believe this should reasonably close #830.