### PR TITLE
Relax T: Zero bound on Matrix::select_rows() and Matrix::select_columns()

### DIFF
--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -14,7 +14,7 @@ use crate::base::{DefaultAllocator, Matrix, OMatrix, RowVector, Scalar, Vector};
 use crate::{Storage, UninitMatrix};
 use std::mem::MaybeUninit;
 
-/// # Rows and columns extraction
+/// # Triangular matrix extraction
 impl<T: Scalar + Zero, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Extracts the upper triangular part of this matrix (including the diagonal).
     #[inline]
@@ -41,7 +41,10 @@ impl<T: Scalar + Zero, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 
         res
     }
+}
 
+/// # Rows and columns extraction
+impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Creates a new matrix by extracting the given set of rows from `self`.
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[must_use]

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -92,6 +92,7 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// - [Interpolation <span style="float:right;">`lerp`, `slerp`…</span>](#interpolation)
 /// - [BLAS functions <span style="float:right;">`gemv`, `gemm`, `syger`…</span>](#blas-functions)
 /// - [Swizzling <span style="float:right;">`xx`, `yxz`…</span>](#swizzling)
+/// - [Triangular matrix extraction <span style="float:right;">`upper_triangle`, `lower_triangle`</span>](#triangular-matrix-extraction)
 ///
 /// #### Statistics
 /// - [Common operations <span style="float:right;">`row_sum`, `column_mean`, `variance`…</span>](#common-statistics-operations)


### PR DESCRIPTION
Original issue:  #1046.

Should I add  "Triangular matrix extraction" bullet to Matrix documentation, now as it is decoupled from select functions?