### PR TITLE
Make `from_matrix_unchecked`es const

### DIFF
--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -66,6 +66,30 @@ impl<'a, T: RealField + Deserialize<'a>> Deserialize<'a> for Orthographic3<T> {
     }
 }
 
+impl<T> Orthographic3<T> {
+    /// Wraps the given matrix to interpret it as a 3D orthographic matrix.
+    ///
+    /// It is not checked whether or not the given matrix actually represents an orthographic
+    /// projection.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{Orthographic3, Point3, Matrix4};
+    /// let mat = Matrix4::new(
+    ///     2.0 / 9.0, 0.0,        0.0,         -11.0 / 9.0,
+    ///     0.0,       2.0 / 18.0, 0.0,         -22.0 / 18.0,
+    ///     0.0,       0.0,       -2.0 / 999.9, -1000.1 / 999.9,
+    ///     0.0,       0.0,        0.0,         1.0
+    /// );
+    /// let proj = Orthographic3::from_matrix_unchecked(mat);
+    /// assert_eq!(proj, Orthographic3::new(1.0, 10.0, 2.0, 20.0, 0.1, 1000.0));
+    /// ```
+    #[inline]
+    pub const fn from_matrix_unchecked(matrix: Matrix4<T>) -> Self {
+        Self { matrix }
+    }
+}
+
 impl<T: RealField> Orthographic3<T> {
     /// Creates a new orthographic projection matrix.
     ///
@@ -119,28 +143,6 @@ impl<T: RealField> Orthographic3<T> {
         res.set_znear_and_zfar(znear, zfar);
 
         res
-    }
-
-    /// Wraps the given matrix to interpret it as a 3D orthographic matrix.
-    ///
-    /// It is not checked whether or not the given matrix actually represents an orthographic
-    /// projection.
-    ///
-    /// # Example
-    /// ```
-    /// # use nalgebra::{Orthographic3, Point3, Matrix4};
-    /// let mat = Matrix4::new(
-    ///     2.0 / 9.0, 0.0,        0.0,         -11.0 / 9.0,
-    ///     0.0,       2.0 / 18.0, 0.0,         -22.0 / 18.0,
-    ///     0.0,       0.0,       -2.0 / 999.9, -1000.1 / 999.9,
-    ///     0.0,       0.0,        0.0,         1.0
-    /// );
-    /// let proj = Orthographic3::from_matrix_unchecked(mat);
-    /// assert_eq!(proj, Orthographic3::new(1.0, 10.0, 2.0, 20.0, 0.1, 1000.0));
-    /// ```
-    #[inline]
-    pub fn from_matrix_unchecked(matrix: Matrix4<T>) -> Self {
-        Self { matrix }
     }
 
     /// Creates a new orthographic projection matrix from an aspect ratio and the vertical field of view.

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -67,6 +67,17 @@ impl<'a, T: RealField + Deserialize<'a>> Deserialize<'a> for Perspective3<T> {
     }
 }
 
+impl<T> Perspective3<T> {
+    /// Wraps the given matrix to interpret it as a 3D perspective matrix.
+    ///
+    /// It is not checked whether or not the given matrix actually represents a perspective
+    /// projection.
+    #[inline]
+    pub const fn from_matrix_unchecked(matrix: Matrix4<T>) -> Self {
+        Self { matrix }
+    }
+}
+
 impl<T: RealField> Perspective3<T> {
     /// Creates a new perspective matrix from the aspect ratio, y field of view, and near/far planes.
     pub fn new(aspect: T, fovy: T, znear: T, zfar: T) -> Self {
@@ -90,15 +101,6 @@ impl<T: RealField> Perspective3<T> {
         res.matrix[(3, 2)] = -T::one();
 
         res
-    }
-
-    /// Wraps the given matrix to interpret it as a 3D perspective matrix.
-    ///
-    /// It is not checked whether or not the given matrix actually represents a perspective
-    /// projection.
-    #[inline]
-    pub fn from_matrix_unchecked(matrix: Matrix4<T>) -> Self {
-        Self { matrix }
     }
 
     /// Retrieves the inverse of the underlying homogeneous matrix.

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -130,10 +130,10 @@ where
     }
 }
 
-impl<T: Scalar, const D: usize> Rotation<T, D> {
+impl<T, const D: usize> Rotation<T, D> {
     /// Creates a new rotation from the given square matrix.
     ///
-    /// The matrix squareness is checked but not its orthonormality.
+    /// The matrix orthonormality is not checked.
     ///
     /// # Example
     /// ```
@@ -154,12 +154,7 @@ impl<T: Scalar, const D: usize> Rotation<T, D> {
     /// assert_eq!(*rot.matrix(), mat);
     /// ```
     #[inline]
-    pub fn from_matrix_unchecked(matrix: SMatrix<T, D, D>) -> Self {
-        assert!(
-            matrix.is_square(),
-            "Unable to create a rotation from a non-square matrix."
-        );
-
+    pub const fn from_matrix_unchecked(matrix: SMatrix<T, D, D>) -> Self {
         Self { matrix }
     }
 }


### PR DESCRIPTION
Now that [`T` is unbounded](https://github.com/dimforge/nalgebra/pull/932), the unchecked constructors can be `const`.