### PR TITLE
Concise Debug impls

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -195,10 +195,7 @@ pub struct Matrix<T, R, C, S> {
 
 impl<T, R: Dim, C: Dim, S: fmt::Debug> fmt::Debug for Matrix<T, R, C, S> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        formatter
-            .debug_struct("Matrix")
-            .field("data", &self.data)
-            .finish()
+        self.data.fmt(formatter)
     }
 }
 

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 #[cfg(feature = "abomonation-serialize")]
 use std::io::{Result as IOResult, Write};
 use std::ops::Deref;
@@ -24,9 +25,15 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// and [`UnitQuaternion`](crate::UnitQuaternion); both built on top of `Unit`.  If you are interested
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
-#[derive(Clone, Hash, Debug, Copy)]
+#[derive(Clone, Hash, Copy)]
 pub struct Unit<T> {
     pub(crate) value: T,
+}
+
+impl<T: fmt::Debug> fmt::Debug for Unit<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.value.fmt(formatter)
+    }
 }
 
 #[cfg(feature = "bytemuck")]

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -40,13 +40,22 @@ use std::mem::MaybeUninit;
 /// may have some other methods, e.g., `isometry.inverse_transform_point(&point)`. See the documentation
 /// of said transformations for details.
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OPoint<T: Scalar, D: DimName>
 where
     DefaultAllocator: Allocator<T, D>,
 {
     /// The coordinates of this point, i.e., the shift from the origin.
     pub coords: OVector<T, D>,
+}
+
+impl<T: Scalar + fmt::Debug, D: DimName> fmt::Debug for OPoint<T, D>
+where
+    DefaultAllocator: Allocator<T, D>,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.coords.as_slice().fmt(formatter)
+    }
 }
 
 impl<T: Scalar + hash::Hash, D: DimName> hash::Hash for OPoint<T, D>

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -27,10 +27,16 @@ use crate::geometry::{Point3, Rotation};
 /// A quaternion. See the type alias `UnitQuaternion = Unit<Quaternion>` for a quaternion
 /// that may be used as a rotation.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct Quaternion<T> {
     /// This quaternion as a 4D vector of coordinates in the `[ x, y, z, w ]` storage order.
     pub coords: Vector4<T>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for Quaternion<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.coords.as_slice().fmt(formatter)
+    }
 }
 
 impl<T: Scalar + Hash> Hash for Quaternion<T> {

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -54,9 +54,14 @@ use crate::geometry::Point;
 /// * [Conversion to a matrix <span style="float:right;">`matrix`, `to_homogeneous`…</span>](#conversion-to-a-matrix)
 ///
 #[repr(C)]
-#[derive(Debug)]
 pub struct Rotation<T, const D: usize> {
     matrix: SMatrix<T, D, D>,
+}
+
+impl<T: fmt::Debug, const D: usize> fmt::Debug for Rotation<T, D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.matrix.fmt(formatter)
+    }
 }
 
 impl<T: Scalar + hash::Hash, const D: usize> hash::Hash for Rotation<T, D>

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -1,6 +1,6 @@
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use std::any::Any;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::hash;
 use std::marker::PhantomData;
 
@@ -157,7 +157,6 @@ super_tcategory_impl!(
 /// It is stored as a matrix with dimensions `(D + 1, D + 1)`, e.g., it stores a 4x4 matrix for a
 /// 3D transformation.
 #[repr(C)]
-#[derive(Debug)]
 pub struct Transform<T: RealField, C: TCategory, const D: usize>
 where
     Const<D>: DimNameAdd<U1>,
@@ -165,6 +164,16 @@ where
 {
     matrix: OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     _phantom: PhantomData<C>,
+}
+
+impl<T: RealField + Debug, C: TCategory, const D: usize> Debug for Transform<T, C, D>
+where
+    Const<D>: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.matrix.fmt(formatter)
+    }
 }
 
 impl<T: RealField + hash::Hash, C: TCategory, const D: usize> hash::Hash for Transform<T, C, D>

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -22,11 +22,16 @@ use crate::geometry::Point;
 
 /// A translation.
 #[repr(C)]
-#[derive(Debug)]
 pub struct Translation<T, const D: usize> {
     /// The translation coordinates, i.e., how much is added to a point's coordinates when it is
     /// translated.
     pub vector: SVector<T, D>,
+}
+
+impl<T: fmt::Debug, const D: usize> fmt::Debug for Translation<T, D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.vector.as_slice().fmt(formatter)
+    }
 }
 
 impl<T: Scalar + hash::Hash, const D: usize> hash::Hash for Translation<T, D>

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -80,8 +80,8 @@ fn iter() {
 #[test]
 fn debug_output_corresponds_to_data_container() {
     let m = Matrix2::new(1.0, 2.0, 3.0, 4.0);
-    let output_stable = "Matrix { data: [[1, 3], [2, 4]] }"; // Current output on the stable channel.
-    let output_nightly = "Matrix { data: [[1.0, 3.0], [2.0, 4.0]] }"; // Current output on the nightly channel.
+    let output_stable = "[[1, 3], [2, 4]]"; // Current output on the stable channel.
+    let output_nightly = "[[1.0, 3.0], [2.0, 4.0]]"; // Current output on the nightly channel.
     let current_output = format!("{:?}", m);
     dbg!(output_stable);
     dbg!(output_nightly);


### PR DESCRIPTION
Replace the verbose derived (or nearly equivalent) `Debug` impls for several newtypes with explicit impls that forward to the inner type, making readable diagnostics logging much easier.

I've found absolutely every time I'm trying to debug-log a nalgebra type I need to manually dig out the underlying array to have any hope of being able to scan a large amount of logged data to find irregularities. This is particularly awkward when I'm trying to log a structure that contains various nalgebra types, and hence can't just have `.coords.data` or whatever slapped on the end. This is also consistent with the existing `Debug` impls for e.g. `Orthographic3` and `Perspective3`, and with e.g. `Vec` in the stdlib.

In most cases, formatting is directly forwarded to the contents of each newtype. When a type wrapping a matrix is necessarily always wrapping a column vector, I instead forwarded to `as_slice()` as the extra layer of `[]` would add no information. I also considered extending the impl for `Matrix` to omit the outer `[]` for column vectors, but I'm not sure if that's too dynamic. Thoughts?

Before:
`Isometry { rotation: Unit { value: Quaternion { coords: Matrix { data: [[0.0, 0.0, 0.0, 1.0]] } } }, translation: Translation { vector: Matrix { data: [[0.0, 0.0, 0.0]] } } }`

After:
`Isometry { rotation: [0.0, 0.0, 0.0, 1.0], translation: [0.0, 0.0, 0.0] }`