### PR TITLE
Attempt at fixing UB in `allocate_uninitialized`

### DIFF
--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -22,7 +22,7 @@ pub trait Allocator<T: Scalar, R: Dim, C: Dim = U1>: Any + Sized {
     type Buffer: ContiguousStorageMut<T, R, C> + Clone;
 
     /// Allocates a buffer with the given number of rows and columns without initializing its content.
-    unsafe fn allocate_uninitialized(nrows: R, ncols: C) -> mem::MaybeUninit<Self::Buffer>;
+    fn allocate_uninitialized(nrows: R, ncols: C) -> mem::MaybeUninit<Self::Buffer>;
 
     /// Allocates a buffer initialized with the content of the given iterator.
     fn allocate_from_iterator<I: IntoIterator<Item = T>>(

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -31,9 +31,9 @@ use abomonation::Abomonation;
 #[repr(C)]
 #[derive(Eq, Debug, Clone, PartialEq)]
 pub struct VecStorage<T, R: Dim, C: Dim> {
-    data: Vec<T>,
-    nrows: R,
-    ncols: C,
+    pub(crate) data: Vec<T>,
+    pub(crate) nrows: R,
+    pub(crate) ncols: C,
 }
 
 #[cfg(feature = "serde-serialize")]


### PR DESCRIPTION
Currently, `allocate_uninitialized` uses a `set_len` call to make an "uninitialized" vector. However, this is undefined behavior per the Rust docs. I'm currently attempting to remedy this by using `MaybeUninit`. 

Tests are currently crashing, so either my implementation is wrong, or there's UB elsewhere (or both).