### PR TITLE
Sound implementation of from row iterator

### DIFF
--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -41,6 +41,13 @@ pub trait Allocator<T, R: Dim, C: Dim = U1>: Any + Sized {
         ncols: C,
         iter: I,
     ) -> Self::Buffer;
+
+    /// Allocates a buffer initialized with the content of the given row-major order iterator.
+    fn allocate_from_row_iterator<I: IntoIterator<Item = T>>(
+        nrows: R,
+        ncols: C,
+        iter: I,
+    ) -> Self::Buffer;
 }
 
 /// A matrix reallocator. Changes the size of the memory buffer that initially contains (`RFrom` ×

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -86,6 +86,17 @@ where
         Self::from_data(DefaultAllocator::allocate_from_iterator(nrows, ncols, iter))
     }
 
+    /// Creates a matrix with all its elements filled by an row-major order iterator.
+    #[inline]
+    pub fn from_row_iterator_generic<I>(nrows: R, ncols: C, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self::from_data(DefaultAllocator::allocate_from_row_iterator(
+            nrows, ncols, iter,
+        ))
+    }
+
     /// Creates a matrix with its elements filled with the components provided by a slice in
     /// row-major order.
     ///
@@ -477,6 +488,36 @@ macro_rules! impl_constructors(
         pub fn from_iterator<I>($($args: usize,)* iter: I) -> Self
             where I: IntoIterator<Item = T> {
             Self::from_iterator_generic($($gargs, )* iter)
+        }
+
+        /// Creates a matrix or vector with all its elements filled by a row-major iterator.
+        ///
+        /// The output matrix is filled row-by-row.
+        ///
+        /// ## Example
+        /// ```
+        /// # use nalgebra::{Matrix2x3, Vector3, DVector, DMatrix};
+        /// # use std::iter;
+        ///
+        /// let v = Vector3::from_row_iterator((0..3).into_iter());
+        /// // The additional argument represents the vector dimension.
+        /// let dv = DVector::from_row_iterator(3, (0..3).into_iter());
+        /// let m = Matrix2x3::from_row_iterator((0..6).into_iter());
+        /// // The two additional arguments represent the matrix dimensions.
+        /// let dm = DMatrix::from_row_iterator(2, 3, (0..6).into_iter());
+        ///
+        /// // For Vectors from_row_iterator is identical to from_iterator
+        /// assert!(v.x == 0 && v.y == 1 && v.z == 2);
+        /// assert!(dv[0] == 0 && dv[1] == 1 && dv[2] == 2);
+        /// assert!(m.m11 == 0 && m.m12 == 1 && m.m13 == 2 &&
+        ///         m.m21 == 3 && m.m22 == 4 && m.m23 == 5);
+        /// assert!(dm[(0, 0)] == 0 && dm[(0, 1)] == 1 && dm[(0, 2)] == 2 &&
+        ///         dm[(1, 0)] == 3 && dm[(1, 1)] == 4 && dm[(1, 2)] == 5);
+        /// ```
+        #[inline]
+        pub fn from_row_iterator<I>($($args: usize,)* iter: I) -> Self
+            where I: IntoIterator<Item = T> {
+            Self::from_row_iterator_generic($($gargs, )* iter)
         }
 
         /// Creates a matrix or vector filled with the results of a function applied to each of its

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -98,7 +98,8 @@ impl<T: Scalar, const R: usize, const C: usize> Allocator<T, Const<R>, Const<C>>
         {
             unsafe {
                 *res_ptr
-                    .get_unchecked_mut((i % ncols.value()) * nrows.value() + i / ncols.value()) = MaybeUninit::new(e);
+                    .get_unchecked_mut((i % ncols.value()) * nrows.value() + i / ncols.value()) =
+                    MaybeUninit::new(e);
             }
             // res_ptr[(i % ncols.value()) * nrows.value() + i / ncols.value()] = e;
             count += 1;
@@ -247,7 +248,8 @@ impl<T: Scalar, R: DimName> Allocator<T, R, Dynamic> for DefaultAllocator {
 
         unsafe {
             for (i, e) in it.enumerate() {
-                *res_ptr.add((i % ncols.value()) * nrows.value() + i / ncols.value()) = MaybeUninit::new(e).assume_init();
+                *res_ptr.add((i % ncols.value()) * nrows.value() + i / ncols.value()) =
+                    MaybeUninit::new(e).assume_init();
                 count += 1;
             }
             res.set_len(nrows.value() * ncols.value());


### PR DESCRIPTION
I noticed that there already was a  PR(#888) for #850, but the requested changes were not implemented since they were requested a couple of month ago.

In order to achieve the requested features I:

1. Forked the repository used in #888, in order to maintain the contribution made by @chammika-become 
2. Rebased the branch _from_row_iterator_  with the current commit of the _dev_ branch of nalgebra
3. Allocated the buffer through `allocate_uninit`
4. Initialized the stored values through `MaybeUninit::new`
5. Called `Self::assume_init` when returning the result