### PR TITLE
[Sparse] Add `clear_triplets()`

### DIFF
--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -211,6 +211,26 @@ impl<T> CooMatrix<T> {
         self.values.push(v);
     }
 
+    /// Remove a single triplet from the matrix.
+    ///
+    /// This removes the value `v` from the `i`th row and `j`th column in the matrix.
+    pub fn clear_triplet(&mut self, i: usize, j: usize, v: T) -> Option<(usize, usize, T)>
+    where
+        T: PartialEq,
+    {
+        let triple_idx = self
+            .triplet_iter()
+            .position(|triplet| triplet == (i, j, &v));
+        if let Some(triple_idx) = triple_idx {
+            self.row_indices.remove(triple_idx);
+            self.col_indices.remove(triple_idx);
+            let retv = self.values.remove(triple_idx);
+            Some((i, j, retv))
+        } else {
+            None
+        }
+    }
+
     /// The number of rows in the matrix.
     #[inline]
     #[must_use]

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -214,7 +214,7 @@ impl<T> CooMatrix<T> {
     /// Remove a single triplet from the matrix.
     ///
     /// This removes the value `v` from the `i`th row and `j`th column in the matrix.
-    pub fn clear_triplet(&mut self, i: usize, j: usize, v: T) -> Option<(usize, usize, T)>
+    pub fn clear_triplet(&mut self, i: usize, j: usize, v: T) -> Option<T>
     where
         T: PartialEq,
     {
@@ -224,8 +224,8 @@ impl<T> CooMatrix<T> {
         if let Some(triple_idx) = triple_idx {
             self.row_indices.remove(triple_idx);
             self.col_indices.remove(triple_idx);
-            let retv = self.values.remove(triple_idx);
-            Some((i, j, retv))
+            let removed_value = self.values.remove(triple_idx);
+            Some(removed_value)
         } else {
             None
         }

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -212,7 +212,7 @@ impl<T> CooMatrix<T> {
     }
 
     /// Clear all triplets from the matrix.
-    pub fn clear_triplets(&mut self, i: usize, j: usize, v: T)
+    pub fn clear_triplets(&mut self)
     where
         T: PartialEq,
     {

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -212,10 +212,7 @@ impl<T> CooMatrix<T> {
     }
 
     /// Clear all triplets from the matrix.
-    pub fn clear_triplets(&mut self)
-    where
-        T: PartialEq,
-    {
+    pub fn clear_triplets(&mut self) {
         self.col_indices.clear();
         self.row_indices.clear();
         self.values.clear();

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -211,24 +211,14 @@ impl<T> CooMatrix<T> {
         self.values.push(v);
     }
 
-    /// Remove a single triplet from the matrix.
-    ///
-    /// This removes the value `v` from the `i`th row and `j`th column in the matrix.
-    pub fn clear_triplet(&mut self, i: usize, j: usize, v: T) -> Option<T>
+    /// Clear all triplets from the matrix.
+    pub fn clear_triplets(&mut self, i: usize, j: usize, v: T) -> Option<T>
     where
         T: PartialEq,
     {
-        let triple_idx = self
-            .triplet_iter()
-            .position(|triplet| triplet == (i, j, &v));
-        if let Some(triple_idx) = triple_idx {
-            self.row_indices.remove(triple_idx);
-            self.col_indices.remove(triple_idx);
-            let removed_value = self.values.remove(triple_idx);
-            Some(removed_value)
-        } else {
-            None
-        }
+        self.col_indices.clear();
+        self.row_indices.clear();
+        self.values.clear();
     }
 
     /// The number of rows in the matrix.

--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -212,7 +212,7 @@ impl<T> CooMatrix<T> {
     }
 
     /// Clear all triplets from the matrix.
-    pub fn clear_triplets(&mut self, i: usize, j: usize, v: T) -> Option<T>
+    pub fn clear_triplets(&mut self, i: usize, j: usize, v: T)
     where
         T: PartialEq,
     {

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -238,7 +238,7 @@ fn coo_clear_triplets_valid_entries() {
         vec![(0, 0, &1), (0, 0, &2), (2, 2, &3)]
     );
     coo.clear_triplets();
-    assert_eq(coo.triplet_iter.collect::<Vec<_>>(), vec![]);
+    assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![]);
     // making sure everyhting works after clearing
     coo.push(0, 0, 1);
     coo.push(0, 0, 2);

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -227,32 +227,18 @@ fn coo_push_valid_entries() {
 }
 
 #[test]
-fn coo_clear_triplet_valid_entries() {
+fn coo_clear_triplets_valid_entries() {
     let mut coo = CooMatrix::new(3, 3);
 
     coo.push(0, 0, 1);
     coo.push(0, 0, 2);
     coo.push(2, 2, 3);
-
-    // clear a triplet that is not included
-    let triplet = coo.clear_triplet(0, 0, 0);
-    assert_eq!(triplet, None);
     assert_eq!(
         coo.triplet_iter().collect::<Vec<_>>(),
         vec![(0, 0, &1), (0, 0, &2), (2, 2, &3)]
     );
-    let triplet = coo.clear_triplet(0, 0, 1);
-    assert_eq!(triplet, Some(1));
-    assert_eq!(
-        coo.triplet_iter().collect::<Vec<_>>(),
-        vec![(0, 0, &2), (2, 2, &3)]
-    );
-    let triplet = coo.clear_triplet(0, 0, 2);
-    assert_eq!(triplet, Some(2));
-    assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![(2, 2, &3)]);
-    let triplet = coo.clear_triplet(2, 2, 3);
-    assert_eq!(triplet, Some(3));
-    assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![]);
+    coo.clear_triplets();
+    assert_eq(coo.triplet_iter.collect::<Vec<_>>(), vec![]);
 }
 
 #[test]

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -227,6 +227,35 @@ fn coo_push_valid_entries() {
 }
 
 #[test]
+fn coo_clear_triplet_valid_entries() {
+    let mut coo = CooMatrix::new(3, 3);
+
+    coo.push(0, 0, 1);
+    coo.push(0, 0, 2);
+    coo.push(2, 2, 3);
+
+    // clear a triplet that is not included
+    let triplet = coo.clear_triplet(0, 0, 0);
+    assert_eq!(triplet, None);
+    assert_eq!(
+        coo.triplet_iter().collect::<Vec<_>>(),
+        vec![(0, 0, &1), (0, 0, &2), (2, 2, &3)]
+    );
+    let triplet = coo.clear_triplet(0, 0, 1);
+    assert_eq!(triplet, Some((0, 0, 1)));
+    assert_eq!(
+        coo.triplet_iter().collect::<Vec<_>>(),
+        vec![(0, 0, &2), (2, 2, &3)]
+    );
+    let triplet = coo.clear_triplet(0, 0, 2);
+    assert_eq!(triplet, Some((0, 0, 2)));
+    assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![(2, 2, &3)]);
+    let triplet = coo.clear_triplet(2, 2, 3);
+    assert_eq!(triplet, Some((2, 2, 3)));
+    assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![]);
+}
+
+#[test]
 fn coo_push_out_of_bounds_entries() {
     {
         // 0x0 matrix

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -242,16 +242,16 @@ fn coo_clear_triplet_valid_entries() {
         vec![(0, 0, &1), (0, 0, &2), (2, 2, &3)]
     );
     let triplet = coo.clear_triplet(0, 0, 1);
-    assert_eq!(triplet, Some((0, 0, 1)));
+    assert_eq!(triplet, Some(1));
     assert_eq!(
         coo.triplet_iter().collect::<Vec<_>>(),
         vec![(0, 0, &2), (2, 2, &3)]
     );
     let triplet = coo.clear_triplet(0, 0, 2);
-    assert_eq!(triplet, Some((0, 0, 2)));
+    assert_eq!(triplet, Some(2));
     assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![(2, 2, &3)]);
     let triplet = coo.clear_triplet(2, 2, 3);
-    assert_eq!(triplet, Some((2, 2, 3)));
+    assert_eq!(triplet, Some(3));
     assert_eq!(coo.triplet_iter().collect::<Vec<_>>(), vec![]);
 }
 

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -239,6 +239,14 @@ fn coo_clear_triplets_valid_entries() {
     );
     coo.clear_triplets();
     assert_eq(coo.triplet_iter.collect::<Vec<_>>(), vec![]);
+    // making sure everyhting works after clearing
+    coo.push(0, 0, 1);
+    coo.push(0, 0, 2);
+    coo.push(2, 2, 3);
+    assert_eq!(
+        coo.triplet_iter().collect::<Vec<_>>(),
+        vec![(0, 0, &1), (0, 0, &2), (2, 2, &3)]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the `clear_triplet()` method to the `CooMatrix` struct.
The goal of the method is to be able to remove triplets before construction.

Some outstanding questions:
* Spelling of the method? @Andlon suggested `clear_triplet` in the Discord. Another option might be `pop` or `pop_triplet` to correspond to `push`.
* Should out of bounds values cause a panic? It is probably fine to just return a `None` value.
* What should the return type be? Currently it is `Option<T>`.