### PR TITLE
point_dim_name: Fix serde impls and Distribution impl for OPoint

### DIFF
--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -85,6 +85,7 @@ where
 impl<T: Scalar + Serialize, D: DimName> Serialize for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
+    <DefaultAllocator as Allocator<T, D>>::Buffer: Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -98,12 +99,13 @@ where
 impl<'a, T: Scalar + Deserialize<'a>, D: DimName> Deserialize<'a> for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
+    <DefaultAllocator as Allocator<T, D>>::Buffer: Deserialize<'a>
 {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where
         Des: Deserializer<'a>,
     {
-        let coords = SVector::<T, D>::deserialize(deserializer)?;
+        let coords = OVector::<T, D>::deserialize(deserializer)?;
 
         Ok(Self::from(coords))
     }

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -168,7 +168,7 @@ where
     /// Generate a `Point` where each coordinate is an independent variate from `[0, 1)`.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> OPoint<T, D> {
-        Point::from(rng.gen::<OVector<T, D>>())
+        OPoint::from(rng.gen::<OVector<T, D>>())
     }
 }
 


### PR DESCRIPTION
This adds some missing fixes on top of the `point_dim_name` branch that were necessary for `serde` and `rand` integrations to work correctly.

Hopefully we can run the full CI suite to uncover additional problems.