### PR TITLE
Add methods to compute the products of a single matrix components/row/columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - The conversion trait `From<Vec<T>>` and method `from_vec_storage` for `RowDVector`. See [#975](https://github.com/dimforge/nalgebra/issues/975)
 - Added implementation of `From` and `Into` for converting between `nalgebra` types and types from
   `glam 0.18`. These can be enabled by enabling the `convert-glam018` cargo features.
+- Added the methods `Matrix::product`, `::row_product`, `::row_product_tr`, and `::column_product` to compute the
+  product of the components, rows, or columns, of a single matrix or vector.
 
 ## [0.29.0]
 ### Breaking changes


### PR DESCRIPTION
This adds the methods `Matrix::product`, `::row_product`, `::row_product_tr`, and `::column_product` to compute the product of the components, rows, or columns, of a single matrix or vector.
This is similar to the existing `Matrix::sum`, `::row_sum`, `row_sum_tr`, and `::column_sum` methods.