### PR TITLE
Release v0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.31.2] (09 Oct. 2022)
+
+### Modified
+- Use `#[inline]` on the `Dim` implementation for `Const` to improve opt-level 1 performance.
+- Make the `Point::new` constructions const-fn.
+
+### Added
+- Add `UnitVector::cast` to change the underlying scalar type.
+
+
 ## [0.31.1] (31 July 2022)
 
 ### Modified

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nalgebra"
-version = "0.31.1"
+version = "0.31.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."


### PR DESCRIPTION
### Modified
- Use `#[inline]` on the `Dim` implementation for `Const` to improve opt-level 1 performance.
- Make the `Point::new` constructions const-fn.

### Added
- Add `UnitVector::cast` to change the underlying scalar type.