### PR TITLE
Use #[inline] to improve opt-level 1 performance

### DIFF
--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -252,14 +252,17 @@ pub trait ToTypenum {
 }
 
 unsafe impl<const T: usize> Dim for Const<T> {
+    #[inline]
     fn try_to_usize() -> Option<usize> {
         Some(T)
     }
 
+    #[inline]
     fn value(&self) -> usize {
         T
     }
 
+    #[inline]
     fn from_usize(dim: usize) -> Self {
         assert_eq!(dim, T);
         Self


### PR DESCRIPTION
fixes #1139

My dev environment is not set up properly for nalgebra, so I've been unable to test this locally in any of the standard ways, but these changes work correctly with Hypermine, and the changes are simple enough that I believe it's worth creating a PR anyway.

Please let me know if there's anything I need to do before this can be merged, if it can be merged at all.