### PR TITLE
Do not require T: (De)Serialize for OPoint impl

### DIFF
--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -82,7 +82,7 @@ where
 }
 
 #[cfg(feature = "serde-serialize-no-std")]
-impl<T: Scalar + Serialize, D: DimName> Serialize for OPoint<T, D>
+impl<T: Scalar, D: DimName> Serialize for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
     <DefaultAllocator as Allocator<T, D>>::Buffer: Serialize,
@@ -96,7 +96,7 @@ where
 }
 
 #[cfg(feature = "serde-serialize-no-std")]
-impl<'a, T: Scalar + Deserialize<'a>, D: DimName> Deserialize<'a> for OPoint<T, D>
+impl<'a, T: Scalar, D: DimName> Deserialize<'a> for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
     <DefaultAllocator as Allocator<T, D>>::Buffer: Deserialize<'a>,


### PR DESCRIPTION
The bounds recently got a little too strict.

I probably messed this up when I fixed serde compilation during the recent `OPoint` introduction?