### PR TITLE
Add cargo-features resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [package]
 name    = "nalgebra"
 version = "0.27.1"


### PR DESCRIPTION
Attempting to run `cargo udeps` throws the following warning:

```
cargo +nightly udeps
error: failed to parse manifest at `/home/tobin/build/github.com/tcharding/nalgebra/Cargo.toml`

Caused by:
  feature `resolver` is required

  consider adding `cargo-features = ["resolver"]` to the manifest
```

This can be resolved by adding `cargo-features = ["resolver"]` to the
manifest file as suggested.

_Why_ this is needed by cargo udeps when it is the default behaviour now
I do not know.