### PR TITLE
WIP: Implement Serde Serialize/Deserialize for nalgebra-sparse types (Again)

### DIFF
--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -13,8 +13,12 @@ keywords = [ "linear", "algebra", "matrix", "vector", "math" ]
 license = "Apache-2.0"
 
 [features]
+default = ["serde-serialize"]
 proptest-support = ["proptest", "nalgebra/proptest-support"]
 compare = [ "matrixcompare-core" ]
+# Sparse uses std::collection::Vec, so no-std is a non-starter for now
+# serde-serialize-no-std = [ "serde" ]
+serde-serialize        = [ "serde", "serde/std", "serde_test"]
 
 # Enable to enable running some tests that take a lot of time to run
 slow-tests = []
@@ -24,11 +28,14 @@ nalgebra = { version="0.29", path = "../" }
 num-traits = { version = "0.2", default-features = false }
 proptest = { version = "1.0", optional = true }
 matrixcompare-core = { version = "0.1.0", optional = true }
+serde = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
+serde_test = { version = "1.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.10"
 matrixcompare = { version = "0.3.0", features = [ "proptest-support" ] }
 nalgebra = { version="0.29", path = "../", features = ["compare"] }
+serde_json = "1.0"
 
 [package.metadata.docs.rs]
 # Enable certain features when building docs for docs.rs

--- a/nalgebra-sparse/src/csc.rs
+++ b/nalgebra-sparse/src/csc.rs
@@ -12,6 +12,9 @@ use nalgebra::Scalar;
 use num_traits::One;
 use std::slice::{Iter, IterMut};
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
 /// A CSC representation of a sparse matrix.
 ///
 /// The Compressed Sparse Column (CSC) format is well-suited as a general-purpose storage format
@@ -121,6 +124,7 @@ use std::slice::{Iter, IterMut};
 ///
 /// [Wikipedia article]: https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_column_(CSC_or_CCS)
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct CscMatrix<T> {
     // Cols are major, rows are minor in the sparsity pattern
     pub(crate) cs: CsMatrix<T>,

--- a/nalgebra-sparse/src/csr.rs
+++ b/nalgebra-sparse/src/csr.rs
@@ -13,6 +13,9 @@ use num_traits::One;
 use std::iter::FromIterator;
 use std::slice::{Iter, IterMut};
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
 /// A CSR representation of a sparse matrix.
 ///
 /// The Compressed Sparse Row (CSR) format is well-suited as a general-purpose storage format
@@ -122,6 +125,7 @@ use std::slice::{Iter, IterMut};
 ///
 /// [Wikipedia article]: https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct CsrMatrix<T> {
     // Rows are major, cols are minor in the sparsity pattern
     pub(crate) cs: CsMatrix<T>,

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -344,3 +344,16 @@ fn coo_push_matrix_out_of_bounds_entries() {
         assert_panics!(CooMatrix::new(3, 3).push_matrix(2, 2, &inserted));
     }
 }
+
+#[test]
+fn coo_serde() {
+    // Arbitrary matrix, with duplicates
+    let i = vec![0, 1, 0, 0, 0, 0, 2, 1];
+    let j = vec![0, 2, 0, 1, 0, 3, 3, 2];
+    let v = vec![2, 3, 4, 7, 1, 3, 1, 5];
+    let coo = CooMatrix::<i32>::try_from_triplets(3, 5, i.clone(), j.clone(), v.clone()).unwrap();
+
+    let serialized = serde_json::to_string(&coo).unwrap();
+    let deserialized = serde_json::from_str::<CooMatrix<i32>>(&serialized).unwrap();
+    assert_eq!(coo, deserialized);
+}

--- a/nalgebra-sparse/tests/unit_tests/csc.rs
+++ b/nalgebra-sparse/tests/unit_tests/csc.rs
@@ -28,21 +28,21 @@ fn csc_matrix_valid_data() {
         assert_eq!(matrix.ncols(), 3);
         assert_eq!(matrix.nnz(), 0);
         assert_eq!(matrix.col_offsets(), &[0, 0, 0, 0]);
-        assert_eq!(matrix.row_indices(), &[]);
-        assert_eq!(matrix.values(), &[]);
+        assert_eq!(matrix.row_indices(), &[0; 0]);
+        assert_eq!(matrix.values(), &[0; 0]);
 
         assert!(matrix.triplet_iter().next().is_none());
         assert!(matrix.triplet_iter_mut().next().is_none());
 
         assert_eq!(matrix.col(0).nrows(), 2);
         assert_eq!(matrix.col(0).nnz(), 0);
-        assert_eq!(matrix.col(0).row_indices(), &[]);
-        assert_eq!(matrix.col(0).values(), &[]);
+        assert_eq!(matrix.col(0).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col(0).values(), &[0; 0]);
         assert_eq!(matrix.col_mut(0).nrows(), 2);
         assert_eq!(matrix.col_mut(0).nnz(), 0);
-        assert_eq!(matrix.col_mut(0).row_indices(), &[]);
-        assert_eq!(matrix.col_mut(0).values(), &[]);
-        assert_eq!(matrix.col_mut(0).values_mut(), &[]);
+        assert_eq!(matrix.col_mut(0).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col_mut(0).values(), &[0; 0]);
+        assert_eq!(matrix.col_mut(0).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.col_mut(0).rows_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -50,13 +50,13 @@ fn csc_matrix_valid_data() {
 
         assert_eq!(matrix.col(1).nrows(), 2);
         assert_eq!(matrix.col(1).nnz(), 0);
-        assert_eq!(matrix.col(1).row_indices(), &[]);
-        assert_eq!(matrix.col(1).values(), &[]);
+        assert_eq!(matrix.col(1).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col(1).values(), &[0; 0]);
         assert_eq!(matrix.col_mut(1).nrows(), 2);
         assert_eq!(matrix.col_mut(1).nnz(), 0);
-        assert_eq!(matrix.col_mut(1).row_indices(), &[]);
-        assert_eq!(matrix.col_mut(1).values(), &[]);
-        assert_eq!(matrix.col_mut(1).values_mut(), &[]);
+        assert_eq!(matrix.col_mut(1).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col_mut(1).values(), &[0; 0]);
+        assert_eq!(matrix.col_mut(1).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.col_mut(1).rows_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -64,13 +64,13 @@ fn csc_matrix_valid_data() {
 
         assert_eq!(matrix.col(2).nrows(), 2);
         assert_eq!(matrix.col(2).nnz(), 0);
-        assert_eq!(matrix.col(2).row_indices(), &[]);
-        assert_eq!(matrix.col(2).values(), &[]);
+        assert_eq!(matrix.col(2).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col(2).values(), &[0; 0]);
         assert_eq!(matrix.col_mut(2).nrows(), 2);
         assert_eq!(matrix.col_mut(2).nnz(), 0);
-        assert_eq!(matrix.col_mut(2).row_indices(), &[]);
-        assert_eq!(matrix.col_mut(2).values(), &[]);
-        assert_eq!(matrix.col_mut(2).values_mut(), &[]);
+        assert_eq!(matrix.col_mut(2).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col_mut(2).values(), &[0; 0]);
+        assert_eq!(matrix.col_mut(2).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.col_mut(2).rows_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -82,8 +82,8 @@ fn csc_matrix_valid_data() {
         let (offsets, indices, values) = matrix.disassemble();
 
         assert_eq!(offsets, vec![0, 0, 0, 0]);
-        assert_eq!(indices, vec![]);
-        assert_eq!(values, vec![]);
+        assert_eq!(indices, Vec::<usize>::new());
+        assert_eq!(values, Vec::<i32>::new());
     }
 
     {
@@ -134,13 +134,13 @@ fn csc_matrix_valid_data() {
 
         assert_eq!(matrix.col(1).nrows(), 6);
         assert_eq!(matrix.col(1).nnz(), 0);
-        assert_eq!(matrix.col(1).row_indices(), &[]);
-        assert_eq!(matrix.col(1).values(), &[]);
+        assert_eq!(matrix.col(1).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col(1).values(), &[0; 0]);
         assert_eq!(matrix.col_mut(1).nrows(), 6);
         assert_eq!(matrix.col_mut(1).nnz(), 0);
-        assert_eq!(matrix.col_mut(1).row_indices(), &[]);
-        assert_eq!(matrix.col_mut(1).values(), &[]);
-        assert_eq!(matrix.col_mut(1).values_mut(), &[]);
+        assert_eq!(matrix.col_mut(1).row_indices(), &[0; 0]);
+        assert_eq!(matrix.col_mut(1).values(), &[0; 0]);
+        assert_eq!(matrix.col_mut(1).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.col_mut(1).rows_and_values_mut(),
             ([].as_ref(), [].as_mut())

--- a/nalgebra-sparse/tests/unit_tests/csr.rs
+++ b/nalgebra-sparse/tests/unit_tests/csr.rs
@@ -620,6 +620,42 @@ fn csr_matrix_row_iter() {
     }
 }
 
+#[test]
+fn csr_matrix_serde_roundtrip() {
+    let offsets = vec![0, 2, 2, 5];
+    let indices = vec![0, 5, 1, 2, 3];
+    let values = vec![0, 1, 2, 3, 4];
+    let matrix =
+        CsrMatrix::try_from_csr_data(3, 6, offsets.clone(), indices.clone(), values.clone())
+            .unwrap();
+    let serialized = serde_json::to_string(&matrix).unwrap();
+    let deserialized = serde_json::from_str::<CsrMatrix<i32>>(&serialized).unwrap();
+    assert_eq!(matrix, deserialized);
+}
+
+#[test]
+#[should_panic(expected = "Pattern non-zero count doesn't match number of values")]
+fn csr_matrix_serde() {
+    let offsets = vec![0, 2, 2, 5];
+    let indices = vec![0, 5, 1, 2, 3];
+    let values = vec![0, 1, 2, 3, 4];
+    let matrix =
+        CsrMatrix::try_from_csr_data(3, 6, offsets.clone(), indices.clone(), values.clone())
+            .unwrap();
+    let mut serialized = serde_json::to_value(&matrix).unwrap();
+    let obj = serialized.as_object_mut().unwrap();
+    // Patch the JSON to introduce
+    let values_array = obj
+        .get_mut("cs")
+        .unwrap()
+        .get_mut("values")
+        .unwrap()
+        .as_array_mut()
+        .unwrap();
+    values_array.pop();
+    let _deserialized = serde_json::from_value::<CsrMatrix<i32>>(serialized).unwrap();
+}
+
 proptest! {
     #[test]
     fn csr_double_transpose_is_identity(csr in csr_strategy()) {

--- a/nalgebra-sparse/tests/unit_tests/csr.rs
+++ b/nalgebra-sparse/tests/unit_tests/csr.rs
@@ -30,21 +30,21 @@ fn csr_matrix_valid_data() {
         assert_eq!(matrix.ncols(), 2);
         assert_eq!(matrix.nnz(), 0);
         assert_eq!(matrix.row_offsets(), &[0, 0, 0, 0]);
-        assert_eq!(matrix.col_indices(), &[]);
-        assert_eq!(matrix.values(), &[]);
+        assert_eq!(matrix.col_indices(), &[0; 0]);
+        assert_eq!(matrix.values(), &[0; 0]);
 
         assert!(matrix.triplet_iter().next().is_none());
         assert!(matrix.triplet_iter_mut().next().is_none());
 
         assert_eq!(matrix.row(0).ncols(), 2);
         assert_eq!(matrix.row(0).nnz(), 0);
-        assert_eq!(matrix.row(0).col_indices(), &[]);
-        assert_eq!(matrix.row(0).values(), &[]);
+        assert_eq!(matrix.row(0).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row(0).values(), &[0; 0]);
         assert_eq!(matrix.row_mut(0).ncols(), 2);
         assert_eq!(matrix.row_mut(0).nnz(), 0);
-        assert_eq!(matrix.row_mut(0).col_indices(), &[]);
-        assert_eq!(matrix.row_mut(0).values(), &[]);
-        assert_eq!(matrix.row_mut(0).values_mut(), &[]);
+        assert_eq!(matrix.row_mut(0).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row_mut(0).values(), &[0; 0]);
+        assert_eq!(matrix.row_mut(0).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.row_mut(0).cols_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -52,13 +52,13 @@ fn csr_matrix_valid_data() {
 
         assert_eq!(matrix.row(1).ncols(), 2);
         assert_eq!(matrix.row(1).nnz(), 0);
-        assert_eq!(matrix.row(1).col_indices(), &[]);
-        assert_eq!(matrix.row(1).values(), &[]);
+        assert_eq!(matrix.row(1).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row(1).values(), &[0; 0]);
         assert_eq!(matrix.row_mut(1).ncols(), 2);
         assert_eq!(matrix.row_mut(1).nnz(), 0);
-        assert_eq!(matrix.row_mut(1).col_indices(), &[]);
-        assert_eq!(matrix.row_mut(1).values(), &[]);
-        assert_eq!(matrix.row_mut(1).values_mut(), &[]);
+        assert_eq!(matrix.row_mut(1).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row_mut(1).values(), &[0; 0]);
+        assert_eq!(matrix.row_mut(1).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.row_mut(1).cols_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -66,13 +66,13 @@ fn csr_matrix_valid_data() {
 
         assert_eq!(matrix.row(2).ncols(), 2);
         assert_eq!(matrix.row(2).nnz(), 0);
-        assert_eq!(matrix.row(2).col_indices(), &[]);
-        assert_eq!(matrix.row(2).values(), &[]);
+        assert_eq!(matrix.row(2).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row(2).values(), &[0; 0]);
         assert_eq!(matrix.row_mut(2).ncols(), 2);
         assert_eq!(matrix.row_mut(2).nnz(), 0);
-        assert_eq!(matrix.row_mut(2).col_indices(), &[]);
-        assert_eq!(matrix.row_mut(2).values(), &[]);
-        assert_eq!(matrix.row_mut(2).values_mut(), &[]);
+        assert_eq!(matrix.row_mut(2).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row_mut(2).values(), &[0; 0]);
+        assert_eq!(matrix.row_mut(2).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.row_mut(2).cols_and_values_mut(),
             ([].as_ref(), [].as_mut())
@@ -84,8 +84,8 @@ fn csr_matrix_valid_data() {
         let (offsets, indices, values) = matrix.disassemble();
 
         assert_eq!(offsets, vec![0, 0, 0, 0]);
-        assert_eq!(indices, vec![]);
-        assert_eq!(values, vec![]);
+        assert_eq!(indices, Vec::<usize>::new());
+        assert_eq!(values, Vec::<i32>::new());
     }
 
     {
@@ -136,13 +136,13 @@ fn csr_matrix_valid_data() {
 
         assert_eq!(matrix.row(1).ncols(), 6);
         assert_eq!(matrix.row(1).nnz(), 0);
-        assert_eq!(matrix.row(1).col_indices(), &[]);
-        assert_eq!(matrix.row(1).values(), &[]);
+        assert_eq!(matrix.row(1).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row(1).values(), &[0; 0]);
         assert_eq!(matrix.row_mut(1).ncols(), 6);
         assert_eq!(matrix.row_mut(1).nnz(), 0);
-        assert_eq!(matrix.row_mut(1).col_indices(), &[]);
-        assert_eq!(matrix.row_mut(1).values(), &[]);
-        assert_eq!(matrix.row_mut(1).values_mut(), &[]);
+        assert_eq!(matrix.row_mut(1).col_indices(), &[0; 0]);
+        assert_eq!(matrix.row_mut(1).values(), &[0; 0]);
+        assert_eq!(matrix.row_mut(1).values_mut(), &[0; 0]);
         assert_eq!(
             matrix.row_mut(1).cols_and_values_mut(),
             ([].as_ref(), [].as_mut())

--- a/nalgebra-sparse/tests/unit_tests/pattern.rs
+++ b/nalgebra-sparse/tests/unit_tests/pattern.rs
@@ -152,3 +152,20 @@ fn sparsity_pattern_try_from_invalid_data() {
         assert_eq!(pattern, Err(SparsityPatternFormatError::DuplicateEntry));
     }
 }
+
+#[test]
+fn sparsity_pattern_serde() {
+    // Round trip
+    {
+        // Arbitrary pattern
+        let offsets = vec![0, 2, 2, 5];
+        let indices = vec![0, 5, 1, 2, 3];
+        let pattern =
+            SparsityPattern::try_from_offsets_and_indices(3, 6, offsets.clone(), indices.clone())
+                .unwrap();
+
+        let serialized = serde_json::to_string(&pattern).unwrap();
+        let deserialized = serde_json::from_str::<SparsityPattern>(&serialized).unwrap();
+        assert_eq!(pattern, deserialized);
+    }
+}

--- a/nalgebra-sparse/tests/unit_tests/pattern.rs
+++ b/nalgebra-sparse/tests/unit_tests/pattern.rs
@@ -15,17 +15,17 @@ fn sparsity_pattern_valid_data() {
         assert_eq!(pattern.minor_dim(), 2);
         assert_eq!(pattern.nnz(), 0);
         assert_eq!(pattern.major_offsets(), &[0, 0, 0, 0]);
-        assert_eq!(pattern.minor_indices(), &[]);
-        assert_eq!(pattern.lane(0), &[]);
-        assert_eq!(pattern.lane(1), &[]);
-        assert_eq!(pattern.lane(2), &[]);
+        assert_eq!(pattern.minor_indices(), &[0; 0]);
+        assert_eq!(pattern.lane(0), &[0; 0]);
+        assert_eq!(pattern.lane(1), &[0; 0]);
+        assert_eq!(pattern.lane(2), &[0; 0]);
         assert!(pattern.entries().next().is_none());
 
         assert_eq!(pattern, SparsityPattern::zeros(3, 2));
 
         let (offsets, indices) = pattern.disassemble();
         assert_eq!(offsets, vec![0, 0, 0, 0]);
-        assert_eq!(indices, vec![]);
+        assert_eq!(indices, Vec::<usize>::new());
     }
 
     {
@@ -42,7 +42,7 @@ fn sparsity_pattern_valid_data() {
         assert_eq!(pattern.minor_indices(), indices.as_slice());
         assert_eq!(pattern.nnz(), 5);
         assert_eq!(pattern.lane(0), &[0, 5]);
-        assert_eq!(pattern.lane(1), &[]);
+        assert_eq!(pattern.lane(1), &[0; 0]);
         assert_eq!(pattern.lane(2), &[1, 2, 3]);
         assert_eq!(
             pattern.entries().collect::<Vec<_>>(),


### PR DESCRIPTION
I'm opening this in response to seeing  https://github.com/dimforge/nalgebra/pull/1019

This PR is still a work in progress and hadn't yet nailed down a testing strategy.

Compared to #1019, my approach focuses on simplicity of code (e.g. it derives as much as possible), likely at the cost of simplicity and readability of the serialized output (which isn't important for my needs but might be for others). I don't have a strong preference for my approach over the one in #1019, but I figured I'd share and see what the maintainers think.

To get around using a helper struct, I'm using trick I saw here: https://github.com/serde-rs/serde/issues/1220

@w1th0utnam3 feel free to look and comment.