### PR TITLE
Don't panic ScLERPing `UnitDualQuaternion` with equal rotation

### DIFF
--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -57,7 +57,10 @@ impl<T: Scalar> PartialEq for DualQuaternion<T> {
 
 impl<T: Scalar + Zero> Default for DualQuaternion<T> {
     fn default() -> Self {
-        Self { real: Quaternion::default(), dual: Quaternion::default() }
+        Self {
+            real: Quaternion::default(),
+            dual: Quaternion::default(),
+        }
     }
 }
 
@@ -472,7 +475,9 @@ where
     #[inline]
     #[must_use = "Did you mean to use inverse_mut()?"]
     pub fn inverse(&self) -> Self {
-        let real = Unit::new_unchecked(self.as_ref().real.clone()).inverse().into_inner();
+        let real = Unit::new_unchecked(self.as_ref().real.clone())
+            .inverse()
+            .into_inner();
         let dual = -real.clone() * self.as_ref().dual.clone() * real.clone();
         UnitDualQuaternion::new_unchecked(DualQuaternion { real, dual })
     }
@@ -494,7 +499,9 @@ where
     #[inline]
     pub fn inverse_mut(&mut self) {
         let quat = self.as_mut_unchecked();
-        quat.real = Unit::new_unchecked(quat.real.clone()).inverse().into_inner();
+        quat.real = Unit::new_unchecked(quat.real.clone())
+            .inverse()
+            .into_inner();
         quat.dual = -quat.real.clone() * quat.dual.clone() * quat.real.clone();
     }
 
@@ -661,8 +668,11 @@ where
         let norm_squared = difference.real.vector().norm_squared();
         if relative_eq!(norm_squared, T::zero(), epsilon = epsilon) {
             return Some(Self::from_parts(
-                self.translation().vector.lerp(&other.translation().vector, t).into(),
-                self.rotation()
+                self.translation()
+                    .vector
+                    .lerp(&other.translation().vector, t)
+                    .into(),
+                self.rotation(),
             ));
         }
 
@@ -675,8 +685,7 @@ where
         let mut pitch = -two * difference.dual.scalar() * inverse_norm.clone();
         let direction = difference.real.vector() * inverse_norm.clone();
         let moment = (difference.dual.vector()
-            - direction.clone()
-                * (pitch.clone() * difference.real.scalar() * half.clone()))
+            - direction.clone() * (pitch.clone() * difference.real.scalar() * half.clone()))
             * inverse_norm;
 
         angle *= t.clone();
@@ -974,7 +983,8 @@ impl<T: RealField + RelativeEq<Epsilon = T>> RelativeEq for UnitDualQuaternion<T
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.as_ref().relative_eq(other.as_ref(), epsilon, max_relative)
+        self.as_ref()
+            .relative_eq(other.as_ref(), epsilon, max_relative)
     }
 }
 

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -354,7 +354,7 @@ impl<T: RealField + UlpsEq<Epsilon = T>> UlpsEq for DualQuaternion<T> {
     }
 }
 
-/// A unit quaternions. May be used to represent a rotation followed by a
+/// A unit dual quaternion. May be used to represent a rotation followed by a
 /// translation.
 pub type UnitDualQuaternion<T> = Unit<DualQuaternion<T>>;
 


### PR DESCRIPTION
Solves #1013.

Previously, when screw-linearly interpolating two unit dual quaternions
that had an identical orientation, `try_sclerp` would return `None`, as
the operation would introduce a division-by-zero.

This PR splits out the cases where two unit dual quaternions have an
identical orientation from the cases where they have opposite
orientations. In the case where they have identical orientations, the
operation is well-defined, but the exponential parameterization could
not handle it without introducing NaNs. Therefore, the function detects
this case and simply defaults to linearly interpolating the
translational components and using one of the two inputs' rotation
components.

The case where the inputs have opposite rotations is now detected
separately using the dot product of the real (rotation) parts, which was
already being computed anyway.

Also introduces proptests for these specific scenarios, to avoid any
regression.