### PR TITLE
Trivial doc comment improvements

### DIFF
--- a/nalgebra-glm/src/lib.rs
+++ b/nalgebra-glm/src/lib.rs
@@ -21,7 +21,7 @@
    **nalgebra-glm** using the module prefix `glm::`. For example you will write `glm::rotate(...)` instead
    of the more verbose `nalgebra_glm::rotate(...)`:
 
-   ```rust
+   ```
    extern crate nalgebra_glm as glm;
    ```
 

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -30,7 +30,7 @@
 //! the system installation of netlib without LAPACKE (note the E) or
 //! CBLAS:
 //!
-//! ```.ignore
+//! ```ignore
 //! sudo apt-get install gfortran libblas3gf liblapack3gf
 //! export CARGO_FEATURE_SYSTEM_NETLIB=1
 //! export CARGO_FEATURE_EXCLUDE_LAPACKE=1
@@ -44,7 +44,7 @@
 //!
 //! On macOS, do this to use Apple's Accelerate framework:
 //!
-//! ```.ignore
+//! ```ignore
 //! export CARGO_FEATURES="--no-default-features --features accelerate"
 //! cargo build ${CARGO_FEATURES}
 //! ```

--- a/nalgebra-sparse/src/convert/mod.rs
+++ b/nalgebra-sparse/src/convert/mod.rs
@@ -7,7 +7,7 @@
 //! The following example illustrates how to convert between matrix formats with the `From`
 //! implementations.
 //!
-//! ```rust
+//! ```
 //! use nalgebra_sparse::{csr::CsrMatrix, csc::CscMatrix, coo::CooMatrix};
 //! use nalgebra::DMatrix;
 //!

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -20,7 +20,7 @@ use crate::SparseFormatError;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use nalgebra_sparse::{coo::CooMatrix, csr::CsrMatrix, csc::CscMatrix};
 ///
 /// // Initialize a matrix with all zeros (no explicitly stored entries).

--- a/nalgebra-sparse/src/csc.rs
+++ b/nalgebra-sparse/src/csc.rs
@@ -19,7 +19,7 @@ use std::slice::{Iter, IterMut};
 ///
 /// # Usage
 ///
-/// ```rust
+/// ```
 /// use nalgebra_sparse::csc::CscMatrix;
 /// use nalgebra::{DMatrix, Matrix3x4};
 /// use matrixcompare::assert_matrix_eq;
@@ -97,7 +97,7 @@ use std::slice::{Iter, IterMut};
 /// represents the matrix in a column-by-column fashion. The entries associated with column `j` are
 /// determined as follows:
 ///
-/// ```rust
+/// ```
 /// # let col_offsets: Vec<usize> = vec![0, 0];
 /// # let row_indices: Vec<usize> = vec![];
 /// # let values: Vec<i32> = vec![];

--- a/nalgebra-sparse/src/csr.rs
+++ b/nalgebra-sparse/src/csr.rs
@@ -19,7 +19,7 @@ use std::slice::{Iter, IterMut};
 ///
 /// # Usage
 ///
-/// ```rust
+/// ```
 /// use nalgebra_sparse::csr::CsrMatrix;
 /// use nalgebra::{DMatrix, Matrix3x4};
 /// use matrixcompare::assert_matrix_eq;
@@ -97,7 +97,7 @@ use std::slice::{Iter, IterMut};
 /// represents the matrix in a row-by-row fashion. The entries associated with row `i` are
 /// determined as follows:
 ///
-/// ```rust
+/// ```
 /// # let row_offsets: Vec<usize> = vec![0, 0];
 /// # let col_indices: Vec<usize> = vec![];
 /// # let values: Vec<i32> = vec![];

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -73,7 +73,7 @@
 //!
 //! # Example: COO -> CSR -> matrix-vector product
 //!
-//! ```rust
+//! ```
 //! use nalgebra_sparse::{coo::CooMatrix, csr::CsrMatrix};
 //! use nalgebra::{DMatrix, DVector};
 //! use matrixcompare::assert_matrix_eq;

--- a/nalgebra-sparse/src/ops/mod.rs
+++ b/nalgebra-sparse/src/ops/mod.rs
@@ -90,7 +90,7 @@
 //! `C <- 3.0 * C + 2.0 * A^T * B`, where `A`, `B`, `C` are matrices and `A^T` is the transpose
 //! of `A`. The simplest way to write this is:
 //!
-//! ```rust
+//! ```
 //! # use nalgebra_sparse::csr::CsrMatrix;
 //! # let a = CsrMatrix::identity(10); let b = CsrMatrix::identity(10);
 //! # let mut c = CsrMatrix::identity(10);
@@ -109,7 +109,7 @@
 //!
 //! An alternative way to implement this expression (here using CSR matrices) is:
 //!
-//! ```rust
+//! ```
 //! # use nalgebra_sparse::csr::CsrMatrix;
 //! # let a = CsrMatrix::identity(10); let b = CsrMatrix::identity(10);
 //! # let mut c = CsrMatrix::identity(10);

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -58,7 +58,7 @@ pub unsafe trait Storage<T: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     /// Compute the index corresponding to the irow-th row and icol-th column of this matrix. The
     /// index must be such that the following holds:
     ///
-    /// ```.ignore
+    /// ```ignore
     /// let lindex = self.linear_index(irow, icol);
     /// assert!(*self.get_unchecked(irow, icol) == *self.get_unchecked_linear(lindex))
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ and the official package manager: [cargo](https://github.com/rust-lang/cargo).
 
 Simply add the following to your `Cargo.toml` file:
 
-```.ignore
+```ignore
 [dependencies]
 // TODO: replace the * by the latest version.
 nalgebra = "*"
@@ -26,7 +26,7 @@ Most useful functionalities of **nalgebra** are grouped in the root module `nalg
 However, the recommended way to use **nalgebra** is to import types and traits
 explicitly, and call free-functions using the `na::` prefix:
 
-```.rust
+```
 #[macro_use]
 extern crate approx; // For the macro relative_eq!
 extern crate nalgebra as na;

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -27,7 +27,7 @@
 //! In `proptest`, it is usually preferable to have free functions that generate *strategies*.
 //! Currently, the [matrix](fn.matrix.html) function fills this role. The analogous function for
 //! column vectors is [vector](fn.vector.html). Let's take a quick look at how it may be used:
-//! ```rust
+//! ```
 //! use nalgebra::proptest::matrix;
 //! use proptest::prelude::*;
 //!
@@ -52,7 +52,7 @@
 //! number of columns to vary. One way to do this is to use `proptest` combinators in combination
 //! with [matrix](fn.matrix.html) as follows:
 //!
-//! ```rust
+//! ```
 //! use nalgebra::{Dynamic, OMatrix, Const};
 //! use nalgebra::proptest::matrix;
 //! use proptest::prelude::*;
@@ -92,7 +92,7 @@
 //!
 //! If you don't care about the dimensions of matrices, you can write tests like these:
 //!
-//! ```rust
+//! ```
 //! use nalgebra::{DMatrix, DVector, Dynamic, Matrix3, OMatrix, Vector3, U3};
 //! use proptest::prelude::*;
 //!


### PR DESCRIPTION
[The rustdoc book](https://doc.rust-lang.org/rustdoc/documentation-tests.html) states that all code between triple backticks is automatically interpreted as Rust code, and specifies the `ignore` keyword to not run a certain test. I removed all redundant instances of the `rust` keyword in code blocks, and replaced all instances of the undocumented keyword `.ignore` by their documented `ignore` counterpart.