### PR TITLE
Implement a few handy functions for `Quaternion` and `DualQuaternion`

### DIFF
--- a/src/geometry/dual_quaternion_construction.rs
+++ b/src/geometry/dual_quaternion_construction.rs
@@ -1,11 +1,9 @@
-use crate::{
-    DualQuaternion, Isometry3, Quaternion, Scalar, SimdRealField, Translation3, UnitDualQuaternion,
-    UnitQuaternion,
-};
+use crate::{DualQuaternion, Isometry3, Quaternion, Scalar, SimdRealField, Translation3, UnitDualQuaternion, UnitQuaternion, Vector3};
 use num::{One, Zero};
 #[cfg(feature = "arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 use simba::scalar::SupersetOf;
+use std::ops::{Mul, Div};
 
 impl<T: Scalar> DualQuaternion<T> {
     /// Creates a dual quaternion from its rotation and translation components.
@@ -89,6 +87,34 @@ where
         Self {
             real,
             dual: Quaternion::zero(),
+        }
+    }
+
+    /// Creates a dual quaternion from a real part and a vector representing a 3d translation.
+    /// The real part is generally expected to be a unit quaternion. 
+    ///
+    /// **It is your responsibility to normalize the real part before calling this function.**
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{DualQuaternion, Quaternion, Vector3};
+    /// let rot = Quaternion::new(0.71, 0.0, 0.0, -0.71);
+    /// let translation = Vector3::new(1.0, 0.0, 0.0);
+    ///
+    /// let dq = DualQuaternion::from_real_and_translation(rot, translation);
+    /// assert_eq!(dq.real.w, 0.71);
+    /// assert_eq!(dq.dual.w, 0.0);
+    /// assert_eq!(dq.dual.i, 0.355);
+    /// assert_eq!(dq.dual.j, 0.355);
+    /// assert_eq!(dq.dual.k, 0.0);
+    /// ```
+    #[inline]
+    pub fn from_real_and_translation(real: Quaternion<T>, translation: Vector3<T>) -> Self
+    {
+        let dual = Quaternion::from_imag(translation).mul(&real).div(T::one() + T::one());
+        Self {
+            real,
+            dual,
         }
     }
 }

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
+use std::ops::Mul;
 
 #[cfg(feature = "serde-serialize-no-std")]
 use crate::base::storage::Owned;
@@ -352,6 +353,25 @@ where
     #[must_use]
     pub fn dot(&self, rhs: &Self) -> T {
         self.coords.dot(&rhs.coords)
+    }
+
+    /// Rotate a vector by this quaternion.
+    /// Due to floating-point errors, this will have slight inaccuracies.
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::{Vector3, Quaternion};
+    /// let q = Quaternion::<f32>::new(0.71, 0.0, 0.0, -0.71);
+    /// let v_in = Vector3::new(1.0, 0.0, 0.0);
+    /// let v_out = Vector3::new(0.0, -1.0, 0.0);
+    /// let r = q.rotate(&v_in);
+    /// assert!((r.x - v_out.x).abs() < 0.01);
+    /// assert!((r.y - v_out.y).abs() < 0.01);
+    /// assert!((r.z - v_out.z).abs() < 0.01);
+    /// ```
+    #[inline]
+    pub fn rotate(&self, vector: &Vector3<T>) -> Vector3<T> {
+        self.mul(Quaternion::from_imag(vector.clone())).mul(self.conjugate()).vector().into()
     }
 }
 

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -355,24 +355,6 @@ where
         self.coords.dot(&rhs.coords)
     }
 
-    /// Rotate a vector by this quaternion.
-    /// Due to floating-point errors, this will have slight inaccuracies.
-    ///
-    /// # Example
-    /// ```
-    /// # use nalgebra::{Vector3, Quaternion};
-    /// let q = Quaternion::<f32>::new(0.71, 0.0, 0.0, -0.71);
-    /// let v_in = Vector3::new(1.0, 0.0, 0.0);
-    /// let v_out = Vector3::new(0.0, -1.0, 0.0);
-    /// let r = q.rotate(&v_in);
-    /// assert!((r.x - v_out.x).abs() < 0.01);
-    /// assert!((r.y - v_out.y).abs() < 0.01);
-    /// assert!((r.z - v_out.z).abs() < 0.01);
-    /// ```
-    #[inline]
-    pub fn rotate(&self, vector: &Vector3<T>) -> Vector3<T> {
-        self.mul(Quaternion::from_imag(vector.clone())).mul(self.conjugate()).vector().into()
-    }
 }
 
 impl<T: SimdRealField> Quaternion<T>


### PR DESCRIPTION
In a recent project, I stumbled across a few quaternion related functions I wished this library had. So, here is my pull request to try to add them.

I would appreciate feedback on my work here if anybody has some to give.

## What's new

 - ~`Quaterion::rotate(&self, Vector3) -> Vector3`~
   - ~Given any `Vector3`, rotate it by the quaternion and return the rotated vector result~
 - `DualQuaternion::from_real_and_translation(Quaterion, Vector3) -> DualQuaternion`
   - Construct a `DualQuaternion` from a real part (rotation) and a vector representing a 3d translation
 - `DualQuaternion::translation(&self) -> Vector3`
   - Calculate the 3d translation that any `DualQuaternion` represents