### PR TITLE
Support conversion for glam `0.21`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ convert-glam017 = [ "glam017" ]
 convert-glam018 = [ "glam018" ]
 convert-glam019 = [ "glam019" ]
 convert-glam020 = [ "glam020" ]
+convert-glam021 = [ "glam021" ]
 
 # Serialization
 ## To use serde in a #[no-std] environment, enable the
@@ -95,6 +96,7 @@ glam017        = { package = "glam", version = "0.17", optional = true }
 glam018        = { package = "glam", version = "0.18", optional = true }
 glam019        = { package = "glam", version = "0.19", optional = true }
 glam020        = { package = "glam", version = "0.20", optional = true }
+glam021        = { package = "glam", version = "0.21", optional = true }
 cust_core      = { version = "0.1", optional = true }
 
 

--- a/src/third_party/glam/common/glam_matrix.rs
+++ b/src/third_party/glam/common/glam_matrix.rs
@@ -14,7 +14,7 @@ macro_rules! impl_vec_conversion(
         impl From<$Vec2> for Vector2<$N> {
             #[inline]
             fn from(e: $Vec2) -> Vector2<$N> {
-                (*e.as_ref()).into()
+                <[$N;2]>::from(e).into()
             }
         }
 
@@ -31,7 +31,7 @@ macro_rules! impl_vec_conversion(
         impl From<$Vec3> for Vector3<$N> {
             #[inline]
             fn from(e: $Vec3) -> Vector3<$N> {
-                (*e.as_ref()).into()
+                <[$N;3]>::from(e).into()
             }
         }
 
@@ -48,7 +48,7 @@ macro_rules! impl_vec_conversion(
         impl From<$Vec4> for Vector4<$N> {
             #[inline]
             fn from(e: $Vec4) -> Vector4<$N> {
-                (*e.as_ref()).into()
+                <[$N;4]>::from(e).into()
             }
         }
 

--- a/src/third_party/glam/common/glam_point.rs
+++ b/src/third_party/glam/common/glam_point.rs
@@ -9,7 +9,7 @@ macro_rules! impl_point_conversion(
         impl From<$Vec2> for Point2<$N> {
             #[inline]
             fn from(e: $Vec2) -> Point2<$N> {
-                (*e.as_ref()).into()
+                <[$N;2]>::from(e).into()
             }
         }
 
@@ -23,7 +23,7 @@ macro_rules! impl_point_conversion(
         impl From<$Vec3> for Point3<$N> {
             #[inline]
             fn from(e: $Vec3) -> Point3<$N> {
-                (*e.as_ref()).into()
+                <[$N;3]>::from(e).into()
             }
         }
 
@@ -37,7 +37,7 @@ macro_rules! impl_point_conversion(
         impl From<$Vec4> for Point4<$N> {
             #[inline]
             fn from(e: $Vec4) -> Point4<$N> {
-                (*e.as_ref()).into()
+                <[$N;4]>::from(e).into()
             }
         }
 

--- a/src/third_party/glam/mod.rs
+++ b/src/third_party/glam/mod.rs
@@ -12,3 +12,5 @@ mod v018;
 mod v019;
 #[cfg(feature = "glam020")]
 mod v020;
+#[cfg(feature = "glam021")]
+mod v021;

--- a/src/third_party/glam/v021/mod.rs
+++ b/src/third_party/glam/v021/mod.rs
@@ -1,0 +1,18 @@
+#[path = "../common/glam_isometry.rs"]
+mod glam_isometry;
+#[path = "../common/glam_matrix.rs"]
+mod glam_matrix;
+#[path = "../common/glam_point.rs"]
+mod glam_point;
+#[path = "../common/glam_quaternion.rs"]
+mod glam_quaternion;
+#[path = "../common/glam_rotation.rs"]
+mod glam_rotation;
+#[path = "../common/glam_similarity.rs"]
+mod glam_similarity;
+#[path = "../common/glam_translation.rs"]
+mod glam_translation;
+#[path = "../common/glam_unit_complex.rs"]
+mod glam_unit_complex;
+
+pub(self) use glam021 as glam;


### PR DESCRIPTION
Add feature `convert-glam021`.

Conversion macros changed to use the `From` trait to convert glam types to arrays because The `BVec*` types no longer implement `AsRef`.