### PR TITLE
Simplify Matrix::is_identity while also improving performance

### DIFF
--- a/src/base/properties.rs
+++ b/src/base/properties.rs
@@ -63,47 +63,15 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         T::Epsilon: Clone,
     {
         let (nrows, ncols) = self.shape();
-        let d;
 
-        if nrows > ncols {
-            d = ncols;
-
-            for i in d..nrows {
-                for j in 0..ncols {
-                    if !relative_eq!(self[(i, j)], T::zero(), epsilon = eps.clone()) {
-                        return false;
-                    }
-                }
-            }
-        } else {
-            // nrows <= ncols
-            d = nrows;
-
+        for j in 0..ncols {
             for i in 0..nrows {
-                for j in d..ncols {
-                    if !relative_eq!(self[(i, j)], T::zero(), epsilon = eps.clone()) {
-                        return false;
-                    }
-                }
-            }
-        }
-
-        // Off-diagonal elements of the sub-square matrix.
-        for i in 1..d {
-            for j in 0..i {
-                // TODO: use unsafe indexing.
-                if !relative_eq!(self[(i, j)], T::zero(), epsilon = eps.clone())
-                    || !relative_eq!(self[(j, i)], T::zero(), epsilon = eps.clone())
+                let el = unsafe { self.get_unchecked((i, j)) };
+                if (i == j && !relative_eq!(*el, T::one(), epsilon = eps.clone()))
+                    || (i != j && !relative_eq!(*el, T::zero(), epsilon = eps.clone()))
                 {
                     return false;
                 }
-            }
-        }
-
-        // Diagonal elements of the sub-square matrix.
-        for i in 0..d {
-            if !relative_eq!(self[(i, i)], T::one(), epsilon = eps.clone()) {
-                return false;
             }
         }
 

--- a/src/base/properties.rs
+++ b/src/base/properties.rs
@@ -7,10 +7,10 @@ use simba::scalar::{ClosedAdd, ClosedMul, ComplexField, RealField};
 use crate::base::allocator::Allocator;
 use crate::base::dimension::{Dim, DimMin};
 use crate::base::storage::Storage;
-use crate::base::{DefaultAllocator, Matrix, Scalar, SquareMatrix};
+use crate::base::{DefaultAllocator, Matrix, SquareMatrix};
 use crate::RawStorage;
 
-impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
+impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// The total number of elements of this matrix.
     ///
     /// # Examples:

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -351,7 +351,7 @@ impl<T: RealField + UlpsEq<Epsilon = T>> UlpsEq for DualQuaternion<T> {
 
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
-        self.clone().to_vector().ulps_eq(&other.clone().to_vector(), epsilon.clone(), max_ulps.clone()) ||
+        self.clone().to_vector().ulps_eq(&other.clone().to_vector(), epsilon.clone(), max_ulps) ||
         // Account for the double-covering of S², i.e. q = -q.
         self.clone().to_vector().iter().zip(other.clone().to_vector().iter()).all(|(a, b)| a.ulps_eq(&-b.clone(), epsilon.clone(), max_ulps))
     }

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -629,7 +629,7 @@ where
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
         self.translation
-            .ulps_eq(&other.translation, epsilon.clone(), max_ulps.clone())
+            .ulps_eq(&other.translation, epsilon.clone(), max_ulps)
             && self.rotation.ulps_eq(&other.rotation, epsilon, max_ulps)
     }
 }

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -415,7 +415,7 @@ where
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
         self.isometry
-            .ulps_eq(&other.isometry, epsilon.clone(), max_ulps.clone())
+            .ulps_eq(&other.isometry, epsilon.clone(), max_ulps)
             && self.scaling.ulps_eq(&other.scaling, epsilon, max_ulps)
     }
 }

--- a/src/geometry/unit_complex.rs
+++ b/src/geometry/unit_complex.rs
@@ -458,8 +458,7 @@ impl<T: RealField> UlpsEq for UnitComplex<T> {
 
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
-        self.re
-            .ulps_eq(&other.re, epsilon.clone(), max_ulps.clone())
+        self.re.ulps_eq(&other.re, epsilon.clone(), max_ulps)
             && self.im.ulps_eq(&other.im, epsilon, max_ulps)
     }
 }


### PR DESCRIPTION
This benchmark shows ~4% performance improvement.

```rust
use nalgebra as na;
use rand::prelude::*;
use std::time::{Duration, Instant};

fn main() {
    let mut time = Duration::ZERO;
    const N: usize = 500_000;
    for _ in 0..N {
        time += bench();
    }
    dbg!(time);
}

fn bench() -> Duration {
    let mut rng = thread_rng();
    let m1 = na::DMatrix::<f32>::new_random(rng.gen_range(10..100), rng.gen_range(10..100));

    let timer = Instant::now();
    let _ = m1.is_identity(1.0);
    timer.elapsed()
}
```