### PR TITLE
Fix UnitComplex cast doctest failure on macOS

### DIFF
--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -131,10 +131,11 @@ where
     ///
     /// # Example
     /// ```
+    /// #[macro_use] extern crate approx;
     /// # use nalgebra::UnitComplex;
     /// let c = UnitComplex::new(1.0f64);
     /// let c2 = c.cast::<f32>();
-    /// assert_eq!(c2, UnitComplex::new(1.0f32));
+    /// assert_relative_eq!(c2, UnitComplex::new(1.0f32));
     /// ```
     pub fn cast<To: Scalar>(self) -> UnitComplex<To>
     where


### PR DESCRIPTION
I have a test failing on macOS (MacBook Pro M1 Max) on dev that isn't failing in CI. It looks like a precision issue as a result of the equality assertion only running in CI or x86.

```
failures:

---- src/geometry/unit_complex_construction.rs - geometry::unit_complex_construction::UnitComplex<T>::cast (line 133) stdout ----
Test executable failed (exit code 101).

stderr:
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Complex { re: 0.5403023, im: 0.84147096 }`,
 right: `Complex { re: 0.54030234, im: 0.841471 }`', src/geometry/unit_complex_construction.rs:7:1
stack backtrace:
   0:        0x102df1310 - std::backtrace_rs::backtrace::libunwind::trace::h449592924b3bd63f
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:        0x102df1310 - std::backtrace_rs::backtrace::trace_unsynchronized::ha2aaeafed0c31c90
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x102df1310 - std::sys_common::backtrace::_print_fmt::h58db85a17304976f
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/sys_common/backtrace.rs:66:5
   3:        0x102df1310 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h10cf06316d33e2a9
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/sys_common/backtrace.rs:45:22
   4:        0x102e0a608 - core::fmt::write::h1faf18c959c3a8df
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/fmt/mod.rs:1190:17
   5:        0x102dee770 - std::io::Write::write_fmt::h86ab231360bc97d2
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/io/mod.rs:1657:15
   6:        0x102df2e78 - std::sys_common::backtrace::_print::h771b4aab9b128422
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/sys_common/backtrace.rs:48:5
   7:        0x102df2e78 - std::sys_common::backtrace::print::h637de99a9f76e8a7
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/sys_common/backtrace.rs:35:9
   8:        0x102df2e78 - std::panicking::default_hook::{{closure}}::h36e628ffaf3cd44f
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:295:22
   9:        0x102df2af0 - std::panicking::default_hook::h3ee1564a7544e58f
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:314:9
  10:        0x102df34d8 - std::panicking::rust_panic_with_hook::h191339fbd2fe2360
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:698:17
  11:        0x102df3260 - std::panicking::begin_panic_handler::{{closure}}::h91c230befd9929e3
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:588:13
  12:        0x102df17f8 - std::sys_common::backtrace::__rust_end_short_backtrace::haaaeebb1d37476b3
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/sys_common/backtrace.rs:138:18
  13:        0x102df2f9c - rust_begin_unwind
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
  14:        0x102e10abc - core::panicking::panic_fmt::h4fe1013b011ef602
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
  15:        0x102e09014 - core::panicking::assert_failed_inner::h67a65df2c19c8ccd
  16:        0x102e0ed6c - core::panicking::assert_failed::hb1b6a4c789a9ef91
  17:        0x102ddd42c - rust_out::main::_doctest_main_src_geometry_unit_complex_construction_rs_133_0::hcc9b30603756b230
  18:        0x102ddd350 - rust_out::main::he239c4229bb09803
  19:        0x102ddd328 - core::ops::function::FnOnce::call_once::hbb670cb492d44776
  20:        0x102dddc6c - std::sys_common::backtrace::__rust_begin_short_backtrace::hc19d08930ffeefa9
  21:        0x102dddc2c - std::rt::lang_start::{{closure}}::h662c707d5d1df136
  22:        0x102df0bbc - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h8eb3ac20f80eabfa
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/ops/function.rs:259:13
  23:        0x102df0bbc - std::panicking::try::do_call::ha6ddf2c638427188
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:492:40
  24:        0x102df0bbc - std::panicking::try::hda8741de507c1ad0
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:456:19
  25:        0x102df0bbc - std::panic::catch_unwind::h82424a01f258bd39
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panic.rs:137:14
  26:        0x102df0bbc - std::rt::lang_start_internal::{{closure}}::h67e296ed5b030b7b
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/rt.rs:128:48
  27:        0x102df0bbc - std::panicking::try::do_call::hd3dd7e7e10f6424e
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:492:40
  28:        0x102df0bbc - std::panicking::try::ha0a7bd8122e3fb7c
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:456:19
  29:        0x102df0bbc - std::panic::catch_unwind::h809b0e1092e9475d
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panic.rs:137:14
  30:        0x102df0bbc - std::rt::lang_start_internal::h358b6d58e23c88c7
                               at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/rt.rs:128:20
  31:        0x102dddc00 - std::rt::lang_start::hfd375e4321873059
  32:        0x102dddd6c - _main



failures:
    src/geometry/unit_complex_construction.rs - geometry::unit_complex_construction::UnitComplex<T>::cast (line 133)

test result: FAILED. 479 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 31.20s
```