### PR TITLE
allow for nalgebra objects to be their own rkyv::Archive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ convert-glam020 = [ "glam020" ]
 ## `serde-serialize`.
 serde-serialize-no-std = [ "serde", "num-complex/serde" ]
 serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
-rkyv-serialize-no-std  = [ "rkyv", "rkyv_wrappers" ]
-rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "rkyv/validation", "bytecheck" ]
+rkyv-serialize-no-std  = [ "rkyv", "rkyv_wrappers", "num-complex/rkyv" ]
+rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "rkyv/validation", "bytecheck", "num-complex/bytecheck" ]
 
 # Randomness
 ## To use rand in a #[no-std] environment, enable the
@@ -71,15 +71,15 @@ nalgebra-macros = { version = "0.1", path = "nalgebra-macros", optional = true }
 typenum        = "1.12"
 rand-package   = { package = "rand", version = "0.8", optional = true, default-features = false }
 num-traits     = { version = "0.2", default-features = false }
-num-complex    = { version = "0.4", git = "https://github.com/zyansheep/num-complex", default-features = false } # { version = "0.4", default-features = false }
+num-complex    = { version = "0.4", default-features = false }
 num-rational   = { version = "0.4", default-features = false }
 approx         = { version = "0.5", default-features = false }
-simba          = { version = "0.7.0", default-features = false }
+simba          = { version = "0.7", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
-rkyv           = { version = "0.7", optional = true }
+rkyv           = { version = "0.7", default-features = false, optional = true }
 rkyv_wrappers  = { git = "https://github.com/rkyv/rkyv_contrib", optional = true }
 bytecheck      = { version = "~0.6.1", optional = true }
 mint           = { version = "0.5", optional = true }
@@ -134,3 +134,5 @@ lto = true
 # Enable certain features when building docs for docs.rs
 features = [ "proptest-support", "compare", "macros", "rand" ]
 
+[patch.crates-io]
+num-complex = { git = "https://github.com/zyansheep/num-complex" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ nalgebra-macros = { version = "0.1", path = "nalgebra-macros", optional = true }
 typenum        = "1.12"
 rand-package   = { package = "rand", version = "0.8", optional = true, default-features = false }
 num-traits     = { version = "0.2", default-features = false }
-num-complex    = { version = "0.4", default-features = false } # { version = "0.4", default-features = false }
+num-complex    = { version = "0.4", git = "https://github.com/zyansheep/num-complex", default-features = false } # { version = "0.4", default-features = false }
 num-rational   = { version = "0.4", default-features = false }
 approx         = { version = "0.5", default-features = false }
-simba          = { version = "0.7", default-features = false }
+simba          = { version = "0.7.0", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ convert-glam020 = [ "glam020" ]
 ## `serde-serialize`.
 serde-serialize-no-std = [ "serde", "num-complex/serde" ]
 serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
-rkyv-serialize-no-std  = [ "rkyv" ]
-rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "bytecheck" ]
+rkyv-serialize-no-std  = [ "rkyv", "rkyv_wrappers" ]
+rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "rkyv/validation", "bytecheck" ]
 
 # Randomness
 ## To use rand in a #[no-std] environment, enable the
@@ -79,7 +79,8 @@ alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
-rkyv           = { version = "~0.7.1", optional = true }
+rkyv           = { version = "0.7", optional = true }
+rkyv_wrappers   = { git = "https://github.com/rkyv/rkyv_contrib", optional = true }
 bytecheck      = { version = "~0.6.1", optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ nalgebra-macros = { version = "0.1", path = "nalgebra-macros", optional = true }
 typenum        = "1.12"
 rand-package   = { package = "rand", version = "0.8", optional = true, default-features = false }
 num-traits     = { version = "0.2", default-features = false }
-num-complex    = { version = "0.4", default-features = false }
+num-complex    = { version = "0.4", default-features = false } # { version = "0.4", default-features = false }
 num-rational   = { version = "0.4", default-features = false }
 approx         = { version = "0.5", default-features = false }
 simba          = { version = "0.7", default-features = false }
@@ -80,7 +80,7 @@ rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
 rkyv           = { version = "0.7", optional = true }
-rkyv_wrappers   = { git = "https://github.com/rkyv/rkyv_contrib", optional = true }
+rkyv_wrappers  = { git = "https://github.com/rkyv/rkyv_contrib", optional = true }
 bytecheck      = { version = "~0.6.1", optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "1", optional = true }

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -27,6 +27,7 @@ use std::mem;
 /// A array-based statically sized matrix data storage.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
@@ -38,7 +39,6 @@ use std::mem;
     ")
     )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct ArrayStorage<T, const R: usize, const C: usize>(pub [[T; R]; C]);
 

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -27,11 +27,15 @@ use std::mem;
 /// A array-based statically sized matrix data storage.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Self", bound(archive = "
+        T: rkyv::Archive<Archived = T>,
+        [[T; R]; C]: rkyv::Archive<Archived = [[T; R]; C]>
+    "))
 )]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct ArrayStorage<T, const R: usize, const C: usize>(pub [[T; R]; C]);
 

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -30,10 +30,13 @@ use std::mem;
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "ArrayStorage<T::Archived, R, C>", bound(archive = "
+    archive(
+        as = "ArrayStorage<T::Archived, R, C>",
+        bound(archive = "
         T: rkyv::Archive,
         [[T; R]; C]: rkyv::Archive<Archived = [[T::Archived; R]; C]>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -30,9 +30,9 @@ use std::mem;
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Self", bound(archive = "
-        T: rkyv::Archive<Archived = T>,
-        [[T; R]; C]: rkyv::Archive<Archived = [[T; R]; C]>
+    archive(as = "ArrayStorage<T::Archived, R, C>", bound(archive = "
+        T: rkyv::Archive,
+        [[T; R]; C]: rkyv::Archive<Archived = [[T::Archived; R]; C]>
     "))
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -13,11 +13,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Dim of dynamically-sized algebraic entities.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
-#[cfg_attr(
-    feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
-)]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Dynamic {
     value: usize,
@@ -203,11 +198,6 @@ dim_ops!(
 );
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
-)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Const<const R: usize>;
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -150,11 +150,15 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// some concrete types for `T` and a compatible data storage type `S`).
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Self", bound(archive = "
+        S: rkyv::Archive<Archived = S>,
+        PhantomData<(T, R, C)>: rkyv::Archive<Archived = PhantomData<(T, R, C)>>
+    "))
 )]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Matrix<T, R, C, S> {
     /// The data storage that contains all the matrix components. Disappointed?

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -12,7 +12,7 @@ use std::mem;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "rkyv-serialize-no-std")]
-use rkyv::{Archive, Archived, with::With};
+use rkyv::{with::With, Archive, Archived};
 #[cfg(feature = "rkyv-serialize-no-std")]
 use rkyv_wrappers::custom_phantom::CustomPhantom;
 
@@ -158,11 +158,14 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Matrix<T::Archived, R, C, S::Archived>", bound(archive = "
+    archive(
+        as = "Matrix<T::Archived, R, C, S::Archived>",
+        bound(archive = "
         T: Archive,
         S: Archive,
         With<PhantomData<(T, R, C)>, CustomPhantom<(Archived<T>, R, C)>>: Archive<Archived = PhantomData<(Archived<T>, R, C)>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -155,6 +155,7 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// some concrete types for `T` and a compatible data storage type `S`).
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(Archive, rkyv::Serialize, rkyv::Deserialize),
@@ -167,7 +168,6 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
     ")
     )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Matrix<T, R, C, S> {
     /// The data storage that contains all the matrix components. Disappointed?

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -24,9 +24,12 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Unit<T::Archived>", bound(archive = "
+    archive(
+        as = "Unit<T::Archived>",
+        bound(archive = "
         T: rkyv::Archive,
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 // #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -21,6 +21,7 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
 #[derive(Clone, Hash, Copy)]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
@@ -31,7 +32,6 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
     ")
     )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 // #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Unit<T> {
     pub(crate) value: T,

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -21,11 +21,14 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
 #[derive(Clone, Hash, Copy)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Unit<T::Archived>", bound(archive = "
+        T: rkyv::Archive,
+    "))
 )]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 // #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Unit<T> {
     pub(crate) value: T,

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -44,10 +44,13 @@ use simba::scalar::{ClosedNeg, RealField};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "DualQuaternion<T::Archived>", bound(archive = "
+    archive(
+        as = "DualQuaternion<T::Archived>",
+        bound(archive = "
         T: rkyv::Archive,
         Quaternion<T>: rkyv::Archive<Archived = Quaternion<T::Archived>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct DualQuaternion<T> {

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -43,7 +43,11 @@ use simba::scalar::{ClosedNeg, RealField};
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "DualQuaternion<T::Archived>", bound(archive = "
+        T: rkyv::Archive,
+        Quaternion<T>: rkyv::Archive<Archived = Quaternion<T::Archived>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct DualQuaternion<T> {

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -66,6 +66,7 @@ use crate::geometry::{AbstractRotation, Point, Translation};
                        Owned<T, Const<D>>: Deserialize<'de>,
                        T: Scalar"))
 )]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
@@ -78,7 +79,6 @@ use crate::geometry::{AbstractRotation, Point, Translation};
     ")
     )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Isometry<T, R, const D: usize> {
     /// The pure rotational part of this isometry.
     pub rotation: R,

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -69,11 +69,14 @@ use crate::geometry::{AbstractRotation, Point, Translation};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Isometry<T::Archived, R::Archived, D>", bound(archive = "
+    archive(
+        as = "Isometry<T::Archived, R::Archived, D>",
+        bound(archive = "
         T: rkyv::Archive,
         R: rkyv::Archive,
         Translation<T, D>: rkyv::Archive<Archived = Translation<T::Archived, D>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Isometry<T, R, const D: usize> {

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -68,7 +68,12 @@ use crate::geometry::{AbstractRotation, Point, Translation};
 )]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Isometry<T::Archived, R::Archived, D>", bound(archive = "
+        T: rkyv::Archive,
+        R: rkyv::Archive,
+        Translation<T, D>: rkyv::Archive<Archived = Translation<T::Archived, D>>
+    "))
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Isometry<T, R, const D: usize> {

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -23,10 +23,13 @@ use crate::geometry::{Point3, Projective3};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Orthographic3<T::Archived>", bound(archive = "
+    archive(
+        as = "Orthographic3<T::Archived>",
+        bound(archive = "
         T: rkyv::Archive,
         Matrix4<T>: rkyv::Archive<Archived = Matrix4<T::Archived>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -22,7 +22,11 @@ use crate::geometry::{Point3, Projective3};
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Orthographic3<T::Archived>", bound(archive = "
+        T: rkyv::Archive,
+        Matrix4<T>: rkyv::Archive<Archived = Matrix4<T::Archived>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -24,10 +24,13 @@ use crate::geometry::{Point3, Projective3};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Perspective3<T::Archived>", bound(archive = "
+    archive(
+        as = "Perspective3<T::Archived>",
+        bound(archive = "
         T: rkyv::Archive,
         Matrix4<T>: rkyv::Archive<Archived = Matrix4<T::Archived>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -23,7 +23,11 @@ use crate::geometry::{Point3, Projective3};
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Perspective3<T::Archived>", bound(archive = "
+        T: rkyv::Archive,
+        Matrix4<T>: rkyv::Archive<Archived = Matrix4<T::Archived>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -36,11 +36,20 @@ use std::mem::MaybeUninit;
 /// of said transformations for details.
 #[repr(C)]
 #[derive(Clone)]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(
+        as = "OPoint<T::Archived, D>",
+        bound(archive = "
+        T: rkyv::Archive,
+        T::Archived: Scalar,
+        OVector<T, D>: rkyv::Archive<Archived = OVector<T::Archived, D>>,
+        DefaultAllocator: Allocator<T::Archived, D>,
+    ")
+    )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct OPoint<T: Scalar, D: DimName>
 where
     DefaultAllocator: Allocator<T, D>,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -26,7 +26,11 @@ use crate::geometry::{Point3, Rotation};
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Quaternion<T::Archived>", bound(archive = "
+        T: rkyv::Archive,
+        Vector4<T>: rkyv::Archive<Archived = Vector4<T::Archived>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Quaternion<T> {

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -27,10 +27,13 @@ use crate::geometry::{Point3, Rotation};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Quaternion<T::Archived>", bound(archive = "
+    archive(
+        as = "Quaternion<T::Archived>",
+        bound(archive = "
         T: rkyv::Archive,
         Vector4<T>: rkyv::Archive<Archived = Vector4<T::Archived>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Quaternion<T> {

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -52,7 +52,11 @@ use crate::geometry::Point;
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Rotation<T::Archived, D>", bound(archive = "
+        T: rkyv::Archive,
+        SMatrix<T, D, D>: rkyv::Archive<Archived = SMatrix<T::Archived, D, D>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -53,10 +53,13 @@ use crate::geometry::Point;
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Rotation<T::Archived, D>", bound(archive = "
+    archive(
+        as = "Rotation<T::Archived, D>",
+        bound(archive = "
         T: rkyv::Archive,
         SMatrix<T, D, D>: rkyv::Archive<Archived = SMatrix<T::Archived, D, D>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -20,7 +20,11 @@ use crate::geometry::Point;
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Scale<T::Archived, D>", bound(archive = "
+        T: rkyv::Archive,
+        SVector<T, D>: rkyv::Archive<Archived = SVector<T::Archived, D>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -21,10 +21,13 @@ use crate::geometry::Point;
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Scale<T::Archived, D>", bound(archive = "
+    archive(
+        as = "Scale<T::Archived, D>",
+        bound(archive = "
         T: rkyv::Archive,
         SVector<T, D>: rkyv::Archive<Archived = SVector<T::Archived, D>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -34,6 +34,7 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
                        DefaultAllocator: Allocator<T, Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
@@ -46,7 +47,6 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
     ")
     )
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Similarity<T, R, const D: usize> {
     /// The part of this similarity that does not include the scaling factor.
     pub isometry: Isometry<T, R, D>,

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -36,7 +36,12 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
 )]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Similarity<T::Archived, R::Archived, D>", bound(archive = "
+        T: rkyv::Archive,
+        R: rkyv::Archive,
+        Isometry<T, R, D>: rkyv::Archive<Archived = Isometry<T::Archived, R::Archived, D>>
+    "))
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Similarity<T, R, const D: usize> {

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -37,11 +37,14 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Similarity<T::Archived, R::Archived, D>", bound(archive = "
+    archive(
+        as = "Similarity<T::Archived, R::Archived, D>",
+        bound(archive = "
         T: rkyv::Archive,
         R: rkyv::Archive,
         Isometry<T, R, D>: rkyv::Archive<Archived = Isometry<T::Archived, R::Archived, D>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 pub struct Similarity<T, R, const D: usize> {

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -20,7 +20,11 @@ use crate::geometry::Point;
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Translation<T::Archived, D>", bound(archive = "
+        T: rkyv::Archive,
+        SVector<T, D>: rkyv::Archive<Archived = SVector<T::Archived, D>>
+    "))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -21,10 +21,13 @@ use crate::geometry::Point;
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive(as = "Translation<T::Archived, D>", bound(archive = "
+    archive(
+        as = "Translation<T::Archived, D>",
+        bound(archive = "
         T: rkyv::Archive,
         SVector<T, D>: rkyv::Archive<Archived = SVector<T::Archived, D>>
-    "))
+    ")
+    )
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ an optimized set of tools for computer graphics and physics. Those features incl
     unused_variables,
     unused_mut,
     unused_parens,
-    unused_qualifications,
+    // unused_qualifications,
     rust_2018_idioms,
     rust_2018_compatibility,
     future_incompatible,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,14 +77,13 @@ an optimized set of tools for computer graphics and physics. Those features incl
     unused_variables,
     unused_mut,
     unused_parens,
-    // unused_qualifications,
     rust_2018_idioms,
     rust_2018_compatibility,
     future_incompatible,
     missing_copy_implementations
 )]
-#![cfg_attr(feature = "rkyv-serialize-no-std", warn(unused_results))] // TODO: deny this once bytecheck stops generating warnings.
-#![cfg_attr(not(feature = "rkyv-serialize-no-std"), deny(unused_results))]
+#![cfg_attr(feature = "rkyv-serialize-no-std", allow(unused_results))] // TODO: deny this once bytecheck stops generating warnings.
+#![cfg_attr(not(feature = "rkyv-serialize-no-std"), deny(unused_results), deny(unused_qualifications))] // TODO: deny this globally
 #![doc(
     html_favicon_url = "https://nalgebra.org/img/favicon.ico",
     html_root_url = "https://docs.rs/nalgebra/0.25.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,11 @@ an optimized set of tools for computer graphics and physics. Those features incl
     missing_copy_implementations
 )]
 #![cfg_attr(feature = "rkyv-serialize-no-std", allow(unused_results))] // TODO: deny this once bytecheck stops generating warnings.
-#![cfg_attr(not(feature = "rkyv-serialize-no-std"), deny(unused_results), deny(unused_qualifications))] // TODO: deny this globally
+#![cfg_attr(
+    not(feature = "rkyv-serialize-no-std"),
+    deny(unused_results),
+    deny(unused_qualifications)
+)] // TODO: deny this globally
 #![doc(
     html_favicon_url = "https://nalgebra.org/img/favicon.ico",
     html_root_url = "https://docs.rs/nalgebra/0.25.0"

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -8,6 +8,7 @@ mod matrix_slice;
 #[cfg(feature = "mint")]
 mod mint;
 mod serde;
+mod rkyv;
 
 #[cfg(feature = "compare")]
 mod matrixcompare;

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -7,8 +7,8 @@ mod matrix;
 mod matrix_slice;
 #[cfg(feature = "mint")]
 mod mint;
-mod serde;
 mod rkyv;
+mod serde;
 
 #[cfg(feature = "compare")]
 mod matrixcompare;

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "rkyv-serialize")]
+
+use na::{
+    DMatrix, Isometry2, Isometry3, IsometryMatrix2, IsometryMatrix3, Matrix2x3, Matrix3x4, Point2,
+    Point3, Quaternion, Rotation2, Rotation3, Similarity2, Similarity3, SimilarityMatrix2,
+    SimilarityMatrix3, Translation2, Translation3, Unit, Vector2,
+};
+use rand;
+use rkyv::{Archive, Serialize, Deserialize};
+
+macro_rules! test_rkyv(
+    ($($test: ident, $ty: ident);* $(;)*) => {$(
+        #[test]
+        fn $test() {
+            let v: $ty<f32> = rand::random();
+			let bytes = rkyv::to_bytes::<_, 256>(&v).unwrap();
+
+			let archived = rkyv::check_archived_root::<$ty<f32>>(&bytes[..]).unwrap();
+			assert_eq!(archived, &value);
+
+			assert_eq!(format!("{:?}", value), format!("{:?}", archive));
+        }
+    )*}
+);
+
+test_rkyv!(
+    rkyv_matrix3x4,          Matrix3x4;
+    rkyv_point3,             Point3;
+    rkyv_translation3,       Translation3;
+    rkyv_rotation3,          Rotation3;
+    rkyv_isometry3,          Isometry3;
+    rkyv_isometry_matrix3,   IsometryMatrix3;
+    rkyv_similarity3,        Similarity3;
+    rkyv_similarity_matrix3, SimilarityMatrix3;
+    rkyv_quaternion,         Quaternion;
+    rkyv_point2,             Point2;
+    rkyv_translation2,       Translation2;
+    rkyv_rotation2,          Rotation2;
+    rkyv_isometry2,          Isometry2;
+    rkyv_isometry_matrix2,   IsometryMatrix2;
+    rkyv_similarity2,        Similarity2;
+    rkyv_similarity_matrix2, SimilarityMatrix2;
+);

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -12,21 +12,21 @@ macro_rules! test_rkyv(
     ($($test: ident, $ty: ident);* $(;)*) => {$(
         #[test]
         fn $test() {
-            let v: $ty<f32> = rand::random();
-			let bytes = rkyv::to_bytes::<_, 256>(&v).unwrap();
+            let value: $ty<f32> = rand::random();
+			let bytes = rkyv::to_bytes::<_, 256>(&value).unwrap();
 
 			let archived = rkyv::check_archived_root::<$ty<f32>>(&bytes[..]).unwrap();
 			assert_eq!(archived, &value);
 
-			assert_eq!(format!("{:?}", value), format!("{:?}", archive));
+			assert_eq!(format!("{:?}", value), format!("{:?}", archived));
         }
     )*}
 );
 
 test_rkyv!(
     rkyv_matrix3x4,          Matrix3x4;
-    rkyv_point3,             Point3;
-    rkyv_translation3,       Translation3;
+    // rkyv_point3,             Point3;
+   /*  rkyv_translation3,       Translation3;
     rkyv_rotation3,          Rotation3;
     rkyv_isometry3,          Isometry3;
     rkyv_isometry_matrix3,   IsometryMatrix3;
@@ -39,5 +39,5 @@ test_rkyv!(
     rkyv_isometry2,          Isometry2;
     rkyv_isometry_matrix2,   IsometryMatrix2;
     rkyv_similarity2,        Similarity2;
-    rkyv_similarity_matrix2, SimilarityMatrix2;
+    rkyv_similarity_matrix2, SimilarityMatrix2; */
 );

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -6,7 +6,7 @@ use na::{
     SimilarityMatrix3, Translation2, Translation3, Unit, Vector2,
 };
 use rand;
-use rkyv::{Archive, Serialize, Deserialize, Infallible};
+use rkyv::{Archive, Deserialize, Infallible, Serialize};
 
 macro_rules! test_rkyv_archived_impls(
     ($($test: ident, $ty: ident);* $(;)*) => {$(

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -8,7 +8,7 @@ use na::{
 use rand;
 use rkyv::{Archive, Deserialize, Infallible, Serialize};
 
-macro_rules! test_rkyv_archived_impls(
+macro_rules! test_rkyv_same_type(
     ($($test: ident, $ty: ident);* $(;)*) => {$(
         #[test]
         fn $test() {
@@ -16,44 +16,48 @@ macro_rules! test_rkyv_archived_impls(
 			let bytes = rkyv::to_bytes::<_, 256>(&value).unwrap();
 
 			let archived = rkyv::check_archived_root::<$ty<f32>>(&bytes[..]).unwrap();
+            // Compare archived and non-archived
 			assert_eq!(archived, &value);
 
+            // Make sure Debug implementations are the same for Archived and non-Archived versions.
 			assert_eq!(format!("{:?}", value), format!("{:?}", archived));
         }
     )*}
 );
-macro_rules! test_rkyv(
+macro_rules! test_rkyv_diff_type(
     ($($test: ident, $ty: ident);* $(;)*) => {$(
         #[test]
         fn $test() {
-            let value: $ty<f32> = rand::random();
+            let value: $ty<String> = Default::default();
 			let bytes = rkyv::to_bytes::<_, 256>(&value).unwrap();
 
-			let archived = rkyv::check_archived_root::<$ty<f32>>(&bytes[..]).unwrap();
-            let deserialized: $ty<f32> = archived.deserialize(&mut Infallible).unwrap();
+			let archived = rkyv::check_archived_root::<$ty<String>>(&bytes[..]).unwrap();
+            let deserialized: $ty<String> = archived.deserialize(&mut Infallible).unwrap();
 			assert_eq!(deserialized, value);
         }
     )*}
 );
 
-test_rkyv_archived_impls!(
-    rkyv_matrix3x4,         Matrix3x4;
+// Tests to make sure
+test_rkyv_same_type!(
+    rkyv_same_type_matrix3x4,          Matrix3x4;
+    rkyv_same_type_point3,             Point3;
+    rkyv_same_type_translation3,       Translation3;
+    rkyv_same_type_rotation3,          Rotation3;
+    rkyv_same_type_isometry3,          Isometry3;
+    rkyv_same_type_isometry_matrix3,   IsometryMatrix3;
+    rkyv_same_type_similarity3,        Similarity3;
+    rkyv_same_type_similarity_matrix3, SimilarityMatrix3;
+    rkyv_same_type_quaternion,         Quaternion;
+    rkyv_same_type_point2,             Point2;
+    rkyv_same_type_translation2,       Translation2;
+    rkyv_same_type_rotation2,          Rotation2;
+    rkyv_same_type_isometry2,          Isometry2;
+    rkyv_same_type_isometry_matrix2,   IsometryMatrix2;
+    rkyv_same_type_similarity2,        Similarity2;
+    rkyv_same_type_similarity_matrix2, SimilarityMatrix2;
 );
 
-test_rkyv!(
-    // rkyv_point3,             Point3;
-    rkyv_translation3,       Translation3;
-    /* rkyv_rotation3,          Rotation3;
-    rkyv_isometry3,          Isometry3;
-    rkyv_isometry_matrix3,   IsometryMatrix3;
-    rkyv_similarity3,        Similarity3;
-    rkyv_similarity_matrix3, SimilarityMatrix3;
-    rkyv_quaternion,         Quaternion; */
-    // rkyv_point2,             Point2;
-    rkyv_translation2,       Translation2;
-    /* rkyv_rotation2,          Rotation2;
-    rkyv_isometry2,          Isometry2;
-    rkyv_isometry_matrix2,   IsometryMatrix2;
-    rkyv_similarity2,        Similarity2;
-    rkyv_similarity_matrix2, SimilarityMatrix2; */
-);
+test_rkyv_diff_type! {
+    rkyv_diff_type_matrix3x4,          Matrix3x4;
+}

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -6,9 +6,9 @@ use na::{
     SimilarityMatrix3, Translation2, Translation3, Unit, Vector2,
 };
 use rand;
-use rkyv::{Archive, Serialize, Deserialize};
+use rkyv::{Archive, Serialize, Deserialize, Infallible};
 
-macro_rules! test_rkyv(
+macro_rules! test_rkyv_archived_impls(
     ($($test: ident, $ty: ident);* $(;)*) => {$(
         #[test]
         fn $test() {
@@ -22,20 +22,36 @@ macro_rules! test_rkyv(
         }
     )*}
 );
+macro_rules! test_rkyv(
+    ($($test: ident, $ty: ident);* $(;)*) => {$(
+        #[test]
+        fn $test() {
+            let value: $ty<f32> = rand::random();
+			let bytes = rkyv::to_bytes::<_, 256>(&value).unwrap();
+
+			let archived = rkyv::check_archived_root::<$ty<f32>>(&bytes[..]).unwrap();
+            let deserialized: $ty<f32> = archived.deserialize(&mut Infallible).unwrap();
+			assert_eq!(deserialized, value);
+        }
+    )*}
+);
+
+test_rkyv_archived_impls!(
+    rkyv_matrix3x4,         Matrix3x4;
+);
 
 test_rkyv!(
-    rkyv_matrix3x4,          Matrix3x4;
     // rkyv_point3,             Point3;
-   /*  rkyv_translation3,       Translation3;
-    rkyv_rotation3,          Rotation3;
+    rkyv_translation3,       Translation3;
+    /* rkyv_rotation3,          Rotation3;
     rkyv_isometry3,          Isometry3;
     rkyv_isometry_matrix3,   IsometryMatrix3;
     rkyv_similarity3,        Similarity3;
     rkyv_similarity_matrix3, SimilarityMatrix3;
-    rkyv_quaternion,         Quaternion;
-    rkyv_point2,             Point2;
+    rkyv_quaternion,         Quaternion; */
+    // rkyv_point2,             Point2;
     rkyv_translation2,       Translation2;
-    rkyv_rotation2,          Rotation2;
+    /* rkyv_rotation2,          Rotation2;
     rkyv_isometry2,          Isometry2;
     rkyv_isometry_matrix2,   IsometryMatrix2;
     rkyv_similarity2,        Similarity2;


### PR DESCRIPTION
make it so that nalgebra objects archive as themselves. Allows for implementations on `Matrix` and other types to also work in a zero-copy environment.
Draft PR, I will extend this to the other types soon. Any critiques or help with figuring out why I can't `allow(unused_qualifications)` in `cfg_attr` are welcome.