### PR TITLE
Generalized `slerp()` and `powf()` for `Rotation<T,N>`

### DIFF
--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -140,7 +140,8 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
                 transmute::<&Rotation3<T>,&Self>(&self3d.slerp_3d(other3d, t)).clone()
             },
 
-            _ => self * (self/other).powf(t)
+            //the multiplication order matters here
+            _ => (other/self).powf(t) * self
         }
 
     }

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -118,7 +118,8 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
     pub fn general_pow(self, t:T) -> Self {
         if D<=1 { return self; }
 
-        // println!("r:{}", self);
+        println!("r:{}", self);
+        println!("{}", self.clone().into_inner().hessenberg().unpack_h());
 
         //taking the (real) schur form is guaranteed to produce a block-diagonal matrix
         //where each block is either a 1 (if there's no rotation in that axis) or a 2x2
@@ -163,58 +164,5 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
         Self::from_matrix_unchecked(q * d * qt)
 
     }
-
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-    use std::f64::consts::PI;
-
-    const EPS: f64 = 2E-10;
-
-    #[test]
-    fn rot_pow() {
-
-        let r1 = Rotation2::new(0.0);
-        let r2 = Rotation2::new(PI/4.0);
-        let r3 = Rotation2::new(PI/2.0);
-
-        assert_relative_eq!(r1.general_pow(0.5), r1, epsilon=EPS);
-        assert_relative_eq!(r3.general_pow(0.5), r2, epsilon=EPS);
-
-    }
-
-    #[test]
-    fn basis_rot() {
-
-        const D:usize = 4;
-
-        let basis_blades = |n| (0..n).flat_map(
-            move |i| (i..n).map(move |j| (i,j))
-        ).filter(|(i,j)| i!=j);
-
-        for (i1,j1) in basis_blades(D) {
-
-            for (i2,j2) in basis_blades(D) {
-
-                if i1==i2 || j1==j2 || i1==j2 || j1==i2 { continue; }
-
-                let r1 = Rotation::<_,D>::basis_rot(i1,j1,PI/4.0) *
-                    Rotation::<_,D>::basis_rot(i2,j2,PI/4.0);
-                let r2 = Rotation::<_,D>::basis_rot(i1,j1,PI/2.0) *
-                    Rotation::<_,D>::basis_rot(i2,j2,PI/2.0);
-
-                println!("{}{}",r1,r2);
-
-                assert_relative_eq!(r2.general_pow(0.5), r1, epsilon=EPS);
-
-            }
-
-        }
-
-    }
-
 
 }

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -118,11 +118,15 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
     pub fn general_pow(self, t:T) -> Self {
         if D<=1 { return self; }
 
+        println!("r:{}", self);
+
         //taking the (real) schur form is guaranteed to produce a block-diagonal matrix
         //where each block is either a 1 (if there's no rotation in that axis) or a 2x2
         //rotation matrix in a particular plane
         let schur = self.into_inner().schur();
         let (q, mut d) = schur.unpack();
+
+        println!("q:{}d:{:.3}", q, d);
 
         //go down the diagonal and pow every block
         for i in 0..(D-1) {
@@ -131,9 +135,13 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
             //NOTE: the impl of the schur decomposition always sets the inferior diagonal to 0
             if !d[(i+1,i)].is_zero() {
 
+                println!("{}", i);
+
                 //convert to a complex num and take the arg()
                 let (c, s) = (d[(i,i)].clone(), d[(i+1,i)].clone());
                 let angle = s.atan2(c);
+
+                println!("{}", angle);
 
                 //scale the arg and exponentiate back
                 let angle2 = angle * t.clone();
@@ -148,6 +156,7 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
             }
 
         }
+        println!("d:{:.3}", d);
 
         let qt = q.transpose(); //avoids an extra clone
 

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -118,7 +118,7 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
     pub fn general_pow(self, t:T) -> Self {
         if D<=1 { return self; }
 
-        println!("r:{}", self);
+        // println!("r:{}", self);
 
         //taking the (real) schur form is guaranteed to produce a block-diagonal matrix
         //where each block is either a 1 (if there's no rotation in that axis) or a 2x2
@@ -126,7 +126,7 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
         let schur = self.into_inner().schur();
         let (q, mut d) = schur.unpack();
 
-        println!("q:{}d:{:.3}", q, d);
+        // println!("q:{}d:{:.3}", q, d);
 
         //go down the diagonal and pow every block
         for i in 0..(D-1) {
@@ -135,13 +135,13 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
             //NOTE: the impl of the schur decomposition always sets the inferior diagonal to 0
             if !d[(i+1,i)].is_zero() {
 
-                println!("{}", i);
+                // println!("{}", i);
 
                 //convert to a complex num and take the arg()
                 let (c, s) = (d[(i,i)].clone(), d[(i+1,i)].clone());
                 let angle = s.atan2(c);
 
-                println!("{}", angle);
+                // println!("{}", angle);
 
                 //scale the arg and exponentiate back
                 let angle2 = angle * t.clone();
@@ -156,7 +156,7 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
             }
 
         }
-        println!("d:{:.3}", d);
+        // println!("d:{:.3}", d);
 
         let qt = q.transpose(); //avoids an extra clone
 

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -89,11 +89,26 @@ impl<T:RealField, const D: usize> Rotation<T,D> where
         Allocator<T,DimDiff<Const<D>,U1>>
 {
 
+    ///
+    /// Computes the spherical linear interpolation between two general rotations.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use nalgebra::geometry::Rotation3;
+    ///
+    /// let q1 = Rotation3::from_euler_angles(std::f32::consts::FRAC_PI_4, 0.0, 0.0);
+    /// let q2 = Rotation3::from_euler_angles(-std::f32::consts::PI, 0.0, 0.0);
+    ///
+    /// let q = q1.slerp(&q2, 1.0 / 3.0);
+    ///
+    /// assert_eq!(q.euler_angles(), (std::f32::consts::FRAC_PI_2, 0.0, 0.0));
+    /// ```
+    ///
     //FIXME: merging slerp for Rotation2 and Rotation3 into this raises the trait bounds
     //from SimdRealField to RealField
     #[inline]
     #[must_use]
-    #[warn(missing_docs)]
     pub fn slerp(&self, other: &Self, t:T) -> Self {
 
         use std::mem::transmute;

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -1,4 +1,6 @@
-use crate::{RealField, Rotation2, Rotation3, SimdRealField, UnitComplex, UnitQuaternion};
+use crate::{RealField, Rotation, Rotation2, Rotation3, SimdRealField, UnitComplex, UnitQuaternion};
+use crate::{Const, U1, DimSub, DimDiff, Storage, ArrayStorage, Allocator, DefaultAllocator};
+use crate::SMatrix;
 
 /// # Interpolation
 impl<T: SimdRealField> Rotation2<T> {
@@ -78,4 +80,132 @@ impl<T: SimdRealField> Rotation3<T> {
         let q2 = UnitQuaternion::from(other.clone());
         q1.try_slerp(&q2, t, epsilon).map(|q| q.into())
     }
+}
+
+impl<T:SimdRealField, const D: usize> Rotation<T,D> {
+
+    #[warn(missing_docs)]
+    pub fn basis_rot(i:usize, j:usize, angle:T) -> Self {
+
+        let mut m = SMatrix::identity();
+        if i==j { return Self::from_matrix_unchecked(m); }
+
+        let (s,c) = angle.simd_sin_cos();
+        m[(i,i)] = c.clone();
+        m[(i,j)] = -s.clone();
+        m[(j,i)] = s;
+        m[(j,j)] = c;
+
+        Self::from_matrix_unchecked(m)
+
+    }
+}
+
+impl<T:RealField, const D: usize> Rotation<T,D> where
+    Const<D>: DimSub<U1>,
+    ArrayStorage<T,D,D>: Storage<T,Const<D>,Const<D>>,
+    DefaultAllocator: Allocator<T,Const<D>,Const<D>,Buffer=ArrayStorage<T,D,D>> + Allocator<T,Const<D>> +
+        Allocator<T,Const<D>,DimDiff<Const<D>,U1>> +
+        Allocator<T,DimDiff<Const<D>,U1>>
+{
+
+    #[warn(missing_docs)]
+    pub fn general_slerp(&self, other: &Self, t:T) -> Self {
+        self * (self/other).general_pow(t)
+    }
+
+    #[warn(missing_docs)]
+    pub fn general_pow(self, t:T) -> Self {
+        if D<=1 { return self; }
+
+        //taking the (real) schur form is guaranteed to produce a block-diagonal matrix
+        //where each block is either a 1 (if there's no rotation in that axis) or a 2x2
+        //rotation matrix in a particular plane
+        let schur = self.into_inner().schur();
+        let (q, mut d) = schur.unpack();
+
+        //go down the diagonal and pow every block
+        for i in 0..(D-1) {
+
+            //we've found a 2x2 block!
+            //NOTE: the impl of the schur decomposition always sets the inferior diagonal to 0
+            if !d[(i+1,i)].is_zero() {
+
+                //convert to a complex num and take the arg()
+                let (c, s) = (d[(i,i)].clone(), d[(i+1,i)].clone());
+                let angle = s.atan2(c);
+
+                //scale the arg and exponentiate back
+                let angle2 = angle * t.clone();
+                let (s2, c2) = angle2.sin_cos();
+
+                //convert back into a rot block
+                d[(i,  i  )] =  c2.clone();
+                d[(i,  i+1)] = -s2.clone();
+                d[(i+1,i  )] =  s2;
+                d[(i+1,i+1)] =  c2;
+
+            }
+
+        }
+
+        let qt = q.transpose(); //avoids an extra clone
+
+        Self::from_matrix_unchecked(q * d * qt)
+
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::f64::consts::PI;
+
+    const EPS: f64 = 2E-10;
+
+    #[test]
+    fn rot_pow() {
+
+        let r1 = Rotation2::new(0.0);
+        let r2 = Rotation2::new(PI/4.0);
+        let r3 = Rotation2::new(PI/2.0);
+
+        assert_relative_eq!(r1.general_pow(0.5), r1, epsilon=EPS);
+        assert_relative_eq!(r3.general_pow(0.5), r2, epsilon=EPS);
+
+    }
+
+    #[test]
+    fn basis_rot() {
+
+        const D:usize = 4;
+
+        let basis_blades = |n| (0..n).flat_map(
+            move |i| (i..n).map(move |j| (i,j))
+        ).filter(|(i,j)| i!=j);
+
+        for (i1,j1) in basis_blades(D) {
+
+            for (i2,j2) in basis_blades(D) {
+
+                if i1==i2 || j1==j2 || i1==j2 || j1==i2 { continue; }
+
+                let r1 = Rotation::<_,D>::basis_rot(i1,j1,PI/4.0) *
+                    Rotation::<_,D>::basis_rot(i2,j2,PI/4.0);
+                let r2 = Rotation::<_,D>::basis_rot(i1,j1,PI/2.0) *
+                    Rotation::<_,D>::basis_rot(i2,j2,PI/2.0);
+
+                println!("{}{}",r1,r2);
+
+                assert_relative_eq!(r2.general_pow(0.5), r1, epsilon=EPS);
+
+            }
+
+        }
+
+    }
+
+
 }

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -1,6 +1,5 @@
 use crate::{RealField, Rotation, Rotation2, Rotation3, SimdRealField, UnitComplex, UnitQuaternion};
 use crate::{Const, U1, DimSub, DimDiff, Storage, ArrayStorage, Allocator, DefaultAllocator};
-use crate::SMatrix;
 
 /// # Interpolation
 impl<T: SimdRealField> Rotation2<T> {

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -1010,8 +1010,24 @@ where
 impl<T:RealField, const D: usize> Rotation<T,D>
 {
 
+    ///
+    /// Raise the rotation to a given floating power, i.e., returns the rotation with the same
+    /// axis as `self` and an angle equal to `self.angle()` multiplied by `n`.
+    ///
+    /// # Example
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # use nalgebra::{Rotation3, Vector3, Unit};
+    ///
+    /// let axis = Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0));
+    /// let angle = 1.2;
+    /// let rot = Rotation3::from_axis_angle(&axis, angle);
+    /// let pow = rot.powf(2.0);
+    ///
+    /// assert_relative_eq!(pow.axis().unwrap(), axis, epsilon = 1.0e-6);
+    /// assert_eq!(pow.angle(), 2.4);
+    /// ```
     //FIXME: merging powf for Rotation2 into this raises the trait bounds from SimdRealField to RealField
-    #[warn(missing_docs)]
     pub fn powf(&self, t: T) -> Self where
         Const<D>: DimSub<U1>,
         ArrayStorage<T,D,D>: Storage<T,Const<D>,Const<D>>,

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -1065,19 +1065,21 @@ impl<T:RealField, const D: usize> Rotation<T,D>
         // println!("q:{}d:{:.3}", q, d);
 
         //go down the diagonal and pow every block
-        for i in 0..(D-1) {
+        let mut i = 0;
+        while i < D-1 {
 
-            //we've found a 2x2 block!
-            //NOTE: the impl of the schur decomposition always sets the inferior diagonal to 0
-            if !d[(i+1,i)].is_zero() {
+            if
+                //For most 2x2 blocks
+                //NOTE: we use strict equality since `nalgebra`'s schur decomp sets the infradiagonal to zero
+                !d[(i+1,i)].is_zero() ||
 
-                // println!("{}", i);
+                //for +-180 deg rotations
+                d[(i,i)]<T::zero() && d[(i+1,i+1)]<T::zero()
+            {
 
-                //convert to a complex num and take the arg()
+                //convert to a complex num and find the arg()
                 let (c, s) = (d[(i,i)].clone(), d[(i+1,i)].clone());
-                let angle = s.atan2(c);
-
-                // println!("{}", angle);
+                let angle = s.atan2(c); //for +-180deg rots, this implicitely takes the +180 branch
 
                 //scale the arg and exponentiate back
                 let angle2 = angle * t.clone();
@@ -1089,6 +1091,12 @@ impl<T:RealField, const D: usize> Rotation<T,D>
                 d[(i+1,i  )] =  s2;
                 d[(i+1,i+1)] =  c2;
 
+                //increase by 2 so we don't accidentally misinterpret the
+                //next line as a 180deg rotation
+                i += 2;
+
+            } else {
+                i += 1;
             }
 
         }

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -52,7 +52,6 @@ mod proptest_tests {
                 ) {
 
                     use nalgebra::*;
-                    use num_traits::Zero;
 
                     //make an orthonormal basis
                     let mut basis = [$($v1, $v2),*];
@@ -81,7 +80,7 @@ mod proptest_tests {
                         bivector += bivectors[i];
                     }
 
-                    let r1 = Rotation::from_matrix_unchecked(bivector.exp()).general_pow(pow);
+                    let r1 = Rotation::from_matrix_unchecked(bivector.exp()).powf(pow);
                     let r2 = Rotation::from_matrix_unchecked((bivector * pow).exp());
 
                     prop_assert!(relative_eq!(r1, r2, epsilon=1e-7));

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -32,7 +32,7 @@ fn quaternion_euler_angles_issue_494() {
 
 #[cfg(feature = "proptest-support")]
 mod proptest_tests {
-    use na::{self, Rotation2, Rotation3, Unit};
+    use na::{self, Rotation, Rotation2, Rotation3, Unit};
     use simba::scalar::RealField;
     use std::f64;
 
@@ -229,5 +229,79 @@ mod proptest_tests {
                 prop_assert_eq!(r, Rotation3::identity())
             }
         }
+
+        // macro_rules! gen_pof_rotation_test {
+        //     ($(
+        //         fn $powf_rot_n:ident($($v1:ident in $vec1:ident(), $v2:ident in $vec2:ident()),*);
+        //     )*) => {$
+        //
+        //         #[test]
+        //         fn $powf_rot_n(
+        //             $($v1 in $vec1(), $v2 in $vec2(),)*
+        //             pow in PROPTEST_F64
+        //         ) {
+        //
+        //         }
+        //
+        //     )*}
+        // }
+
+        #[test]
+        fn powf_rotation_4(
+            v1 in vector4(), v2 in vector4(),
+            v3 in vector4(), v4 in vector4(),
+            pow in PROPTEST_F64
+        ) {
+
+            use nalgebra::*;
+            use num_traits::Zero;
+
+            type Rotation4<T> = Rotation<T,4>;
+
+            //make an orthonormal basis
+            let mut basis = [v1,v2,v3,v4];
+            Vector::orthonormalize(&mut basis);
+            let [v1,v2,v3,v4] = basis;
+
+            //"wedge" the vectors to make two 2-blades representing two rotation planes
+            //since we start with vector pairs, each bivector is guaranteed to be simple
+            let mut b1 = v1.transpose().kronecker(&v2) - v2.transpose().kronecker(&v1);
+            let mut b2 = v3.transpose().kronecker(&v4) - v4.transpose().kronecker(&v3);
+
+            //condition b1
+            if let Some((unit, norm)) = Unit::try_new_and_get(b1, 0.0) {
+                //every component is duplicated once, so there's an extra factor or sqrt(2) in the norm
+                //and wrap angle into the correct range
+                let mut angle = norm / 2.0f64.sqrt();
+                angle = na::wrap(angle, -f64::pi(), f64::pi());
+                b1 = unit.into_inner() * angle * 2.0f64.sqrt();
+            }
+
+            //condition b2
+            if let Some((unit, norm)) = Unit::try_new_and_get(b2, 0.0) {
+                let mut angle = norm / 2.0f64.sqrt();
+                angle = na::wrap(angle, -f64::pi(), f64::pi());
+                b2 = unit.into_inner() * angle * 2.0f64.sqrt();
+            }
+
+            let bivector  = b1+b2;
+
+            println!("b:{:.3}", bivector);
+
+            let r1 = Rotation4::from_matrix_unchecked(bivector.exp());
+            let r2 = Rotation4::from_matrix_unchecked((bivector * pow).exp());
+
+            // println!("{}{}", r1, r2);
+            // println!("{}", r1.general_pow(pow));
+
+            prop_assert!(
+                relative_eq!(r1.general_pow(pow), r2, epsilon=1e-7)
+            );
+
+
+        }
+
+
+
     }
 }


### PR DESCRIPTION
Implements `Rotation::slerp()` and `Rotation::powf()` for all static dimensions.

Solves #908. Potentially interacts with #657, #1093, and #1094

The algorithm I used for `powf()` works by first computing the Real Schur form of the backing matrix to get it in a block-diagonal form, and then interpolating each 2x2 block as if it were a 2D rotation. The `slerp()` implementation then interpolates using `(R2/R1)^t * R1`. If the dimension is 2 or 3 though, it falls back on the old implementation using complex numbers and Quaternions.

My first consideration was to instead compute `powf()` by first taking the logarithm, multiplying by the exponent, and then taking the exponential. The issue with that was that in order to compute the log, we'd most likely have to either take a sequence of square roots using newton's method (which can get quite unstable when starting near a 180degree rotation) or do a Schur based algorithm. So since we'd be computing the form anyway, I opted to just do both the exponential and logarithm steps in one go with a Schur decomposition.

In order to do all of this, I obviously had to extend the API a bit, but _for the most part_, it should just be drop in place for most users. The implementation does add a fair number of extra trait bounds for the dimension so it could use the Schur decomposition, but in the 2D and 3D cases, those should just resolve down and not affect any code using the old versions. **However**, I _did_ have to force `T` to be a `RealField`, which is an added restriction from the old 2D case, which previously only required `SimdRealField`. Unless it's decided the generalized pow and slerp should be separate from the old implementations, I don't really know how else to unify them without this problem happening.

Lastly, from my experience working with Geometric algebra, I *do* know of an additional algorithm that works in the special case of 4D and 5D. I haven't implemented it here yet, but if there's enough desire for it, I could implement it and run some benchmarks to see if it should be added as a specialization for sake of optimization.

