### PR TITLE
Allow setting Cholesky field directly; more lax decomposition method

### DIFF
--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -74,6 +74,14 @@ where
         Cholesky { chol: matrix }
     }
 
+    /// Uses the given matrix as-is without any checks or modifications as the
+    /// Cholesky decomposition.
+    ///
+    /// It is up to the user to ensure all invariants hold.
+    pub fn pack_dirty(matrix: OMatrix<T, D, D>) -> Self {
+        Cholesky { chol: matrix }
+    }
+
     /// Retrieves the lower-triangular factor of the Cholesky decomposition with its strictly
     /// upper-triangular part filled with zeros.
     pub fn unpack(mut self) -> OMatrix<T, D, D> {

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -1,5 +1,16 @@
 #![cfg(all(feature = "proptest-support", feature = "debug"))]
 
+#[test]
+// #[rustfmt::skip]
+fn cholesky_with_substitute() {
+    // Make a tiny covariance matrix with a small covariance value.
+    let m = na::Matrix2::new(1.0, f64::NAN, 1.0, 1e-32);
+    // Show that the cholesky fails for our matrix. We then try again with a substitute.
+    assert!(na::Cholesky::new(m).is_none());
+    // ...and show that we get some result this time around.
+    assert!(na::Cholesky::new_with_substitute(m, 1e-8).is_some());
+}
+
 macro_rules! gen_tests(
     ($module: ident, $scalar: ty) => {
         mod $module {


### PR DESCRIPTION
Please see individual commits. This makes working with Cholesky quite a bit more flexible.