### PR TITLE
Fix Point display to respect formatting parameters

### DIFF
--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -458,16 +458,10 @@ where
     DefaultAllocator: Allocator<T, D>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{")?;
+        let precision = f.precision().unwrap_or(3);
 
-        let mut it = self.coords.iter();
-
-        write!(f, "{}", *it.next().unwrap())?;
-
-        for comp in it {
-            write!(f, ", {}", *comp)?;
-        }
-
+        write!(f, "Point {{")?;
+        write!(f, "{:.*}", precision, self.coords)?;
         write!(f, "}}")
     }
 }


### PR DESCRIPTION
This changes Point Display formatting to match formatting of other geometry types, including Isometry, Scale, and Rotation.
Fixes issue #1115 since it passes through the desired precision formatting parameter.

Example:
```rust
let point = nalgebra::Point3::new(1.12345678, 2.12345678, 3.12345678);
println!("{point:.4}");
```

Before:
```
{1.12345678, 2.12345678, 3.12345678}
```
After:
```
Point {
  ┌        ┐
  │ 1.1235 │
  │ 2.1235 │
  │ 3.1235 │
  └        ┘

}
```