### PR TITLE
Add extern crate declarations for lapack{-src}

### DIFF
--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -73,6 +73,9 @@
     html_root_url = "https://nalgebra.org/rustdoc"
 )]
 
+extern crate lapack;
+extern crate lapack_src;
+
 extern crate nalgebra as na;
 extern crate num_traits as num;
 

--- a/nalgebra-lapack/tests/lib.rs
+++ b/nalgebra-lapack/tests/lib.rs
@@ -6,9 +6,6 @@ compile_error!("Tests must be run with `proptest-support`");
 extern crate nalgebra as na;
 extern crate nalgebra_lapack as nl;
 
-extern crate lapack;
-extern crate lapack_src;
-
 mod linalg;
 #[path = "../../tests/proptest/mod.rs"]
 mod proptest;


### PR DESCRIPTION
Without these declarations, `nalgebra-lapack` does not have runtime
linkage requirements for these libraries, meaning that binaries and
libraries using `nalgebra-lapack` have to link `lapack`/`lapack-src`
explicitly which shouldn't be necessary.