### PR TITLE
Remove scalar bound from geometry type defs

### DIFF
--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -38,12 +38,21 @@ use simba::scalar::{ClosedNeg, RealField};
 ///  If a feature that you need is missing, feel free to open an issue or a PR.
 ///  See https://github.com/dimforge/nalgebra/issues/487
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub struct DualQuaternion<T: Scalar> {
+#[derive(Debug, Copy, Clone)]
+pub struct DualQuaternion<T> {
     /// The real component of the quaternion
     pub real: Quaternion<T>,
     /// The dual component of the quaternion
     pub dual: Quaternion<T>,
+}
+
+impl<T: Scalar + Eq> Eq for DualQuaternion<T> {}
+
+impl<T: Scalar> PartialEq for DualQuaternion<T> {
+    #[inline]
+    fn eq(&self, right: &Self) -> bool {
+        self.real == right.real && self.dual == right.dual
+    }
 }
 
 impl<T: Scalar + Zero> Default for DualQuaternion<T> {

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -68,7 +68,7 @@ use crate::geometry::{AbstractRotation, Point, Translation};
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))
 )]
-pub struct Isometry<T: Scalar, R, const D: usize> {
+pub struct Isometry<T, R, const D: usize> {
     /// The pure rotational part of this isometry.
     pub rotation: R,
     /// The pure translational part of this isometry.

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -60,13 +60,15 @@ use crate::geometry::{AbstractRotation, Point, Translation};
     feature = "serde-serialize-no-std",
     serde(bound(serialize = "R: Serialize,
                      DefaultAllocator: Allocator<T, Const<D>>,
-                     Owned<T, Const<D>>: Serialize"))
+                     Owned<T, Const<D>>: Serialize,
+                     T: Scalar"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(deserialize = "R: Deserialize<'de>,
                        DefaultAllocator: Allocator<T, Const<D>>,
-                       Owned<T, Const<D>>: Deserialize<'de>"))
+                       Owned<T, Const<D>>: Deserialize<'de>,
+                       T: Scalar"))
 )]
 pub struct Isometry<T, R, const D: usize> {
     /// The pure rotational part of this isometry.

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -18,7 +18,7 @@ use crate::base::{Matrix4, Vector, Vector3};
 use crate::geometry::{Point3, Projective3};
 
 /// A 3D orthographic projection stored as a homogeneous 4x4 matrix.
-pub struct Orthographic3<T: RealField> {
+pub struct Orthographic3<T> {
     matrix: Matrix4<T>,
 }
 

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -14,12 +14,12 @@ use simba::scalar::RealField;
 
 use crate::base::dimension::U3;
 use crate::base::storage::Storage;
-use crate::base::{Matrix4, Scalar, Vector, Vector3};
+use crate::base::{Matrix4, Vector, Vector3};
 
 use crate::geometry::{Point3, Projective3};
 
 /// A 3D perspective projection stored as a homogeneous 4x4 matrix.
-pub struct Perspective3<T: Scalar> {
+pub struct Perspective3<T> {
     matrix: Matrix4<T>,
 }
 

--- a/src/geometry/reflection.rs
+++ b/src/geometry/reflection.rs
@@ -1,5 +1,5 @@
 use crate::base::constraint::{AreMultipliable, DimEq, SameNumberOfRows, ShapeConstraint};
-use crate::base::{Const, Matrix, Scalar, Unit, Vector};
+use crate::base::{Const, Matrix, Unit, Vector};
 use crate::dimension::{Dim, U1};
 use crate::storage::{Storage, StorageMut};
 use simba::scalar::ComplexField;
@@ -7,7 +7,7 @@ use simba::scalar::ComplexField;
 use crate::geometry::Point;
 
 /// A reflection wrt. a plane.
-pub struct Reflection<T: Scalar, D: Dim, S: Storage<T, D>> {
+pub struct Reflection<T, D, S> {
     axis: Vector<T, D, S>,
     bias: T,
 }

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -55,7 +55,7 @@ use crate::geometry::Point;
 ///
 #[repr(C)]
 #[derive(Debug)]
-pub struct Rotation<T: Scalar, const D: usize> {
+pub struct Rotation<T, const D: usize> {
     matrix: SMatrix<T, D, D>,
 }
 

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -39,7 +39,7 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))
 )]
-pub struct Similarity<T: Scalar, R, const D: usize> {
+pub struct Similarity<T, R, const D: usize> {
     /// The part of this similarity that does not include the scaling factor.
     pub isometry: Isometry<T, R, D>,
     scaling: T,

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -27,14 +27,14 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "T: Serialize,
+    serde(bound(serialize = "T: Scalar + Serialize,
                      R: Serialize,
                      DefaultAllocator: Allocator<T, Const<D>>,
                      Owned<T, Const<D>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "T: Deserialize<'de>,
+    serde(bound(deserialize = "T: Scalar + Deserialize<'de>,
                        R: Deserialize<'de>,
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))


### PR DESCRIPTION
This was inconsistently applied, with some types having <T>, some having
<T: Scalar>, and some having <T: RealField>.
This unifies all types to match the convention of Matrix:
Just declare <T> at type def time, and apply bounds on impls only.

A significant advantage of this approach is const fn construction. Const
fn generics currently still can't have trait bounds, so any generic
const fn needs to only move opaque types around. Construction methods
such as new_unchecked or from_parts can be made const by removing their
generic bounds after this PR.

Actual constification is left to a follow-up PR.

Note that na::Transform is _not_ loosened here, as it has more complicated
definition requirements.