### PR TITLE
Cleanup examples and doc links

### DIFF
--- a/nalgebra-macros/src/lib.rs
+++ b/nalgebra-macros/src/lib.rs
@@ -125,7 +125,6 @@ impl Parse for Matrix {
 /// (`;`) designates that a new row begins.
 ///
 /// # Examples
-///
 /// ```
 /// use nalgebra::matrix;
 ///
@@ -170,6 +169,7 @@ pub fn matrix(stream: TokenStream) -> TokenStream {
 /// `SMatrix`, it produces instances of `DMatrix`. At the moment it is not usable
 /// in `const fn` contexts.
 ///
+/// # Example
 /// ```
 /// use nalgebra::dmatrix;
 ///
@@ -243,8 +243,7 @@ impl Parse for Vector {
 /// `vector!` is intended to be the most readable and performant way of constructing small,
 /// fixed-size vectors, and it is usable in `const fn` contexts.
 ///
-/// ## Examples
-///
+/// # Example
 /// ```
 /// use nalgebra::vector;
 ///
@@ -271,6 +270,7 @@ pub fn vector(stream: TokenStream) -> TokenStream {
 /// `SVector`, it produces instances of `DVector`. At the moment it is not usable
 /// in `const fn` contexts.
 ///
+/// # Example
 /// ```
 /// use nalgebra::dvector;
 ///
@@ -301,8 +301,7 @@ pub fn dvector(stream: TokenStream) -> TokenStream {
 /// `point!` is intended to be the most readable and performant way of constructing small,
 /// points, and it is usable in `const fn` contexts.
 ///
-/// ## Examples
-///
+/// # Example
 /// ```
 /// use nalgebra::point;
 ///

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -175,8 +175,7 @@ where
     /// Note that this is **not** the matrix multiplication as in, e.g., numpy. For matrix
     /// multiplication, use one of: `.gemm`, `.mul_to`, `.mul`, the `*` operator.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Vector3, Matrix2x3};
     /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
@@ -207,8 +206,7 @@ where
     /// Note that this is **not** the matrix multiplication as in, e.g., numpy. For matrix
     /// multiplication, use one of: `.gemm`, `.mul_to`, `.mul`, the `*` operator.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Vector2, Complex};
     /// let vec1 = Vector2::new(Complex::new(1.0, 2.0), Complex::new(3.0, 4.0));
@@ -232,8 +230,7 @@ where
 
     /// The dot product between the transpose of `self` and `rhs`.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Vector3, RowVector3, Matrix2x3, Matrix3x2};
     /// let vec1 = Vector3::new(1.0, 2.0, 3.0);
@@ -285,8 +282,7 @@ where
     ///
     /// If `b` is zero, `self` is never read from.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Vector3;
     /// let mut vec1 = Vector3::new(1.0, 2.0, 3.0);
@@ -308,8 +304,7 @@ where
     ///
     /// If `b` is zero, `self` is never read from.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Vector3;
     /// let mut vec1 = Vector3::new(1.0, 2.0, 3.0);
@@ -333,8 +328,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2};
     /// let mut vec1 = Vector2::new(1.0, 2.0);
@@ -425,8 +419,7 @@ where
     /// If `beta` is zero, `self` is never read. If `self` is read, only its lower-triangular part
     /// (including the diagonal) is actually read.
     ///
-    /// # Examples:
-    ///
+    /// # Examples
     /// ```
     /// # use nalgebra::{Matrix2, Vector2};
     /// let mat = Matrix2::new(1.0, 2.0,
@@ -468,8 +461,7 @@ where
     /// If `beta` is zero, `self` is never read. If `self` is read, only its lower-triangular part
     /// (including the diagonal) is actually read.
     ///
-    /// # Examples:
-    ///
+    /// # Examples
     /// ```
     /// # use nalgebra::{Matrix2, Vector2, Complex};
     /// let mat = Matrix2::new(Complex::new(1.0, 0.0), Complex::new(2.0, -0.1),
@@ -552,8 +544,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2};
     /// let mat = Matrix2::new(1.0, 3.0,
@@ -587,8 +578,7 @@ where
     /// For real matrices, this is the same as `.gemv_tr`.
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2, Complex};
     /// let mat = Matrix2::new(Complex::new(1.0, 2.0), Complex::new(3.0, 4.0),
@@ -656,8 +646,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2x3, Vector2, Vector3};
     /// let mut mat = Matrix2x3::repeat(4.0);
@@ -688,8 +677,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix2x3, Vector2, Vector3, Complex};
@@ -722,8 +710,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix2x3, Matrix3x4, Matrix2x4};
@@ -763,8 +750,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix3x2, Matrix3x4, Matrix2x4};
@@ -821,8 +807,7 @@ where
     ///
     /// If `beta` is zero, `self` is never read.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix3x2, Matrix3x4, Matrix2x4, Complex};
@@ -921,8 +906,7 @@ where
     /// If `beta` is zero, `self` is never read. The result is symmetric. Only the lower-triangular
     /// (including the diagonal) part of `self` is read/written.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2};
     /// let mut mat = Matrix2::identity();
@@ -934,6 +918,7 @@ where
     /// mat.ger_symm(10.0, &vec1, &vec2, 5.0);
     /// assert_eq!(mat.lower_triangle(), expected.lower_triangle());
     /// assert_eq!(mat.m12, 99999.99999); // This was untouched.
+    /// ```
     #[inline]
     #[deprecated(note = "This is renamed `syger` to match the original BLAS terminology.")]
     pub fn ger_symm<D2: Dim, D3: Dim, SB, SC>(
@@ -958,8 +943,7 @@ where
     /// If `beta` is zero, `self` is never read. The result is symmetric. Only the lower-triangular
     /// (including the diagonal) part of `self` is read/written.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2};
     /// let mut mat = Matrix2::identity();
@@ -971,6 +955,7 @@ where
     /// mat.syger(10.0, &vec1, &vec2, 5.0);
     /// assert_eq!(mat.lower_triangle(), expected.lower_triangle());
     /// assert_eq!(mat.m12, 99999.99999); // This was untouched.
+    /// ```
     #[inline]
     pub fn syger<D2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -993,8 +978,7 @@ where
     /// If `beta` is zero, `self` is never read. The result is symmetric. Only the lower-triangular
     /// (including the diagonal) part of `self` is read/written.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::{Matrix2, Vector2, Complex};
     /// let mut mat = Matrix2::identity();
@@ -1006,6 +990,7 @@ where
     /// mat.hegerc(Complex::new(10.0, 20.0), &vec1, &vec2, Complex::new(5.0, 15.0));
     /// assert_eq!(mat.lower_triangle(), expected.lower_triangle());
     /// assert_eq!(mat.m12, Complex::new(99999.99999, 88888.88888)); // This was untouched.
+    /// ```
     #[inline]
     pub fn hegerc<D2: Dim, D3: Dim, SB, SC>(
         &mut self,
@@ -1031,8 +1016,7 @@ where
     ///
     /// This uses the provided workspace `work` to avoid allocations for intermediate results.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{DMatrix, DVector};
@@ -1053,6 +1037,7 @@ where
     ///
     /// mat.quadform_tr_with_workspace(&mut workspace, 10.0, &lhs, &mid, 5.0);
     /// assert_relative_eq!(mat, expected);
+    /// ```
     pub fn quadform_tr_with_workspace<D2, S2, R3, C3, S3, D4, S4>(
         &mut self,
         work: &mut Vector<T, D2, S2>,
@@ -1085,8 +1070,7 @@ where
     /// If `D1` is a type-level integer, then the allocation is performed on the stack.
     /// Use `.quadform_tr_with_workspace(...)` instead to avoid allocations.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix2, Matrix3, Matrix2x3, Vector2};
@@ -1100,6 +1084,7 @@ where
     ///
     /// mat.quadform_tr(10.0, &lhs, &mid, 5.0);
     /// assert_relative_eq!(mat, expected);
+    /// ```
     pub fn quadform_tr<R3, C3, S3, D4, S4>(
         &mut self,
         alpha: T,
@@ -1124,6 +1109,7 @@ where
     ///
     /// This uses the provided workspace `work` to avoid allocations for intermediate results.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{DMatrix, DVector};
@@ -1145,6 +1131,7 @@ where
     ///
     /// mat.quadform_with_workspace(&mut workspace, 10.0, &mid, &rhs, 5.0);
     /// assert_relative_eq!(mat, expected);
+    /// ```
     pub fn quadform_with_workspace<D2, S2, D3, S3, R4, C4, S4>(
         &mut self,
         work: &mut Vector<T, D2, S2>,
@@ -1180,6 +1167,7 @@ where
     /// If `D2` is a type-level integer, then the allocation is performed on the stack.
     /// Use `.quadform_with_workspace(...)` instead to avoid allocations.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix2, Matrix3x2, Matrix3};
@@ -1194,6 +1182,7 @@ where
     ///
     /// mat.quadform(10.0, &mid, &rhs, 5.0);
     /// assert_relative_eq!(mat, expected);
+    /// ```
     pub fn quadform<D2, S2, R3, C3, S3>(
         &mut self,
         alpha: T,

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1122,7 +1122,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     }
 
     /// Iterate through the columns of this matrix.
-    /// 
+    ///
     /// # Example
     /// ```
     /// # use nalgebra::Matrix2x3;

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -414,8 +414,6 @@ where
 {
     /// Assumes a matrix's entries to be initialized. This operation should be near zero-cost.
     ///
-    /// For the similar method that operates on matrix slices, see [`slice_assume_init`].
-    ///
     /// # Safety
     /// The user must make sure that every single entry of the buffer has been initialized,
     /// or Undefined Behavior will immediately occur.
@@ -436,12 +434,12 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 
     /// The shape of this matrix returned as the tuple (number of rows, number of columns).
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Matrix3x4;
     /// let mat = Matrix3x4::<f32>::zeros();
     /// assert_eq!(mat.shape(), (3, 4));
+    /// ```
     #[inline]
     #[must_use]
     pub fn shape(&self) -> (usize, usize) {
@@ -458,12 +456,12 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 
     /// The number of rows of this matrix.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Matrix3x4;
     /// let mat = Matrix3x4::<f32>::zeros();
     /// assert_eq!(mat.nrows(), 3);
+    /// ```
     #[inline]
     #[must_use]
     pub fn nrows(&self) -> usize {
@@ -472,12 +470,12 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 
     /// The number of columns of this matrix.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Matrix3x4;
     /// let mat = Matrix3x4::<f32>::zeros();
     /// assert_eq!(mat.ncols(), 4);
+    /// ```
     #[inline]
     #[must_use]
     pub fn ncols(&self) -> usize {
@@ -486,14 +484,14 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 
     /// The strides (row stride, column stride) of this matrix.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::DMatrix;
     /// let mat = DMatrix::<f32>::zeros(10, 10);
     /// let slice = mat.slice_with_steps((0, 0), (5, 3), (1, 2));
     /// // The column strides is the number of steps (here 2) multiplied by the corresponding dimension.
     /// assert_eq!(mat.strides(), (1, 10));
+    /// ```
     #[inline]
     #[must_use]
     pub fn strides(&self) -> (usize, usize) {
@@ -1088,8 +1086,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// Iterates through this matrix coordinates in column-major order.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::Matrix2x3;
     /// let mat = Matrix2x3::new(11, 12, 13,
@@ -1102,6 +1099,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// assert_eq!(*it.next().unwrap(), 13);
     /// assert_eq!(*it.next().unwrap(), 23);
     /// assert!(it.next().is_none());
+    /// ```
     #[inline]
     pub fn iter(&self) -> MatrixIter<'_, T, R, C, S> {
         MatrixIter::new(&self.data)
@@ -1124,6 +1122,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     }
 
     /// Iterate through the columns of this matrix.
+    /// 
     /// # Example
     /// ```
     /// # use nalgebra::Matrix2x3;

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -19,6 +19,7 @@ use simba::scalar::{ClosedNeg, RealField};
 /// `DualQuaternions` are stored as \[..real, ..dual\].
 /// Both of the quaternion components are laid out in `i, j, k, w` order.
 ///
+/// # Example
 /// ```
 /// # use nalgebra::{DualQuaternion, Quaternion};
 ///
@@ -623,6 +624,7 @@ where
     ///     dq.rotation().euler_angles().0, std::f32::consts::FRAC_PI_2, epsilon = 1.0e-6
     /// );
     /// assert_relative_eq!(dq.translation().vector.y, 3.0, epsilon = 1.0e-6);
+    /// ```
     #[inline]
     #[must_use]
     pub fn sclerp(&self, other: &Self, t: T) -> Self
@@ -713,6 +715,7 @@ where
 
     /// Return the rotation part of this unit dual quaternion.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3};
@@ -733,6 +736,7 @@ where
 
     /// Return the translation part of this unit dual quaternion.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3};
@@ -758,6 +762,7 @@ where
 
     /// Builds an isometry from this unit dual quaternion.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3};
@@ -783,6 +788,7 @@ where
     ///
     /// This is the same as the multiplication `self * pt`.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3, Point3};
@@ -807,6 +813,7 @@ where
     ///
     /// This is the same as the multiplication `self * v`.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3};
@@ -831,6 +838,7 @@ where
     /// This may be cheaper than inverting the unit dual quaternion and
     /// transforming the point.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3, Point3};
@@ -856,6 +864,7 @@ where
     /// This may be cheaper than inverting the unit dual quaternion and
     /// transforming the vector.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3};
@@ -880,6 +889,7 @@ where
     /// cheaper than inverting the unit dual quaternion and transforming the
     /// vector.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Unit, Vector3};
@@ -909,6 +919,7 @@ where
     /// Converts this unit dual quaternion interpreted as an isometry
     /// into its equivalent homogeneous transformation matrix.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Matrix4, UnitDualQuaternion, UnitQuaternion, Vector3};

--- a/src/geometry/dual_quaternion_construction.rs
+++ b/src/geometry/dual_quaternion_construction.rs
@@ -27,7 +27,6 @@ impl<T: Scalar> DualQuaternion<T> {
     /// The dual quaternion multiplicative identity.
     ///
     /// # Example
-    ///
     /// ```
     /// # use nalgebra::{DualQuaternion, Quaternion};
     ///
@@ -134,6 +133,7 @@ impl<T: SimdRealField> UnitDualQuaternion<T> {
     /// The unit dual quaternion multiplicative identity, which also represents
     /// the identity transformation as an isometry.
     ///
+    /// # Example
     /// ```
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3, Point3};
     /// let ident = UnitDualQuaternion::identity();
@@ -171,6 +171,7 @@ where
     /// Return a dual quaternion representing the translation and orientation
     /// given by the provided rotation quaternion and translation vector.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{UnitDualQuaternion, UnitQuaternion, Vector3, Point3};
@@ -196,6 +197,7 @@ where
     /// Return a unit dual quaternion representing the translation and orientation
     /// given by the provided isometry.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::{Isometry3, UnitDualQuaternion, UnitQuaternion, Vector3, Point3};

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -319,6 +319,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The left offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -336,6 +337,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The right offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -353,6 +355,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The bottom offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -370,6 +373,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The top offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -387,6 +391,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The near plane offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -404,6 +409,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// The far plane offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -526,6 +532,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the left offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -545,6 +552,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the right offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -564,6 +572,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the bottom offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -583,6 +592,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the top offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -602,6 +612,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the near plane offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -621,6 +632,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the far plane offset of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -640,6 +652,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the view cuboid offsets along the `x` axis.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -665,6 +678,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the view cuboid offsets along the `y` axis.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;
@@ -690,6 +704,7 @@ impl<T: RealField> Orthographic3<T> {
 
     /// Sets the near and far plane offsets of the view cuboid.
     ///
+    /// # Example
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use nalgebra::Orthographic3;

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -267,6 +267,7 @@ where
     /// assert_eq!(it.next(), Some(2.0));
     /// assert_eq!(it.next(), Some(3.0));
     /// assert_eq!(it.next(), None);
+    /// ```
     #[inline]
     pub fn iter(
         &self,
@@ -293,6 +294,7 @@ where
     /// }
     ///
     /// assert_eq!(p, Point3::new(10.0, 20.0, 30.0));
+    /// ```
     #[inline]
     pub fn iter_mut(
         &mut self,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -405,6 +405,7 @@ where
     /// let expected = Quaternion::new(-20.0, 0.0, 0.0, 0.0);
     /// let result = a.inner(&b);
     /// assert_relative_eq!(expected, result, epsilon = 1.0e-5);
+    /// ```
     #[inline]
     #[must_use]
     pub fn inner(&self, other: &Self) -> Self {
@@ -1230,8 +1231,7 @@ where
     /// Panics if the angle between both quaternion is 180 degrees (in which case the interpolation
     /// is not well-defined). Use `.try_slerp` instead to avoid the panic.
     ///
-    /// # Examples:
-    ///
+    /// # Example
     /// ```
     /// # use nalgebra::geometry::UnitQuaternion;
     ///
@@ -1453,7 +1453,6 @@ where
     /// Builds a rotation matrix from this unit quaternion.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1536,7 +1535,6 @@ where
     /// Converts this unit quaternion into its equivalent homogeneous transformation matrix.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1560,7 +1558,6 @@ where
     /// This is the same as the multiplication `self * pt`.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1581,7 +1578,6 @@ where
     /// This is the same as the multiplication `self * v`.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1602,7 +1598,6 @@ where
     /// point.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1625,7 +1620,6 @@ where
     /// vector.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -1646,7 +1640,6 @@ where
     /// vector.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -38,7 +38,6 @@ where
     /// Creates a new identity similarity.
     ///
     /// # Example
-    ///
     /// ```
     /// # use nalgebra::{Similarity2, Point2, Similarity3, Point3};
     ///
@@ -95,7 +94,6 @@ where
     /// its axis passing through the point `p`.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -146,7 +144,6 @@ where
     /// Creates a new similarity from a translation, a rotation, and an uniform scaling factor.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -188,7 +185,6 @@ where
     /// Creates a new similarity from a translation and a rotation angle.
     ///
     /// # Example
-    ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// # use std::f32;
@@ -232,7 +228,6 @@ macro_rules! similarity_construction_impl(
             /// factor.
             ///
             /// # Example
-            ///
             /// ```
             /// # #[macro_use] extern crate approx;
             /// # use std::f32;
@@ -288,7 +283,6 @@ macro_rules! similarity_construction_impl(
             ///   to `eye - at`. Non-collinearity is not checked.
             ///
             /// # Example
-            ///
             /// ```
             /// # #[macro_use] extern crate approx;
             /// # use std::f32;
@@ -316,7 +310,7 @@ macro_rules! similarity_construction_impl(
                 Self::from_isometry(Isometry::<_, $Rot<T>, 3>::face_towards(eye, target, up), scaling)
             }
 
-            /// Deprecated: Use [`SimilarityMatrix3::face_towards`] instead.
+            /// Deprecated: Use [`SimilarityMatrix3::face_towards`](Self::face_towards) instead.
             #[deprecated(note="renamed to `face_towards`")]
             pub fn new_observer_frames(eye:    &Point3<T>,
                                        target: &Point3<T>,
@@ -338,7 +332,6 @@ macro_rules! similarity_construction_impl(
             ///   requirement of this parameter is to not be collinear to `target - eye`.
             ///
             /// # Example
-            ///
             /// ```
             /// # #[macro_use] extern crate approx;
             /// # use std::f32;
@@ -376,7 +369,6 @@ macro_rules! similarity_construction_impl(
             ///   requirement of this parameter is to not be collinear to `target - eye`.
             ///
             /// # Example
-            ///
             /// ```
             /// # #[macro_use] extern crate approx;
             /// # use std::f32;

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -231,6 +231,7 @@ impl<T: Scalar + ClosedAdd, const D: usize> Translation<T, D> {
     /// let t = Translation3::new(1.0, 2.0, 3.0);
     /// let transformed_point = t.transform_point(&Point3::new(4.0, 5.0, 6.0));
     /// assert_eq!(transformed_point, Point3::new(5.0, 7.0, 9.0));
+    /// ```
     #[inline]
     #[must_use]
     pub fn transform_point(&self, pt: &Point<T, D>) -> Point<T, D> {
@@ -247,6 +248,7 @@ impl<T: Scalar + ClosedSub, const D: usize> Translation<T, D> {
     /// let t = Translation3::new(1.0, 2.0, 3.0);
     /// let transformed_point = t.inverse_transform_point(&Point3::new(4.0, 5.0, 6.0));
     /// assert_eq!(transformed_point, Point3::new(3.0, 3.0, 3.0));
+    /// ```
     #[inline]
     #[must_use]
     pub fn inverse_transform_point(&self, pt: &Point<T, D>) -> Point<T, D> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ pub fn min<T: Ord>(a: T, b: T) -> T {
 
 /// The absolute value of `a`.
 ///
-/// Deprecated: Use [`Matrix::abs`] or [`RealField::abs`] instead.
-#[deprecated(note = "use the inherent method `Matrix::abs` or `RealField::abs` instead")]
+/// Deprecated: Use [`Matrix::abs`] or [`ComplexField::abs`] instead.
+#[deprecated(note = "use the inherent method `Matrix::abs` or `ComplexField::abs` instead")]
 #[inline]
 pub fn abs<T: Signed>(a: &T) -> T {
     a.abs()


### PR DESCRIPTION
Close example code fences and normalize containing head line in touched files.
Remove stale reference to `slice_assume_init` (commit 8c6ebf27), fix long dead internal links in deprecation notices.