### PR TITLE
Fix from_matrix when argument is already a valid rotation matrix

### DIFF
--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -413,8 +413,7 @@ where
     #[cfg(feature = "rand-no-std")]
     pub fn from_matrix(m: &Matrix3<T>) -> Self
     where
-        T: RealField + Scalar,
-        Standard: Distribution<Rotation3<T>>,
+        T: RealField,
     {
         Rotation3::from_matrix(m).into()
     }

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -410,9 +410,11 @@ where
     /// This is an iterative method. See `.from_matrix_eps` to provide mover
     /// convergence parameters and starting solution.
     /// This implements "A Robust Method to Extract the Rotational Part of Deformations" by Müller et al.
+    #[cfg(feature = "rand-no-std")]
     pub fn from_matrix(m: &Matrix3<T>) -> Self
     where
-        T: RealField,
+        T: RealField + Scalar,
+        Standard: Distribution<Rotation3<T>>,
     {
         Rotation3::from_matrix(m).into()
     }

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -410,7 +410,6 @@ where
     /// This is an iterative method. See `.from_matrix_eps` to provide mover
     /// convergence parameters and starting solution.
     /// This implements "A Robust Method to Extract the Rotational Part of Deformations" by Müller et al.
-    #[cfg(feature = "rand-no-std")]
     pub fn from_matrix(m: &Matrix3<T>) -> Self
     where
         T: RealField,

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -17,7 +17,7 @@ use std::ops::Neg;
 
 use crate::base::dimension::{U1, U2, U3};
 use crate::base::storage::Storage;
-use crate::base::{Matrix2, Matrix3, SMatrix, SVector, Unit, Vector, Vector1, Vector2, Vector3};
+use crate::base::{Matrix2, Matrix3, SMatrix, SVector, Unit, Vector, Vector1, Vector2, Vector3, UnitVector3};
 
 use crate::geometry::{Rotation2, Rotation3, UnitComplex, UnitQuaternion};
 
@@ -706,15 +706,12 @@ where
     /// This is an iterative method. See `.from_matrix_eps` to provide mover
     /// convergence parameters and starting solution.
     /// This implements "A Robust Method to Extract the Rotational Part of Deformations" by Müller et al.
-    #[cfg(feature = "rand-no-std")]
     pub fn from_matrix(m: &Matrix3<T>) -> Self
     where
-        T: RealField + crate::Scalar,
-        Standard: Distribution<Rotation3<T>>,
+        T: RealField,
     {
         // Starting from a random rotation has almost zero likelihood to end up in a maximum if `m` is already a rotation matrix
-        let random_rotation: Rotation3<T> = rand::thread_rng().gen();
-        Self::from_matrix_eps(m, T::default_epsilon(), 0, random_rotation)
+        Self::from_matrix_eps(m, T::default_epsilon(), 0, Rotation3::identity())
     }
 
     /// Builds a rotation matrix by extracting the rotation part of the given transformation `m`.
@@ -737,6 +734,7 @@ where
             max_iter = usize::MAX;
         }
 
+        let mut perturbation_axes = UnitVector3::new_unchecked(Vector3::new(T::one(), T::zero(), T::zero()));
         let mut rot = guess.into_inner();
 
         for _ in 0..max_iter {
@@ -752,7 +750,25 @@ where
             if let Some((axis, angle)) = Unit::try_new_and_get(axisangle, eps.clone()) {
                 rot = Rotation3::from_axis_angle(&axis, angle) * rot;
             } else {
-                break;
+                // Check if stuck in a maximum w.r.t. the norm (m - rot).norm()
+                let mut perturbed = rot.clone();
+                let norm_squared = (m - &rot).norm_squared();
+                let mut new_norm_squared: T;
+                // Perturb until the new norm is significantly different
+                loop {
+                    perturbed *= Rotation3::from_axis_angle(&perturbation_axes, T::frac_pi_8());
+                    new_norm_squared = (m - &perturbed).norm_squared();
+                    if relative_ne!(norm_squared, new_norm_squared) {
+                        break;
+                    }
+                }
+                // If new norm is larger, it's a minimum
+                if norm_squared < new_norm_squared {
+                    break;
+                }
+                // If not, continue from perturbed rotation, but use a different axes for the next perturbation
+                perturbation_axes = UnitVector3::new_unchecked(Vector3::new(perturbation_axes.y.clone(), perturbation_axes.z.clone(), perturbation_axes.x.clone()));
+                rot = perturbed;
             }
         }
 

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -760,9 +760,14 @@ where
 
                 // Perturb until the new norm is significantly different
                 loop {
-                    perturbed *= Rotation3::from_axis_angle(&perturbation_axes, eps_disturbance.clone());
+                    perturbed *=
+                        Rotation3::from_axis_angle(&perturbation_axes, eps_disturbance.clone());
                     new_norm_squared = (m - &perturbed).norm_squared();
-                    if abs_diff_ne!(norm_squared, new_norm_squared, epsilon = T::default_epsilon()) {
+                    if abs_diff_ne!(
+                        norm_squared,
+                        new_norm_squared,
+                        epsilon = T::default_epsilon()
+                    ) {
                         break;
                     }
                 }

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -735,6 +735,8 @@ where
             max_iter = usize::MAX;
         }
 
+        // Using sqrt(eps) ensures we perturb with something larger than eps; clamp to eps to handle the case of eps > 1.0
+        let eps_disturbance = eps.clone().sqrt().max(eps.clone() * eps.clone());
         let mut perturbation_axes = Vector3::x_axis();
         let mut rot = guess.into_inner();
 
@@ -758,10 +760,9 @@ where
 
                 // Perturb until the new norm is significantly different
                 loop {
-                    perturbed *= Rotation3::from_axis_angle(&perturbation_axes, T::frac_pi_8());
+                    perturbed *= Rotation3::from_axis_angle(&perturbation_axes, eps_disturbance.clone());
                     new_norm_squared = (m - &perturbed).norm_squared();
-
-                    if relative_ne!(norm_squared, new_norm_squared) {
+                    if abs_diff_ne!(norm_squared, new_norm_squared, epsilon = T::default_epsilon()) {
                         break;
                     }
                 }

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -706,11 +706,15 @@ where
     /// This is an iterative method. See `.from_matrix_eps` to provide mover
     /// convergence parameters and starting solution.
     /// This implements "A Robust Method to Extract the Rotational Part of Deformations" by Müller et al.
+    #[cfg(feature = "rand-no-std")]
     pub fn from_matrix(m: &Matrix3<T>) -> Self
     where
-        T: RealField,
+        T: RealField + crate::Scalar,
+        Standard: Distribution<Rotation3<T>>,
     {
-        Self::from_matrix_eps(m, T::default_epsilon(), 0, Self::identity())
+        // Starting from a random rotation has almost zero likelihood to end up in a maximum if `m` is already a rotation matrix
+        let random_rotation: Rotation3<T> = rand::thread_rng().gen();
+        Self::from_matrix_eps(m, T::default_epsilon(), 0, random_rotation)
     }
 
     /// Builds a rotation matrix by extracting the rotation part of the given transformation `m`.
@@ -730,7 +734,7 @@ where
         T: RealField,
     {
         if max_iter == 0 {
-            max_iter = usize::max_value();
+            max_iter = usize::MAX;
         }
 
         let mut rot = guess.into_inner();

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -1,5 +1,7 @@
+use na::{
+    Matrix3, Quaternion, RealField, Rotation3, UnitQuaternion, UnitVector3, Vector2, Vector3,
+};
 use std::f64::consts::PI;
-use na::{Matrix3, Quaternion, RealField, Rotation3, UnitQuaternion, UnitVector3, Vector2, Vector3};
 
 #[test]
 fn angle_2() {
@@ -20,23 +22,41 @@ fn angle_3() {
 #[test]
 fn from_rotation_matrix() {
     // Test degenerate case when from_matrix gets stuck in Identity rotation
-    let identity = Rotation3::from_matrix(&Matrix3::new(
-        1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-    ));
+    let identity =
+        Rotation3::from_matrix(&Matrix3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
     assert_relative_eq!(identity, &Rotation3::identity(), epsilon = 0.001);
-    let rotated_z = Rotation3::from_matrix(&Matrix3::new(
-        1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0,
-    ));
-    assert_relative_eq!(rotated_z, &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI), epsilon = 0.001);
+    let rotated_z =
+        Rotation3::from_matrix(&Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0));
+    assert_relative_eq!(
+        rotated_z,
+        &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI),
+        epsilon = 0.001
+    );
     // Test that issue 628 is fixed
     let m_628 = nalgebra::Matrix3::<f64>::new(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
-    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m_628), epsilon = 0.01);
-    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m_628.clone()), nalgebra::Rotation3::from_matrix(&m_628), epsilon = 0.001);
+    assert_relative_ne!(
+        identity,
+        nalgebra::Rotation3::from_matrix(&m_628),
+        epsilon = 0.01
+    );
+    assert_relative_eq!(
+        nalgebra::Rotation3::from_matrix_unchecked(m_628.clone()),
+        nalgebra::Rotation3::from_matrix(&m_628),
+        epsilon = 0.001
+    );
 
     // Test that issue 1078 is fixed
     let m_1078 = nalgebra::Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
-    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m_1078), epsilon = 0.01);
-    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m_1078.clone()), nalgebra::Rotation3::from_matrix(&m_1078), epsilon = 0.001);
+    assert_relative_ne!(
+        identity,
+        nalgebra::Rotation3::from_matrix(&m_1078),
+        epsilon = 0.01
+    );
+    assert_relative_eq!(
+        nalgebra::Rotation3::from_matrix_unchecked(m_1078.clone()),
+        nalgebra::Rotation3::from_matrix(&m_1078),
+        epsilon = 0.001
+    );
 }
 
 #[test]

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -1,4 +1,5 @@
-use na::{Quaternion, RealField, UnitQuaternion, Vector2, Vector3};
+use std::f64::consts::PI;
+use na::{Matrix3, Quaternion, RealField, Rotation3, UnitQuaternion, UnitVector3, Vector2, Vector3};
 
 #[test]
 fn angle_2() {
@@ -14,6 +15,19 @@ fn angle_3() {
     let b = Vector3::new(8.0, 0.0, 1.0);
 
     assert_eq!(a.angle(&b), 0.0);
+}
+
+#[test]
+fn from_rotation_matrix() {
+    // Test degenerate case when from_matrix_eps gets stuck in maximum
+    let identity = Rotation3::from_matrix(&Matrix3::new(
+        1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+    ));
+    assert_relative_eq!(identity, &Rotation3::identity(), epsilon = 0.001);
+    let rotated_z = Rotation3::from_matrix(&Matrix3::new(
+        1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0,
+    ));
+    assert_relative_eq!(rotated_z, &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI), epsilon = 0.001);
 }
 
 #[test]

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -34,11 +34,7 @@ fn from_rotation_matrix() {
     );
     // Test that issue 627 is fixed
     let m_627 = Matrix3::<f64>::new(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
-    assert_relative_ne!(
-        identity,
-        Rotation3::from_matrix(&m_627),
-        epsilon = 0.01
-    );
+    assert_relative_ne!(identity, Rotation3::from_matrix(&m_627), epsilon = 0.01);
     assert_relative_eq!(
         Rotation3::from_matrix_unchecked(m_627.clone()),
         Rotation3::from_matrix(&m_627),
@@ -46,11 +42,7 @@ fn from_rotation_matrix() {
     );
     // Test that issue 1078 is fixed
     let m_1078 = Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
-    assert_relative_ne!(
-        identity,
-        Rotation3::from_matrix(&m_1078),
-        epsilon = 0.01
-    );
+    assert_relative_ne!(identity, Rotation3::from_matrix(&m_1078), epsilon = 0.01);
     assert_relative_eq!(
         Rotation3::from_matrix_unchecked(m_1078.clone()),
         Rotation3::from_matrix(&m_1078),

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -28,6 +28,10 @@ fn from_rotation_matrix() {
         1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0,
     ));
     assert_relative_eq!(rotated_z, &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI), epsilon = 0.001);
+    // Test that issue 1078 is fixed
+    let m = nalgebra::Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
+    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m));
+    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m.clone()), nalgebra::Rotation3::from_matrix(&m));
 }
 
 #[test]

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -32,30 +32,50 @@ fn from_rotation_matrix() {
         &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI),
         epsilon = 0.001
     );
-    // Test that issue 628 is fixed
-    let m_628 = nalgebra::Matrix3::<f64>::new(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
+    // Test that issue 627 is fixed
+    let m_627 = Matrix3::<f64>::new(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
     assert_relative_ne!(
         identity,
-        nalgebra::Rotation3::from_matrix(&m_628),
+        Rotation3::from_matrix(&m_627),
         epsilon = 0.01
     );
     assert_relative_eq!(
-        nalgebra::Rotation3::from_matrix_unchecked(m_628.clone()),
-        nalgebra::Rotation3::from_matrix(&m_628),
+        Rotation3::from_matrix_unchecked(m_627.clone()),
+        Rotation3::from_matrix(&m_627),
         epsilon = 0.001
     );
-
     // Test that issue 1078 is fixed
-    let m_1078 = nalgebra::Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
+    let m_1078 = Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
     assert_relative_ne!(
         identity,
-        nalgebra::Rotation3::from_matrix(&m_1078),
+        Rotation3::from_matrix(&m_1078),
         epsilon = 0.01
     );
     assert_relative_eq!(
-        nalgebra::Rotation3::from_matrix_unchecked(m_1078.clone()),
-        nalgebra::Rotation3::from_matrix(&m_1078),
+        Rotation3::from_matrix_unchecked(m_1078.clone()),
+        Rotation3::from_matrix(&m_1078),
         epsilon = 0.001
+    );
+    // Additional test cases for eps >= 1.0
+    assert_relative_ne!(
+        identity,
+        Rotation3::from_matrix_eps(&m_627, 1.2, 0, Rotation3::identity()),
+        epsilon = 0.6
+    );
+    assert_relative_eq!(
+        Rotation3::from_matrix_unchecked(m_627.clone()),
+        Rotation3::from_matrix_eps(&m_627, 1.2, 0, Rotation3::identity()),
+        epsilon = 0.6
+    );
+    assert_relative_ne!(
+        identity,
+        Rotation3::from_matrix_eps(&m_1078, 1.0, 0, Rotation3::identity()),
+        epsilon = 0.1
+    );
+    assert_relative_eq!(
+        Rotation3::from_matrix_unchecked(m_1078.clone()),
+        Rotation3::from_matrix_eps(&m_1078, 1.0, 0, Rotation3::identity()),
+        epsilon = 0.1
     );
 }
 

--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -19,7 +19,7 @@ fn angle_3() {
 
 #[test]
 fn from_rotation_matrix() {
-    // Test degenerate case when from_matrix_eps gets stuck in maximum
+    // Test degenerate case when from_matrix gets stuck in Identity rotation
     let identity = Rotation3::from_matrix(&Matrix3::new(
         1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
     ));
@@ -28,10 +28,15 @@ fn from_rotation_matrix() {
         1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0,
     ));
     assert_relative_eq!(rotated_z, &Rotation3::from_axis_angle(&UnitVector3::new_unchecked(Vector3::new(1.0, 0.0, 0.0)), PI), epsilon = 0.001);
+    // Test that issue 628 is fixed
+    let m_628 = nalgebra::Matrix3::<f64>::new(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
+    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m_628), epsilon = 0.01);
+    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m_628.clone()), nalgebra::Rotation3::from_matrix(&m_628), epsilon = 0.001);
+
     // Test that issue 1078 is fixed
-    let m = nalgebra::Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
-    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m));
-    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m.clone()), nalgebra::Rotation3::from_matrix(&m));
+    let m_1078 = nalgebra::Matrix3::<f64>::new(0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0);
+    assert_relative_ne!(identity, nalgebra::Rotation3::from_matrix(&m_1078), epsilon = 0.01);
+    assert_relative_eq!(nalgebra::Rotation3::from_matrix_unchecked(m_1078.clone()), nalgebra::Rotation3::from_matrix(&m_1078), epsilon = 0.001);
 }
 
 #[test]


### PR DESCRIPTION
One possibility of fixing issues #627, #1078 by starting from a random rotation.

I'm not too familiar with how this whole Standard: Distribution<Rotation3<T>> works, so feel free to change to something better.

Of course, one downside of this approach is that in the very rare case of running into the bug (if one gets really unlucky), it might disappear when you re-run it.

Hence, another option would be (if one does not always want to start from a new random rotation) to fix the "random" rotation.

An idea could also be to only do this extra check if the output happens to match the first guess (up to ε), and then start from the next "deterministic" random rotation.

Alternatively, one could check if the determinant of the provided matrix is 1, and then use from_matrix_unchecked, however, this would not fix the case, when the input is a scaled "wrong" rotation matrix such as [2, 0, 0, 0, -2, 0, 0, 0, -2]. (This was suggested in https://github.com/dimforge/nalgebra/issues/627)

PS: The suggested method in the paper, of trying different initializations and checking if the frobenius norm changes, only works for non-orthonormal matrices, as all rotation matrices have the same Frobenius norm of √3. One would have to combine it with the latter approach to first detect orientation matrices.
