### PR TITLE
Removed unnecessary `unsafe` markers

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -79,7 +79,7 @@ where
     }
 
     #[inline]
-    unsafe fn is_contiguous(&self) -> bool {
+    fn is_contiguous(&self) -> bool {
         true
     }
 

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -166,7 +166,7 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-             fn is_contiguous(&self) -> bool {
+            fn is_contiguous(&self) -> bool {
                 // Common cases that can be deduced at compile-time even if one of the dimensions
                 // is Dynamic.
                 if (RStride::is::<U1>() && C::is::<U1>()) || // Column vector.

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -166,7 +166,7 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-            unsafe fn is_contiguous(&self) -> bool {
+             fn is_contiguous(&self) -> bool {
                 // Common cases that can be deduced at compile-time even if one of the dimensions
                 // is Dynamic.
                 if (RStride::is::<U1>() && C::is::<U1>()) || // Column vector.

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -70,24 +70,36 @@ pub unsafe trait Storage<T: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     }
 
     /// Gets the address of the i-th matrix component without performing bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, dereferencing the result will cause undefined behavior.
     #[inline]
-    unsafe fn get_address_unchecked_linear(&self, i: usize) -> *const T {
+    fn get_address_unchecked_linear(&self, i: usize) -> *const T {
         self.ptr().wrapping_add(i)
     }
 
     /// Gets the address of the i-th matrix component without performing bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, dereferencing the result will cause undefined behavior.
     #[inline]
-    unsafe fn get_address_unchecked(&self, irow: usize, icol: usize) -> *const T {
+    fn get_address_unchecked(&self, irow: usize, icol: usize) -> *const T {
         self.get_address_unchecked_linear(self.linear_index(irow, icol))
     }
 
     /// Retrieves a reference to the i-th element without bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
     unsafe fn get_unchecked_linear(&self, i: usize) -> &T {
         &*self.get_address_unchecked_linear(i)
     }
 
     /// Retrieves a reference to the i-th element without bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
     unsafe fn get_unchecked(&self, irow: usize, icol: usize) -> &T {
         self.get_unchecked_linear(self.linear_index(irow, icol))
@@ -96,9 +108,9 @@ pub unsafe trait Storage<T: Scalar, R: Dim, C: Dim = U1>: Debug + Sized {
     /// Indicates whether this data buffer stores its elements contiguously.
     ///
     /// # Safety
-    /// This method is unsafe because unsafe code relies on this properties to performe
-    /// some low-lever optimizations.
-    unsafe fn is_contiguous(&self) -> bool;
+    /// This function must not return `true` if the underlying storage is not contiguous,
+    /// or undefined behaviour will occur.
+    fn is_contiguous(&self) -> bool;
 
     /// Retrieves the data buffer as a contiguous slice.
     ///
@@ -131,30 +143,45 @@ pub unsafe trait StorageMut<T: Scalar, R: Dim, C: Dim = U1>: Storage<T, R, C> {
     fn ptr_mut(&mut self) -> *mut T;
 
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, dereferencing the result will cause undefined behavior.
     #[inline]
-    unsafe fn get_address_unchecked_linear_mut(&mut self, i: usize) -> *mut T {
+    fn get_address_unchecked_linear_mut(&mut self, i: usize) -> *mut T {
         self.ptr_mut().wrapping_add(i)
     }
 
     /// Gets the mutable address of the i-th matrix component without performing bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, dereferencing the result will cause undefined behavior.
     #[inline]
-    unsafe fn get_address_unchecked_mut(&mut self, irow: usize, icol: usize) -> *mut T {
+    fn get_address_unchecked_mut(&mut self, irow: usize, icol: usize) -> *mut T {
         let lid = self.linear_index(irow, icol);
         self.get_address_unchecked_linear_mut(lid)
     }
 
     /// Retrieves a mutable reference to the i-th element without bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, the method will cause undefined behavior.
     unsafe fn get_unchecked_linear_mut(&mut self, i: usize) -> &mut T {
         &mut *self.get_address_unchecked_linear_mut(i)
     }
 
     /// Retrieves a mutable reference to the element at `(irow, icol)` without bound-checking.
+    ///
+    /// # Safety
+    /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
     unsafe fn get_unchecked_mut(&mut self, irow: usize, icol: usize) -> &mut T {
         &mut *self.get_address_unchecked_mut(irow, icol)
     }
 
     /// Swaps two elements using their linear index without bound-checking.
+    ///
+    /// # Safety
+    /// If the indices are out of bounds, the method will cause undefined behavior.
     #[inline]
     unsafe fn swap_unchecked_linear(&mut self, i1: usize, i2: usize) {
         let a = self.get_address_unchecked_linear_mut(i1);
@@ -164,6 +191,9 @@ pub unsafe trait StorageMut<T: Scalar, R: Dim, C: Dim = U1>: Storage<T, R, C> {
     }
 
     /// Swaps two elements without bound-checking.
+    ///
+    /// # Safety
+    /// If the indices are out of bounds, the method will cause undefined behavior.
     #[inline]
     unsafe fn swap_unchecked(&mut self, row_col1: (usize, usize), row_col2: (usize, usize)) {
         let lid1 = self.linear_index(row_col1.0, row_col1.1);

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -180,7 +180,7 @@ where
     }
 
     #[inline]
-    unsafe fn is_contiguous(&self) -> bool {
+    fn is_contiguous(&self) -> bool {
         true
     }
 
@@ -229,7 +229,7 @@ where
     }
 
     #[inline]
-    unsafe fn is_contiguous(&self) -> bool {
+    fn is_contiguous(&self) -> bool {
         true
     }
 


### PR DESCRIPTION
I removed some `unsafe` markers from methods that didn't need them, and added a bit of safety documentation to related methods.