### PR TITLE
Make CSR matrix example more self contained

### DIFF
--- a/nalgebra-sparse/src/csc.rs
+++ b/nalgebra-sparse/src/csc.rs
@@ -24,6 +24,7 @@ use std::slice::{Iter, IterMut};
 /// # Usage
 ///
 /// ```
+/// use nalgebra_sparse::coo::CooMatrix;
 /// use nalgebra_sparse::csc::CscMatrix;
 /// use nalgebra::{DMatrix, Matrix3x4};
 /// use matrixcompare::assert_matrix_eq;
@@ -32,8 +33,9 @@ use std::slice::{Iter, IterMut};
 /// // change the sparsity pattern of the matrix after it has been constructed. The easiest
 /// // way to construct a CSC matrix is to first incrementally construct a COO matrix,
 /// // and then convert it to CSC.
-/// # use nalgebra_sparse::coo::CooMatrix;
-/// # let coo = CooMatrix::<f64>::new(3, 3);
+///
+/// let mut coo = CooMatrix::<f64>::new(3, 3);
+/// coo.push(2, 0, 1.0);
 /// let csc = CscMatrix::from(&coo);
 ///
 /// // Alternatively, a CSC matrix can be constructed directly from raw CSC data.

--- a/nalgebra-sparse/src/csr.rs
+++ b/nalgebra-sparse/src/csr.rs
@@ -25,6 +25,7 @@ use std::slice::{Iter, IterMut};
 /// # Usage
 ///
 /// ```
+/// use nalgebra_sparse::coo::CooMatrix;
 /// use nalgebra_sparse::csr::CsrMatrix;
 /// use nalgebra::{DMatrix, Matrix3x4};
 /// use matrixcompare::assert_matrix_eq;
@@ -33,8 +34,9 @@ use std::slice::{Iter, IterMut};
 /// // change the sparsity pattern of the matrix after it has been constructed. The easiest
 /// // way to construct a CSR matrix is to first incrementally construct a COO matrix,
 /// // and then convert it to CSR.
-/// # use nalgebra_sparse::coo::CooMatrix;
-/// # let coo = CooMatrix::<f64>::new(3, 3);
+///
+/// let mut coo = CooMatrix::<f64>::new(3, 3);
+/// coo.push(2, 0, 1.0);
 /// let csr = CsrMatrix::from(&coo);
 ///
 /// // Alternatively, a CSR matrix can be constructed directly from raw CSR data.


### PR DESCRIPTION
Currently the CSR matrix example isn't self contained, because `coo` isn't defined in the code. This PR fixes that by defining a `coo` matrix, so users reading the example can copy/paste the code for a working example.