### PR TITLE
Fix usage of CheckBytes

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ rand        = [ "rand-no-std", "rand-package/std", "rand-package/std_rng", "rand
 arbitrary        = [ "quickcheck" ]
 proptest-support = [ "proptest" ]
 slow-tests       = []
+rkyv-safe-deser  = [ "rkyv-serialize", "rkyv/validation" ]
 
 [dependencies]
 nalgebra-macros = { version = "0.1", path = "nalgebra-macros", optional = true }

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -27,10 +27,13 @@ use std::mem;
 /// A array-based statically sized matrix data storage.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct ArrayStorage<T, const R: usize, const C: usize>(pub [[T; R]; C]);

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -13,10 +13,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Dim of dynamically-sized algebraic entities.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Dynamic {
@@ -207,7 +210,10 @@ dim_ops!(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Const<const R: usize>;
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -150,10 +150,13 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// some concrete types for `T` and a compatible data storage type `S`).
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Matrix<T, R, C, S> {

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -21,10 +21,13 @@ use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealF
 /// in their documentation, read their dedicated pages directly.
 #[repr(transparent)]
 #[derive(Clone, Hash, Copy)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 // #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Unit<T> {

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -40,10 +40,13 @@ use simba::scalar::{ClosedNeg, RealField};
 ///  See <https://github.com/dimforge/nalgebra/issues/487>
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct DualQuaternion<T> {

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -70,7 +70,10 @@ use crate::geometry::{AbstractRotation, Point, Translation};
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct Isometry<T, R, const D: usize> {
     /// The pure rotational part of this isometry.
     pub rotation: R,

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -19,10 +19,13 @@ use crate::geometry::{Point3, Projective3};
 
 /// A 3D orthographic projection stored as a homogeneous 4x4 matrix.
 #[repr(C)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -20,10 +20,13 @@ use crate::geometry::{Point3, Projective3};
 
 /// A 3D perspective projection stored as a homogeneous 4x4 matrix.
 #[repr(C)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -40,7 +40,10 @@ use std::mem::MaybeUninit;
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct OPoint<T: Scalar, D: DimName>
 where
     DefaultAllocator: Allocator<T, D>,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -23,10 +23,13 @@ use crate::geometry::{Point3, Rotation};
 /// that may be used as a rotation.
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct Quaternion<T> {

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -49,10 +49,13 @@ use crate::geometry::Point;
 /// * [Conversion to a matrix <span style="float:right;">`matrix`, `to_homogeneous`…</span>](#conversion-to-a-matrix)
 ///
 #[repr(C)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -17,10 +17,13 @@ use crate::geometry::Point;
 
 /// A scale which supports non-uniform scaling.
 #[repr(C)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -38,7 +38,10 @@ use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct Similarity<T, R, const D: usize> {
     /// The part of this similarity that does not include the scaling factor.
     pub isometry: Isometry<T, R, D>,

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -17,10 +17,13 @@ use crate::geometry::Point;
 
 /// A translation.
 #[repr(C)]
-#[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[cfg_attr(
     feature = "rkyv-serialize-no-std",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv-serialize",
+    archive_attr(derive(bytecheck::CheckBytes))
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Copy, Clone)]

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -8,6 +8,8 @@ mod matrix_slice;
 #[cfg(feature = "mint")]
 mod mint;
 mod serde;
+#[cfg(feature = "rkyv-serialize-no-std")]
+mod rkyv;
 
 #[cfg(feature = "compare")]
 mod matrixcompare;

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -7,9 +7,9 @@ mod matrix;
 mod matrix_slice;
 #[cfg(feature = "mint")]
 mod mint;
-mod serde;
 #[cfg(feature = "rkyv-serialize-no-std")]
 mod rkyv;
+mod serde;
 
 #[cfg(feature = "compare")]
 mod matrixcompare;

--- a/tests/core/rkyv.rs
+++ b/tests/core/rkyv.rs
@@ -1,0 +1,44 @@
+use na::{
+    Isometry3, IsometryMatrix2, IsometryMatrix3, Matrix3x4, Point2, Point3, Quaternion, Rotation2,
+    Rotation3, Similarity3, SimilarityMatrix2, SimilarityMatrix3, Translation2, Translation3,
+};
+use rkyv::ser::{serializers::AllocSerializer, Serializer};
+
+macro_rules! test_rkyv(
+    ($($test: ident, $ty: ident);* $(;)*) => {$(
+        #[test]
+        fn $test() {
+            let v: $ty<f32> = rand::random();
+            // serialize
+            let mut serializer = AllocSerializer::<0>::default();
+            serializer.serialize_value(&v).unwrap();
+            let serialized = serializer.into_serializer().into_inner();
+
+            let deserialized: $ty<f32> = unsafe { rkyv::from_bytes_unchecked(&serialized).unwrap() };
+            assert_eq!(v, deserialized);
+
+            #[cfg(feature = "rkyv-safe-deser")]
+            {
+                let deserialized: $ty<f32> = rkyv::from_bytes(&serialized).unwrap();
+                assert_eq!(v, deserialized);
+            }
+        }
+    )*}
+);
+
+test_rkyv!(
+    rkyv_matrix3x4,          Matrix3x4;
+    rkyv_point3,             Point3;
+    rkyv_translation3,       Translation3;
+    rkyv_rotation3,          Rotation3;
+    rkyv_isometry3,          Isometry3;
+    rkyv_isometry_matrix3,   IsometryMatrix3;
+    rkyv_similarity3,        Similarity3;
+    rkyv_similarity_matrix3, SimilarityMatrix3;
+    rkyv_quaternion,         Quaternion;
+    rkyv_point2,             Point2;
+    rkyv_translation2,       Translation2;
+    rkyv_rotation2,          Rotation2;
+    rkyv_isometry_matrix2,   IsometryMatrix2;
+    rkyv_similarity_matrix2, SimilarityMatrix2;
+);


### PR DESCRIPTION
According to the [rkyv book](https://rkyv.org/validation.html), the `CheckBytes` trait derive should be applied inside `archive_attr` attribute, or we cannot deserialize data without `unsafe` code.

This PR also added some trivial tests for rkyv serialization and deserialization.