### PR TITLE
Remove `Dim::is()` function because it may be used in unsound ways

### DIFF
--- a/src/base/blas_uninit.rs
+++ b/src/base/blas_uninit.rs
@@ -22,6 +22,7 @@ use crate::base::dimension::{Dim, Dynamic, U1};
 use crate::base::storage::{RawStorage, RawStorageMut};
 use crate::base::uninit::InitStatus;
 use crate::base::{Matrix, Scalar, Vector};
+use crate::TypeEq;
 use std::any::TypeId;
 
 // # Safety

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -2,7 +2,7 @@
 
 //! Traits and tags for identifying the dimension of all algebraic entities.
 
-use std::any::{Any, TypeId};
+use std::any::Any;
 use std::cmp;
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Sub};
@@ -55,12 +55,7 @@ impl IsNotStaticOne for Dynamic {}
 
 /// Trait implemented by any type that can be used as a dimension. This includes type-level
 /// integers and `Dynamic` (for dimensions not known at compile-time).
-pub trait Dim: Any + Debug + Copy + PartialEq + Send + Sync {
-    #[inline(always)]
-    fn is<D: Dim>() -> bool {
-        TypeId::of::<Self>() == TypeId::of::<D>()
-    }
-
+pub trait Dim: Any + Debug + Copy + PartialEq + Send + Sync + 'static {
     /// Gets the compile-time value of `Self`. Returns `None` if it is not known, i.e., if `Self =
     /// Dynamic`.
     fn try_to_usize() -> Option<usize>;

--- a/src/base/matrix_slice.rs
+++ b/src/base/matrix_slice.rs
@@ -8,6 +8,7 @@ use crate::base::dimension::{Const, Dim, DimName, Dynamic, IsNotStaticOne, U1};
 use crate::base::iter::MatrixIter;
 use crate::base::storage::{IsContiguous, Owned, RawStorage, RawStorageMut, Storage};
 use crate::base::{Matrix, Scalar};
+use crate::TypeEq;
 
 macro_rules! slice_storage_impl(
     ($doc: expr; $Storage: ident as $SRef: ty; $T: ident.$get_addr: ident ($Ptr: ty as $Ref: ty)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub use base as core;
 pub use nalgebra_macros::{dmatrix, dvector, matrix, point, vector};
 
 use simba::scalar::SupersetOf;
+use std::any::TypeId;
 use std::cmp::{self, Ordering, PartialOrd};
 
 use num::{One, Signed, Zero};
@@ -530,3 +531,21 @@ pub fn try_convert_ref<From: SupersetOf<To>, To>(t: &From) -> Option<To> {
 pub fn convert_ref_unchecked<From: SupersetOf<To>, To>(t: &From) -> To {
     t.to_subset_unchecked()
 }
+
+/// A trait for comparing types.
+///
+/// # Safety
+///
+/// Poorly implemented `is()` function may cause undefined behavior.
+///
+/// If implementer of this trait wishes to override the provided `is()` function, extra care must
+/// be taken.
+pub unsafe trait TypeEq: 'static {
+    /// Checks if `Self` is `T`
+    fn is<T: 'static>() -> bool {
+        TypeId::of::<Self>() == TypeId::of::<T>()
+    }
+}
+
+/// SAFETY: we don't override `is()` function, so we're good.
+unsafe impl<T: 'static> TypeEq for T {}


### PR DESCRIPTION
Very similar to #957. This part of `nalgebra` will cause UB for a poorly implemented `Dim`:  https://github.com/dimforge/nalgebra/blob/7f236d88aab0c8310d759720c2d8b13bee8e5aeb/src/base/blas.rs#L48-L57

By the way, I think it should be fine to remove those lines. Thanks to monomorphisation, this function will (probably) get optimized anyway https://github.com/dimforge/nalgebra/blob/7f236d88aab0c8310d759720c2d8b13bee8e5aeb/src/base/matrix_slice.rs#L170-L175
