### PR TITLE
Include "rand" in feature list for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,4 +119,4 @@ lto = true
 
 [package.metadata.docs.rs]
 # Enable certain features when building docs for docs.rs
-features = [ "proptest-support", "compare", "macros" ]
+features = [ "proptest-support", "compare", "macros", "rand" ]


### PR DESCRIPTION
Random support was gated by the "rand" feature in version 0.25.1, but not added to the docs.rs list, causing the gated functions to disappear from docs.