### PR TITLE
import macros from alloc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,6 @@ an optimized set of tools for computer graphics and physics. Those features incl
     html_root_url = "https://docs.rs/nalgebra/0.25.0"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "no_unsound_assume_init", allow(unreachable_code))]
 
 #[cfg(feature = "rand-no-std")]
@@ -102,6 +101,7 @@ extern crate approx;
 extern crate num_traits as num;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg_attr(test, macro_use)]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
This solves several issues encountered when trying to build with the alloc feature.

For one, the alloc feature is stable, and has been since Rust 1.36.0:

```rust
warning: the feature `alloc` has been stable since 1.36.0 and no longer requires
 an attribute to enable
  --> src/lib.rs:90:67
   |
90 | #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
   |                                                                   ^^^^^
   |
   = note: `#[warn(stable_features)]` on by default

warning: 1 warning emitted
```

Secondly, this breaks the build on stable:

```rust
 ~/g/r/cv   compilable  cv-optimize  cargo check
    Checking nalgebra v0.27.1
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/matthieu/.cargo/registry/src/github.com-1ecc6299db9ec823/nalgebra-0.27.1/src/lib.rs:89:59
   |
89 | #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
   |                                                           ^^^^^^^^^^^^^^
```

It also fails to build on nightly with the feature configuration we have in Rust CV:

```rust
error: cannot find macro `format` in this scope
  --> C:\Users\vadix\.cargo\registry\src\github.com-1ecc6299db9ec823\nalgebra-0.27.1\src\base\vec_storage.rs:70:43
   |
70 |             return Err(Des::Error::custom(format!(
   |                                           ^^^^^^
   |
   = note: consider importing one of these items:
           alloc::format
           std::format
```

All of these issues are solved by this PR.

We may also want to add a follow up to test `alloc` feature on stable in CI. Currently, the tests aren't even ran, and it only builds with nightly.