### PR TITLE
Implement DeviceCopy for UnitComplex, UnitQuaternion, and Unit<Matrix> instead of using a blanket impl

### DIFF
--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -26,10 +26,10 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
 #[derive(Clone, Hash, Copy)]
-#[cfg_attr(
-    all(not(target_os = "cuda"), feature = "cuda"),
-    derive(cust::DeviceCopy)
-)]
+// #[cfg_attr(
+//     all(not(target_os = "cuda"), feature = "cuda"),
+//     derive(cust::DeviceCopy)
+// )]
 pub struct Unit<T> {
     pub(crate) value: T,
 }
@@ -120,6 +120,17 @@ mod rkyv_impl {
             })
         }
     }
+}
+
+#[cfg(all(not(target_os = "cuda"), feature = "cuda"))]
+unsafe impl<T: cust::memory::DeviceCopy, R, C, S> cust::memory::DeviceCopy
+    for Unit<Matrix<T, R, C, S>>
+where
+    T: Scalar,
+    R: Dim,
+    C: Dim,
+    S: RawStorage<T, R, C> + Copy,
+{
 }
 
 impl<T, R, C, S> PartialEq for Unit<Matrix<T, R, C, S>>

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1068,6 +1068,9 @@ impl<T: RealField + fmt::Display> fmt::Display for Quaternion<T> {
 /// A unit quaternions. May be used to represent a rotation.
 pub type UnitQuaternion<T> = Unit<Quaternion<T>>;
 
+#[cfg(all(not(target_os = "cuda"), feature = "cuda"))]
+unsafe impl<T: cust::memory::DeviceCopy> cust::memory::DeviceCopy for UnitQuaternion<T> {}
+
 impl<T: Scalar + ClosedNeg + PartialEq> PartialEq for UnitQuaternion<T> {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {

--- a/src/geometry/unit_complex.rs
+++ b/src/geometry/unit_complex.rs
@@ -31,6 +31,9 @@ use std::cmp::{Eq, PartialEq};
 /// * [Conversion to a matrix <span style="float:right;">`to_rotation_matrix`, `to_homogeneous`…</span>](#conversion-to-a-matrix)
 pub type UnitComplex<T> = Unit<Complex<T>>;
 
+#[cfg(all(not(target_os = "cuda"), feature = "cuda"))]
+unsafe impl<T: cust::memory::DeviceCopy> cust::memory::DeviceCopy for UnitComplex<T> {}
+
 impl<T: Scalar + PartialEq> PartialEq for UnitComplex<T> {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {


### PR DESCRIPTION
It is still unclear whether or not the support of `Complex` by `Rust-CUDA` will be added as part of the [cust crate](https://github.com/Rust-GPU/Rust-CUDA/pull/10) or as part of the [num-complex crate](https://github.com/rust-num/num-complex/issues/97). In the mean time, this PR manually implements `DeviceCopy` for `UnitComplex` (and other unit types) instead of using `impl DeviceCopy for Unit<T>`.