### PR TITLE
Make display generical for Omatrix

### DIFF
--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1108,3 +1108,30 @@ fn partial_eq_different_types() {
     // assert_ne!(static_mat, typenum_static_mat);
     //assert_ne!(typenum_static_mat, static_mat);
 }
+
+
+
+fn generic_omatrix_to_string<D>(
+    vector: &nalgebra::OVector<f64, D>,
+    matrix: &nalgebra::OMatrix<f64, D, D>) -> (String, String)
+where
+    D: nalgebra::Dim,
+    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<f64, D>,
+    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<f64, D, D>,
+{
+    (vector.to_string(), matrix.to_string())
+}
+
+#[test]
+fn omatrix_to_string() {
+    let dvec: nalgebra::DVector<f64> = nalgebra::dvector![1.0, 2.0];
+    let dmatr: nalgebra::DMatrix<f64> = nalgebra::dmatrix![1.0, 2.0; 3.0, 4.0];
+    let svec: nalgebra::SVector<f64, 2> = nalgebra::vector![1.0, 2.0];
+    let smatr: nalgebra::SMatrix<f64, 2, 2> = nalgebra::matrix![1.0, 2.0; 3.0, 4.0];
+    assert_eq!(
+        generic_omatrix_to_string(&dvec, &dmatr),
+        (dvec.to_string(), dmatr.to_string()));
+    assert_eq!(
+        generic_omatrix_to_string(&svec, &smatr),
+        (svec.to_string(), smatr.to_string()));
+}

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1109,11 +1109,10 @@ fn partial_eq_different_types() {
     //assert_ne!(typenum_static_mat, static_mat);
 }
 
-
-
 fn generic_omatrix_to_string<D>(
     vector: &nalgebra::OVector<f64, D>,
-    matrix: &nalgebra::OMatrix<f64, D, D>) -> (String, String)
+    matrix: &nalgebra::OMatrix<f64, D, D>,
+) -> (String, String)
 where
     D: nalgebra::Dim,
     nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<f64, D>,
@@ -1130,8 +1129,10 @@ fn omatrix_to_string() {
     let smatr: nalgebra::SMatrix<f64, 2, 2> = nalgebra::matrix![1.0, 2.0; 3.0, 4.0];
     assert_eq!(
         generic_omatrix_to_string(&dvec, &dmatr),
-        (dvec.to_string(), dmatr.to_string()));
+        (dvec.to_string(), dmatr.to_string())
+    );
     assert_eq!(
         generic_omatrix_to_string(&svec, &smatr),
-        (svec.to_string(), smatr.to_string()));
+        (svec.to_string(), smatr.to_string())
+    );
 }


### PR DESCRIPTION
In the previous version, the test added in tests/core/matrix.rs failed to compile.

This version remove the dependency to the `Allocator<usize>`, so that the display implementation does not depend of the allocator of `nalgebra`, making it generical for `OMatrix`.

Not relying on `Omatrix<usize, R, C>` implies that some computation have to be done twice.
However, the performance hit is only in `Display`, which I find acceptable (the use case will be for debugging/writing logs)

The difference with the previous version is that `val_width` is called twice per entry instead of once.