### PR TITLE
Parallel Column Iterators with Rayon

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,par-iter;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,par-iter;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon-par;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test
-        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
+        run: cargo test --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon-par;
   test-nalgebra-glm:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
-rayon  = [ "std", "dep:rayon" ]
+par-iter  = [ "std", "rayon" ]
 
 # Conversion
 convert-mint = [ "mint" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
-rayon  = [ "std", "dep:rayon" ]
+rayon-par  = [ "std", "rayon" ]
 
 # Conversion
 convert-mint = [ "mint" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
-rayon  = [ "dep:rayon" ]
+rayon  = [ "std", "dep:rayon" ]
 
 # Conversion
 convert-mint = [ "mint" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
+rayon  = [ "dep:rayon" ]
 
 # Conversion
 convert-mint = [ "mint" ]
@@ -101,7 +102,7 @@ glam020        = { package = "glam", version = "0.20", optional = true }
 glam021        = { package = "glam", version = "0.21", optional = true }
 glam022        = { package = "glam", version = "0.22", optional = true }
 cust_core      = { version = "0.1", optional = true }
-rayon = "1.5" # TODO make this feature gated
+rayon          = { version = "1.5", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ glam020        = { package = "glam", version = "0.20", optional = true }
 glam021        = { package = "glam", version = "0.21", optional = true }
 glam022        = { package = "glam", version = "0.22", optional = true }
 cust_core      = { version = "0.1", optional = true }
-rayon          = { version = "1.5", optional = true }
+rayon          = { version = "1.6", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
-rayon-par  = [ "std", "rayon" ]
+rayon  = [ "std", "dep:rayon" ]
 
 # Conversion
 convert-mint = [ "mint" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,5 @@ lto = true
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
 all-features = true
+# define the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libm    = [ "simba/libm" ]
 libm-force = [ "simba/libm_force" ]
 macros = [ "nalgebra-macros" ]
 cuda   = [ "cust_core", "simba/cuda" ]
-par-iter  = [ "std", "rayon" ]
+
 
 # Conversion
 convert-mint = [ "mint" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ glam020        = { package = "glam", version = "0.20", optional = true }
 glam021        = { package = "glam", version = "0.21", optional = true }
 glam022        = { package = "glam", version = "0.22", optional = true }
 cust_core      = { version = "0.1", optional = true }
-
+rayon = "1.5" # TODO make this feature gated
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -226,7 +226,7 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> Iterator for RowIter<'a
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> ExactSizeIterator
-for RowIter<'a, T, R, C, S>
+    for RowIter<'a, T, R, C, S>
 {
     #[inline]
     fn len(&self) -> usize {
@@ -257,7 +257,7 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> RowIterMut<'a, T, R,
 }
 
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Iterator
-for RowIterMut<'a, T, R, C, S>
+    for RowIterMut<'a, T, R, C, S>
 {
     type Item = MatrixViewMut<'a, T, U1, C, S::RStride, S::CStride>;
 
@@ -284,7 +284,7 @@ for RowIterMut<'a, T, R, C, S>
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ExactSizeIterator
-for RowIterMut<'a, T, R, C, S>
+    for RowIterMut<'a, T, R, C, S>
 {
     #[inline]
     fn len(&self) -> usize {
@@ -341,7 +341,7 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> Iterator for ColumnIter
 }
 
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> DoubleEndedIterator
-for ColumnIter<'a, T, R, C, S>
+    for ColumnIter<'a, T, R, C, S>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         debug_assert!(self.range.start <= self.range.end);
@@ -357,7 +357,7 @@ for ColumnIter<'a, T, R, C, S>
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> ExactSizeIterator
-for ColumnIter<'a, T, R, C, S>
+    for ColumnIter<'a, T, R, C, S>
 {
     #[inline]
     fn len(&self) -> usize {
@@ -366,9 +366,9 @@ for ColumnIter<'a, T, R, C, S>
 }
 
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Producer for ColumnIter<'a, T, R, Cols, S>
-    where
-        T: Send + Sync + Debug + PartialEq + Clone + 'static,
-        S: Sync,
+where
+    T: Send + Sync + Debug + PartialEq + Clone + 'static,
+    S: Sync,
 {
     type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
     type IntoIter = ColumnIter<'a, T, R, Cols, S>;
@@ -404,7 +404,11 @@ pub struct ColumnIterMut<'a, T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> {
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ColumnIterMut<'a, T, R, C, S> {
     pub(crate) fn new(mat: &'a mut Matrix<T, R, C, S>) -> Self {
         let range = 0..mat.ncols();
-        ColumnIterMut { mat, range, phantom: Default::default() }
+        ColumnIterMut {
+            mat,
+            range,
+            phantom: Default::default(),
+        }
     }
 
     fn ncols(&self) -> usize {
@@ -413,7 +417,7 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ColumnIterMut<'a, T,
 }
 
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Iterator
-for ColumnIterMut<'a, T, R, C, S>
+    for ColumnIterMut<'a, T, R, C, S>
 {
     type Item = MatrixViewMut<'a, T, R, U1, S::RStride, S::CStride>;
 
@@ -441,7 +445,7 @@ for ColumnIterMut<'a, T, R, C, S>
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ExactSizeIterator
-for ColumnIterMut<'a, T, R, C, S>
+    for ColumnIterMut<'a, T, R, C, S>
 {
     #[inline]
     fn len(&self) -> usize {
@@ -450,7 +454,7 @@ for ColumnIterMut<'a, T, R, C, S>
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> DoubleEndedIterator
-for ColumnIterMut<'a, T, R, C, S>
+    for ColumnIterMut<'a, T, R, C, S>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         debug_assert!(self.range.start <= self.range.end);
@@ -466,10 +470,10 @@ for ColumnIterMut<'a, T, R, C, S>
 }
 
 impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer
-for ColumnIterMut<'a, T, R, C, S>
-    where
-        T: Send + Sync + Debug + PartialEq + Clone,
-        S: Send + Sync,
+    for ColumnIterMut<'a, T, R, C, S>
+where
+    T: Send + Sync + Debug + PartialEq + Clone,
+    S: Send + Sync,
 {
     type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
     type IntoIter = ColumnIterMut<'a, T, R, C, S>;
@@ -498,4 +502,6 @@ for ColumnIterMut<'a, T, R, C, S>
 }
 
 unsafe impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Send
-for ColumnIterMut<'a, T, R, C, S> {}
+    for ColumnIterMut<'a, T, R, C, S>
+{
+}

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -447,7 +447,7 @@ mod parallel {
 
     impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Producer for ColumnIter<'a, T, R, Cols, S>
     where
-        T: Send + Sync + Debug + PartialEq + Clone + 'static,
+        T: Send + Sync +  Scalar,
         S: Sync,
     {
         type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
@@ -473,10 +473,10 @@ mod parallel {
         }
     }
 
-    impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer
+    impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer
         for ColumnIterMut<'a, T, R, C, S>
     where
-        T: Send + Sync + Debug + PartialEq + Clone,
+        T: Send + Sync + Scalar,
         S: Send + Sync,
     {
         type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -475,23 +475,26 @@ impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> DoubleEndedI
     }
 }
 
-impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer for ColumnIterMut<'a,T,R,C,S> 
-where T  : Send + Sync + Debug + PartialEq + Clone,
-      S: Send + Sync {
+impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer
+    for ColumnIterMut<'a, T, R, C, S>
+where
+    T: Send + Sync + Debug + PartialEq + Clone,
+    S: Send + Sync,
+{
     type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
-    type IntoIter = ColumnIterMut<'a,T,R,C,S>;
+    type IntoIter = ColumnIterMut<'a, T, R, C, S>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self 
+        self
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
         // the index is relative to the size of this current iterator
         // it will always start at zero
-        let pmat : * mut _ = self.mat; 
+        let pmat: *mut _ = self.mat;
 
         let left = Self {
-            mat: unsafe {&mut *pmat},
+            mat: unsafe { &mut *pmat },
             range: self.range.start..(self.range.start + index),
         };
 
@@ -501,10 +504,4 @@ where T  : Send + Sync + Debug + PartialEq + Clone,
         };
         (left, right)
     }
-}
-
-fn test_send<T: Send>(_: T) {}
-
-fn something(mut matrix: DMatrix<f32>) {
-    test_send(matrix.column_iter_mut());
 }

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -13,7 +13,6 @@ use std::mem;
 use crate::base::dimension::{Dim, U1};
 use crate::base::storage::{RawStorage, RawStorageMut};
 use crate::base::{Matrix, MatrixView, MatrixViewMut, Scalar};
-use crate::{DMatrix, DimMax};
 
 macro_rules! iterator {
     (struct $Name:ident for $Storage:ident.$ptr: ident -> $Ptr:ty, $Ref:ty, $SRef: ty) => {

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -397,7 +397,8 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Iterator
 
     #[inline]
     fn next(&'_ mut self) -> Option<Self::Item> {
-        if self.range.start < self.ncols() {
+        debug_assert!(self.range.start <= self.range.end);
+        if self.range.start < self.range.end {
             let res = unsafe { (*self.mat).column_mut(self.range.start) };
             self.range.start += 1;
             Some(res)

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -440,7 +440,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> DoubleEndedI
 }
 
 /// implementations for parallel iteration with rayon
-#[cfg(feature = "rayon")]
+#[cfg(feature = "par-iter")]
 mod parallel {
     use super::*;
     use rayon::iter::plumbing::Producer;

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -314,16 +314,17 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> ColumnIter<'a, T, R, C,
     }
 
     pub(crate) fn split_at(self, index: usize) -> (Self, Self) {
-        // SAFETY: it’s OK even if index > self.range.len() because
-        //         the iterations will yield None in this case.
+        // SAFETY: this makes sur the generated ranges are valid.
+        let split_pos = (self.range.start + index).min(self.range.end);
+
         let left_iter = ColumnIter {
             mat: self.mat,
-            range: self.range.start..(self.range.start + index),
+            range: self.range.start..split_pos,
         };
 
         let right_iter = ColumnIter {
             mat: self.mat,
-            range: (self.range.start + index)..self.range.end,
+            range: split_pos..self.range.end,
         };
 
         (left_iter, right_iter)
@@ -401,19 +402,18 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ColumnIterMut<'a, T,
     }
 
     pub(crate) fn split_at(self, index: usize) -> (Self, Self) {
-        // SAFETY: it’s OK even if index > self.range.len() because
-        //         the iterations will yield None in this case.
-        assert!(index <= self.range.len());
+        // SAFETY: this makes sur the generated ranges are valid.
+        let split_pos = (self.range.start + index).min(self.range.end);
 
         let left_iter = ColumnIterMut {
             mat: self.mat,
-            range: self.range.start..(self.range.start + index),
+            range: self.range.start..split_pos,
             phantom: Default::default(),
         };
 
         let right_iter = ColumnIterMut {
             mat: self.mat,
-            range: (self.range.start + index)..self.range.end,
+            range: split_pos..self.range.end,
             phantom: Default::default(),
         };
 

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -447,7 +447,7 @@ mod parallel {
 
     impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Producer for ColumnIter<'a, T, R, Cols, S>
     where
-        T: Send + Sync +  Scalar,
+        T: Send + Sync + Scalar,
         S: Sync,
     {
         type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -1,5 +1,9 @@
 //! Matrix iterators.
 
+// only enables the `doc_cfg` feature when
+// the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use core::fmt::Debug;
 use core::ops::Range;
 use std::iter::FusedIterator;
@@ -445,6 +449,8 @@ mod parallel {
     use super::*;
     use rayon::iter::plumbing::Producer;
 
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+    /// *only available if compiled with the feature `par-iter`*
     impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Producer for ColumnIter<'a, T, R, Cols, S>
     where
         T: Send + Sync + Scalar,
@@ -473,6 +479,8 @@ mod parallel {
         }
     }
 
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+    /// *only available if compiled with the feature `par-iter`*
     impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> Producer
         for ColumnIterMut<'a, T, R, C, S>
     where

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -100,7 +100,8 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// - [Find the min and max components (vector-specific methods) <span style="float:right;">`argmin`, `argmax`, `icamin`, `icamax`…</span>](#find-the-min-and-max-components-vector-specific-methods)
 ///
 /// #### Iteration, map, and fold
-/// - [Iteration on components, rows, and columns <span style="float:right;">`iter`, `column_iter`, `par_column_iter`…</span>](#iteration-on-components-rows-and-columns)
+/// - [Iteration on components, rows, and columns <span style="float:right;">`iter`, `column_iter`…</span>](#iteration-on-components-rows-and-columns)
+/// - [Parallel iterators using rayon <span style="float:right;">`par_column_iter`, `par_column_iter_mut`…</span>](#parallel-iterators-using-rayon)
 /// - [Elementwise mapping and folding <span style="float:right;">`map`, `fold`, `zip_map`…</span>](#elementwise-mapping-and-folding)
 /// - [Folding or columns and rows <span style="float:right;">`compress_rows`, `compress_columns`…</span>](#folding-on-columns-and-rows)
 ///

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -100,7 +100,7 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// - [Find the min and max components (vector-specific methods) <span style="float:right;">`argmin`, `argmax`, `icamin`, `icamax`…</span>](#find-the-min-and-max-components-vector-specific-methods)
 ///
 /// #### Iteration, map, and fold
-/// - [Iteration on components, rows, and columns <span style="float:right;">`iter`, `column_iter`…</span>](#iteration-on-components-rows-and-columns)
+/// - [Iteration on components, rows, and columns <span style="float:right;">`iter`, `column_iter`, `par_column_iter`…</span>](#iteration-on-components-rows-and-columns)
 /// - [Elementwise mapping and folding <span style="float:right;">`map`, `fold`, `zip_map`…</span>](#elementwise-mapping-and-folding)
 /// - [Folding or columns and rows <span style="float:right;">`compress_rows`, `compress_columns`…</span>](#folding-on-columns-and-rows)
 ///

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -42,6 +42,8 @@ mod min_max;
 /// Mechanisms for working with values that may not be initialized.
 pub mod uninit;
 
+pub mod par_iter;
+
 #[cfg(feature = "rkyv-serialize-no-std")]
 mod rkyv_wrappers;
 

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -42,6 +42,7 @@ mod min_max;
 /// Mechanisms for working with values that may not be initialized.
 pub mod uninit;
 
+#[cfg(feature = "rayon")]
 pub mod par_iter;
 
 #[cfg(feature = "rkyv-serialize-no-std")]

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -42,7 +42,7 @@ mod min_max;
 /// Mechanisms for working with values that may not be initialized.
 pub mod uninit;
 
-#[cfg(feature = "par-iter")]
+#[cfg(feature = "rayon")]
 pub mod par_iter;
 
 #[cfg(feature = "rkyv-serialize-no-std")]

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -42,7 +42,6 @@ mod min_max;
 /// Mechanisms for working with values that may not be initialized.
 pub mod uninit;
 
-
 #[cfg(feature = "par-iter")]
 pub mod par_iter;
 

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -42,7 +42,8 @@ mod min_max;
 /// Mechanisms for working with values that may not be initialized.
 pub mod uninit;
 
-#[cfg(feature = "rayon")]
+
+#[cfg(feature = "par-iter")]
 pub mod par_iter;
 
 #[cfg(feature = "rkyv-serialize-no-std")]

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -3,9 +3,7 @@
 
 use crate::{
     iter::{ColumnIter, ColumnIterMut},
-    Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, U1,
-};
-use core::fmt::Debug;
+    Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, U1, Scalar,};
 use rayon::{iter::plumbing::bridge, prelude::*};
 
 /// A rayon parallel iterator over the colums of a matrix
@@ -23,7 +21,7 @@ impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
-    T: Sync + Send + Clone + Debug + PartialEq + 'static,
+    T: Sync + Send + Scalar,
     S: Sync,
 {
     type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
@@ -43,7 +41,7 @@ where
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
-    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    T: Send + Sync + Scalar,
     S: Sync,
 {
     fn len(&self) -> usize {
@@ -65,7 +63,7 @@ where
 
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
-    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    T: Send + Sync + Scalar,
     S: Sync,
 {
     /// Iterate through the columns of the matrix in parallel using rayon.
@@ -102,7 +100,7 @@ where
     R: Dim,
     Cols: Dim,
     S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>,
-    T: Send + Sync + Debug + PartialEq + Clone + 'static,
+    T: Send + Sync + Scalar,
     S: Send + Sync,
 {
     type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
@@ -123,7 +121,7 @@ where
     R: Dim,
     Cols: Dim,
     S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>,
-    T: Send + Sync + Debug + PartialEq + Clone + 'static,
+    T: Send + Sync + Scalar,
     S: Send + Sync,
 {
     fn drive<C: rayon::iter::plumbing::Consumer<Self::Item>>(self, consumer: C) -> C::Result {
@@ -146,7 +144,7 @@ where
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
     Matrix<T, R, Cols, S>
 where
-    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    T: Send + Sync + Scalar,
     S: Sync,
 {
     /// Mutably iterate through the columns of this matrix in parallel using rayon

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -169,20 +169,19 @@ where
     /// Using parallel column iterators to calculate the sum of the maximum
     /// elements in each column:
     /// ```
-    /// use nalgebra::{dmatrix,DMatrix};
+    /// use nalgebra::{dmatrix, DMatrix};
     /// use rayon::prelude::*;
     ///
-    /// let matrix : DMatrix<f64> =
-    ///         nalgebra::dmatrix![1.,0.,5.;
-    ///                            2.,4.,1.;
-    ///                            3.,2.,2.;];
-    /// let sum_of_max :f64 =
-    ///         matrix
-    ///         .par_column_iter()
-    ///         .map(|col|col.max())
-    ///         .sum();
+    /// let matrix : DMatrix<f64> = dmatrix![1.0, 0.0, 5.0;
+    ///     2.0, 4.0, 1.0;
+    ///     3.0, 2.0, 2.0;
+    /// ];
+    /// let sum_of_max :f64 = matrix
+    ///     .par_column_iter()
+    ///     .map(|col| col.max())
+    ///     .sum();
     ///
-    /// assert_eq!(sum_of_max,3.+4.+5.);
+    /// assert_eq!(sum_of_max,3.0 + 4.0 + 5.0);
     ///                             
     /// ```
     ///
@@ -200,17 +199,16 @@ where
     /// Normalize each column of a matrix with respect to its own maximum value.
     ///
     /// ```
-    /// use nalgebra::{dmatrix,DMatrix};
+    /// use nalgebra::{dmatrix, DMatrix};
     /// use rayon::prelude::*;
     ///
-    /// let mut matrix : DMatrix<f64> =
-    ///                     dmatrix![2.,4.,6.;
-    ///                             1.,2.,3.];
+    /// let mut matrix : DMatrix<f64> = dmatrix![
+    ///     2.0, 4.0, 6.0;
+    ///     1.0, 2.0, 3.0;
+    /// ];
     /// matrix.par_column_iter_mut().for_each(|mut col| col /= col.max());
     ///
-    /// assert_eq!(matrix,
-    ///             dmatrix![1. ,1. , 1.;
-    ///                      0.5,0.5,0.5]);
+    /// assert_eq!(matrix, dmatrix![1.0, 1.0, 1.0; 0.5, 0.5, 0.5]);
     /// ```
     ///
     /// [`par_column_iter`]: crate::Matrix::par_column_iter

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -1,5 +1,9 @@
 //! Parallel iterators for matrices compatible with rayon.
 
+//only enables the `doc_cfg` feature when
+// the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use crate::{
     iter::{ColumnIter, ColumnIterMut},
     Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, Scalar, U1,
@@ -75,6 +79,32 @@ where
     S: Sync,
 {
     /// Iterate through the columns of the matrix in parallel using rayon.
+    /// This iterates over *immutable* references ot the columns of the matrix,
+    /// if *mutable* access to the columns is required, use [`par_column_iter_mut`]
+    /// instead.
+    /// 
+    /// **Example**
+    /// Using parallel column iterators to calculate the sum of the maximum
+    /// elements in each column:
+    /// ```
+    /// use nalgebra::{dmatrix,DMatrix};
+    /// use rayon::prelude::*;
+    ///
+    /// let matrix : DMatrix<f64> = 
+    ///         nalgebra::dmatrix![1.,0.,5.;
+    ///                            2.,4.,1.;
+    ///                            3.,2.,2.;];
+    /// let sum_of_max :f64 = 
+    ///         matrix
+    ///         .par_column_iter()
+    ///         .map(|col|col.max())
+    ///         .sum();
+    ///
+    /// assert_eq!(sum_of_max,3.+4.+5.);
+    ///                             
+    /// ```
+    ///
+    /// [`par_column_iter_mut`]: crate::Matrix::par_column_iter_mut
     pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
         ParColumnIter::new(self)
     }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -14,10 +14,10 @@ use rayon::{iter::plumbing::bridge, prelude::*};
 /// A rayon parallel iterator over the colums of a matrix. It is created
 /// using the [`par_column_iter`] method of [`Matrix`].
 ///
-/// *Only available if compiled with the feature `par-iter`.*
+/// *Only available if compiled with the feature `rayon`.*
 /// [`par_column_iter`]: crate::Matrix::par_column_iter
 /// [`Matrix`]: crate::Matrix
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
     mat: &'a Matrix<T, R, Cols, S>,
 }
@@ -29,7 +29,7 @@ impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -50,8 +50,8 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *Only available if compiled with the feature `par-iter`.*
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+/// *Only available if compiled with the feature `rayon`.*
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -75,9 +75,9 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 /// A rayon parallel iterator through the mutable columns of a matrix.
-/// *Only available if compiled with the feature `par-iter`.*
+/// *Only available if compiled with the feature `rayon`.*
 pub struct ParColumnIterMut<
     'a,
     T,
@@ -88,8 +88,8 @@ pub struct ParColumnIterMut<
     mat: &'a mut Matrix<T, R, Cols, S>,
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *only availabe if compiled with the feature `par-iter`*
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+/// *only availabe if compiled with the feature `rayon`*
 impl<'a, T, R, Cols, S> ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -102,8 +102,8 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *Only available if compiled with the feature `par-iter`*
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+/// *Only available if compiled with the feature `rayon`*
 impl<'a, T, R, Cols, S> ParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -125,8 +125,8 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *Only available if compiled with the feature `par-iter`*
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+/// *Only available if compiled with the feature `rayon`*
 impl<'a, T, R, Cols, S> IndexedParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -152,9 +152,9 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 /// # Parallel iterators using `rayon`
-/// *Only available if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `rayon`*
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
@@ -225,8 +225,8 @@ where
 /// rayon trait part of the public interface of the `ColumnIter`.
 struct ColumnProducer<'a, T, R: Dim, C: Dim, S: RawStorage<T, R, C>>(ColumnIter<'a, T, R, C, S>);
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *only available if compiled with the feature `par-iter`*
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+/// *only available if compiled with the feature `rayon`*
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Producer
     for ColumnProducer<'a, T, R, Cols, S>
 where

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -1,6 +1,6 @@
 //! Parallel iterators for matrices compatible with rayon.
 
-//only enables the `doc_cfg` feature when
+// only enables the `doc_cfg` feature when
 // the `docsrs` configuration attribute is defined
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -12,7 +12,8 @@ use rayon::{iter::plumbing::bridge, prelude::*};
 
 /// A rayon parallel iterator over the colums of a matrix. It is created
 /// using the [`par_column_iter`] method of [`Matrix`].
-///
+/// 
+/// *only availabe if compiled with the feature `par-iter`*
 /// [`par_column_iter`]: crate::Matrix::par_column_iter
 /// [`Matrix`]: crate::Matrix
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
@@ -49,6 +50,7 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+/// *only availabe if compiled with the feature `par-iter`*
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -74,6 +76,7 @@ where
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 /// A rayon parallel iterator through the mutable columns of a matrix
+/// *only availabe if compiled with the feature `par-iter`*
 pub struct ParColumnIterMut<
     'a,
     T,
@@ -85,6 +88,7 @@ pub struct ParColumnIterMut<
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+/// *only availabe if compiled with the feature `par-iter`*
 impl<'a, T, R, Cols, S> ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -98,6 +102,7 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+/// *only availabe if compiled with the feature `par-iter`*
 impl<'a, T, R, Cols, S> ParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -120,6 +125,7 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
+/// *only availabe if compiled with the feature `par-iter`*
 impl<'a, T, R, Cols, S> IndexedParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -12,7 +12,7 @@ use rayon::{iter::plumbing::bridge, prelude::*};
 
 /// A rayon parallel iterator over the colums of a matrix. It is created
 /// using the [`par_column_iter`] method of [`Matrix`].
-/// 
+///
 /// *only availabe if compiled with the feature `par-iter`*
 /// [`par_column_iter`]: crate::Matrix::par_column_iter
 /// [`Matrix`]: crate::Matrix

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -1,0 +1,169 @@
+//! this module implements parallelators to make matrices work with
+//! the rayon crate seamlessly
+
+use core::{
+    fmt::Debug,
+    iter::{Skip, Take},
+    marker::PhantomData,
+    ops::Range,
+};
+use std::os::unix::prelude::AsRawFd;
+
+use rayon::{
+    iter::plumbing::{bridge, Producer},
+    prelude::*,
+};
+
+use crate::{
+    iter::{ColumnIter, ColumnIterMut}, Const, DMatrix, Dim, Dynamic, Matrix, MatrixSlice, MatrixSliceMut,
+    RawStorage, RawStorageMut, U1, SliceStorageMut,
+};
+
+use super::conversion;
+
+/// a rayon parallel iterator over the columns of a matrix
+pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
+    mat: &'a Matrix<T, R, Cols, S>,
+}
+
+impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R, Cols, S> {
+    fn new(matrix: &'a Matrix<T, R, Cols, S>) -> Self {
+        Self { mat: matrix }
+    }
+}
+
+impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParallelIterator
+    for ParColumnIter<'a, T, R, Cols, S>
+where
+    T: Sync + Send + Clone + Debug + PartialEq + 'static,
+    S: Sync,
+{
+    type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
+
+    fn drive_unindexed<Consumer>(self, consumer: Consumer) -> Consumer::Result
+    where
+        Consumer: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.mat.ncols())
+    }
+}
+
+impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
+    for ParColumnIter<'a, T, R, Cols, S>
+where
+    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    S: Sync,
+{
+    fn len(&self) -> usize {
+        self.mat.ncols()
+    }
+
+    fn drive<C: rayon::iter::plumbing::Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn with_producer<CB: rayon::iter::plumbing::ProducerCallback<Self::Item>>(
+        self,
+        callback: CB,
+    ) -> CB::Output {
+        let producer = ColumnIter::new(self.mat);
+        callback.callback(producer)
+    }
+}
+
+impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
+where
+    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    S: Sync,
+{
+    fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
+        ParColumnIter::new(self)
+    }
+}
+
+/// TODO
+pub struct ParColumnIterMut<'a,T,R:Dim ,Cols:Dim, S:RawStorage<T,R,Cols>+RawStorageMut<T,R,Cols>> {
+    mat : &'a mut Matrix<T,R,Cols,S>,
+}
+
+impl<'a,T,R,Cols,S> ParColumnIterMut<'a,T,R,Cols,S> 
+where R: Dim, Cols : Dim, S:RawStorage<T,R,Cols> + RawStorageMut<T,R,Cols> {
+    /// TODO
+    pub fn new(mat : &'a mut Matrix<T,R,Cols,S>) -> Self {
+        Self {
+            mat,
+        }
+    }
+}
+
+impl<'a,T,R,Cols,S> ParallelIterator for ParColumnIterMut<'a,T,R,Cols,S> 
+where R: Dim, Cols : Dim, S:RawStorage<T,R,Cols> + RawStorageMut<T,R,Cols>, 
+T : Send + Sync + Debug + PartialEq + Clone + 'static, 
+S : Send + Sync {
+    type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where
+            C: rayon::iter::plumbing::UnindexedConsumer<Self::Item> {
+                bridge(self,consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.mat.ncols())
+    }
+}
+
+
+impl<'a,T,R,Cols,S> IndexedParallelIterator for ParColumnIterMut<'a,T,R,Cols,S> 
+where R: Dim, Cols : Dim, S:RawStorage<T,R,Cols> + RawStorageMut<T,R,Cols>, 
+T : Send + Sync + Debug + PartialEq + Clone + 'static, 
+S : Send + Sync {
+    fn drive<C: rayon::iter::plumbing::Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self,consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.mat.ncols()
+    }
+
+    fn with_producer<CB: rayon::iter::plumbing::ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output {
+        let producer = ColumnIterMut::new(self.mat);
+        callback.callback(producer)
+    }
+}
+
+impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T,R,Cols>> Matrix<T, R, Cols, S>
+where
+    T: Send + Sync + Clone + Debug + PartialEq + 'static,
+    S: Sync,
+{
+    fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
+        ParColumnIterMut::new(self)
+    }
+}
+
+
+#[test]
+fn parallel_iterator() {
+    let matrix = DMatrix::<f32>::zeros(3, 4);
+    let res: Vec<_> = matrix.par_column_iter().map(|col| col.len()).collect();
+    assert_eq!(res, vec![3, 3, 3, 3]);
+}
+
+#[test]
+fn test_mut_parallel_iter() {
+    let mut matrix = DMatrix::<f32>::zeros(4, 3);
+    matrix.par_column_iter_mut().enumerate().for_each(|(idx,mut col)| col[idx]=1f32);
+    let identity = DMatrix::<f32>::identity(4, 3);
+    assert_eq!(matrix,identity);
+}
+
+
+fn try_some_stuff() {
+    let mut mat = DMatrix::<f32>::zeros(3, 4);
+    let _left = mat.columns_mut(0, 1);
+    let _right = mat.columns_mut(1, 3);
+}

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -15,7 +15,7 @@ use rayon::{iter::plumbing::bridge, prelude::*};
 ///
 /// [`par_column_iter`]: crate::Matrix::par_column_iter
 /// [`Matrix`]: crate::Matrix
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
     mat: &'a Matrix<T, R, Cols, S>,
 }
@@ -27,7 +27,7 @@ impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -48,7 +48,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -72,7 +72,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
@@ -83,7 +83,7 @@ where
     /// if *mutable* access to the columns is required, use [`par_column_iter_mut`]
     /// instead.
     /// 
-    /// **Example**
+    /// # Example
     /// Using parallel column iterators to calculate the sum of the maximum
     /// elements in each column:
     /// ```
@@ -110,7 +110,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 /// A rayon parallel iterator through the mutable columns of a matrix
 pub struct ParColumnIterMut<
     'a,
@@ -122,7 +122,7 @@ pub struct ParColumnIterMut<
     mat: &'a mut Matrix<T, R, Cols, S>,
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<'a, T, R, Cols, S> ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -135,7 +135,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<'a, T, R, Cols, S> ParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -157,7 +157,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<'a, T, R, Cols, S> IndexedParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -183,14 +183,36 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
     Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
     S: Sync,
 {
-    /// Mutably iterate through the columns of this matrix in parallel using rayon
+    /// Mutably iterate through the columns of this matrix in parallel using rayon.
+    /// Allows mutable access to the columns in parallel using mutable references.
+    /// If mutable access to the columns is not required rather use [`par_column_iter`]
+    /// instead.
+    /// 
+    /// # Example 
+    /// Normalize each column of a matrix with respect to its own maximum value.
+    /// 
+    /// ```
+    /// use nalgebra::{dmatrix,DMatrix};
+    /// use rayon::prelude::*;
+    ///
+    /// let mut matrix : DMatrix<f64> =
+    ///                     dmatrix![2.,4.,6.;
+    ///                             1.,2.,3.];
+    /// matrix.par_column_iter_mut().for_each(|mut col| col /= col.max());
+    ///
+    /// assert_eq!(matrix,
+    ///             dmatrix![1. ,1. , 1.;
+    ///                      0.5,0.5,0.5]);
+    /// ```
+    ///
+    /// [`par_column_iter`]: crate::Matrix::par_column_iter
     pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
         ParColumnIterMut::new(self)
     }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -63,7 +63,7 @@ where
     }
 }
 
-impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
+impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,
     S: Sync,
@@ -143,7 +143,7 @@ where
     }
 }
 
-impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
+impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
     Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     iter::{ColumnIter, ColumnIterMut},
-    Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, Scalar, U1,
+    Dim, Matrix, MatrixView, MatrixViewMut, RawStorage, RawStorageMut, Scalar, U1,
 };
 use rayon::iter::plumbing::Producer;
 use rayon::{iter::plumbing::bridge, prelude::*};
@@ -36,7 +36,7 @@ where
     T: Sync + Send + Scalar,
     S: Sync,
 {
-    type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
+    type Item = MatrixView<'a, T, R, U1, S::RStride, S::CStride>;
 
     fn drive_unindexed<Consumer>(self, consumer: Consumer) -> Consumer::Result
     where
@@ -112,7 +112,7 @@ where
     T: Send + Sync + Scalar,
     S: Send + Sync,
 {
-    type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
+    type Item = MatrixViewMut<'a, T, R, U1, S::RStride, S::CStride>;
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where
         C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
@@ -234,7 +234,7 @@ where
     T: Send + Sync + Scalar,
     S: Sync,
 {
-    type Item = MatrixSlice<'a, T, R, U1, S::RStride, S::CStride>;
+    type Item = MatrixView<'a, T, R, U1, S::RStride, S::CStride>;
     type IntoIter = ColumnIter<'a, T, R, Cols, S>;
 
     #[inline]
@@ -271,7 +271,7 @@ where
     T: Send + Sync + Scalar,
     S: Send + Sync,
 {
-    type Item = MatrixSliceMut<'a, T, R, U1, S::RStride, S::CStride>;
+    type Item = MatrixViewMut<'a, T, R, U1, S::RStride, S::CStride>;
     type IntoIter = ColumnIterMut<'a, T, R, C, S>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -3,23 +3,17 @@
 
 use core::{
     fmt::Debug,
-    iter::{Skip, Take},
-    marker::PhantomData,
-    ops::Range,
 };
-use std::os::unix::prelude::AsRawFd;
 
 use rayon::{
-    iter::plumbing::{bridge, Producer},
+    iter::plumbing::{bridge},
     prelude::*,
 };
 
 use crate::{
-    iter::{ColumnIter, ColumnIterMut}, Const, DMatrix, Dim, Dynamic, Matrix, MatrixSlice, MatrixSliceMut,
-    RawStorage, RawStorageMut, U1, SliceStorageMut,
+    iter::{ColumnIter, ColumnIterMut},  DMatrix, Dim,  Matrix, MatrixSlice, MatrixSliceMut,
+    RawStorage, RawStorageMut, U1,
 };
-
-use super::conversion;
 
 /// a rayon parallel iterator over the columns of a matrix
 pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
@@ -145,21 +139,4 @@ where
     pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
         ParColumnIterMut::new(self)
     }
-}
-
-
-
-#[test]
-fn test_mut_parallel_iter() {
-    let mut matrix = DMatrix::<f32>::zeros(4, 3);
-    matrix.par_column_iter_mut().enumerate().for_each(|(idx,mut col)| col[idx]=1f32);
-    let identity = DMatrix::<f32>::identity(4, 3);
-    assert_eq!(matrix,identity);
-}
-
-
-fn try_some_stuff() {
-    let mut mat = DMatrix::<f32>::zeros(3, 4);
-    let _left = mat.columns_mut(0, 1);
-    let _right = mat.columns_mut(1, 3);
 }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -73,44 +73,6 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
-where
-    T: Send + Sync + Scalar,
-    S: Sync,
-{
-    /// Iterate through the columns of the matrix in parallel using rayon.
-    /// This iterates over *immutable* references ot the columns of the matrix,
-    /// if *mutable* access to the columns is required, use [`par_column_iter_mut`]
-    /// instead.
-    ///
-    /// # Example
-    /// Using parallel column iterators to calculate the sum of the maximum
-    /// elements in each column:
-    /// ```
-    /// use nalgebra::{dmatrix,DMatrix};
-    /// use rayon::prelude::*;
-    ///
-    /// let matrix : DMatrix<f64> =
-    ///         nalgebra::dmatrix![1.,0.,5.;
-    ///                            2.,4.,1.;
-    ///                            3.,2.,2.;];
-    /// let sum_of_max :f64 =
-    ///         matrix
-    ///         .par_column_iter()
-    ///         .map(|col|col.max())
-    ///         .sum();
-    ///
-    /// assert_eq!(sum_of_max,3.+4.+5.);
-    ///                             
-    /// ```
-    ///
-    /// [`par_column_iter_mut`]: crate::Matrix::par_column_iter_mut
-    pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
-        ParColumnIter::new(self)
-    }
-}
-
-#[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 /// A rayon parallel iterator through the mutable columns of a matrix
 pub struct ParColumnIterMut<
     'a,
@@ -184,12 +146,44 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
+/// # Parallel iterators using `rayon`
+/// *Only availabe if compiled with the feature `par-iter`*
+impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>>
     Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
     S: Sync,
 {
+    /// Iterate through the columns of the matrix in parallel using rayon.
+    /// This iterates over *immutable* references ot the columns of the matrix,
+    /// if *mutable* access to the columns is required, use [`par_column_iter_mut`]
+    /// instead.
+    ///
+    /// # Example
+    /// Using parallel column iterators to calculate the sum of the maximum
+    /// elements in each column:
+    /// ```
+    /// use nalgebra::{dmatrix,DMatrix};
+    /// use rayon::prelude::*;
+    ///
+    /// let matrix : DMatrix<f64> =
+    ///         nalgebra::dmatrix![1.,0.,5.;
+    ///                            2.,4.,1.;
+    ///                            3.,2.,2.;];
+    /// let sum_of_max :f64 =
+    ///         matrix
+    ///         .par_column_iter()
+    ///         .map(|col|col.max())
+    ///         .sum();
+    ///
+    /// assert_eq!(sum_of_max,3.+4.+5.);
+    ///                             
+    /// ```
+    ///
+    /// [`par_column_iter_mut`]: crate::Matrix::par_column_iter_mut
+    pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
+        ParColumnIter::new(self)
+    }
     /// Mutably iterate through the columns of this matrix in parallel using rayon.
     /// Allows mutable access to the columns in parallel using mutable references.
     /// If mutable access to the columns is not required rather use [`par_column_iter`]
@@ -213,7 +207,8 @@ where
     /// ```
     ///
     /// [`par_column_iter`]: crate::Matrix::par_column_iter
-    pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
+    pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> 
+    where S: RawStorageMut<T, R, Cols>{
         ParColumnIterMut::new(self)
     }
 }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -1,26 +1,23 @@
 //! this module implements parallelators to make matrices work with
 //! the rayon crate seamlessly
 
-use core::{
-    fmt::Debug,
-};
-
+use core::fmt::Debug;
 use rayon::{
     iter::plumbing::{bridge},
     prelude::*,
 };
-
 use crate::{
-    iter::{ColumnIter, ColumnIterMut},  DMatrix, Dim,  Matrix, MatrixSlice, MatrixSliceMut,
+    iter::{ColumnIter, ColumnIterMut}, Dim,  Matrix, MatrixSlice, MatrixSliceMut,
     RawStorage, RawStorageMut, U1,
 };
 
-/// a rayon parallel iterator over the columns of a matrix
+/// A rayon parallel iterator over the colums of a matrix
 pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
     mat: &'a Matrix<T, R, Cols, S>,
 }
 
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R, Cols, S> {
+    /// create a new parallel iterator for the given matrix
     fn new(matrix: &'a Matrix<T, R, Cols, S>) -> Self {
         Self { mat: matrix }
     }
@@ -74,21 +71,21 @@ where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,
     S: Sync,
 {
-    /// TODO
+    /// Iterate through the columns of the matrix in parallel using rayon.
     pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
         ParColumnIter::new(self)
     }
 }
 
-/// TODO
+/// A rayon parallel iterator through the mutable columns of a matrix
 pub struct ParColumnIterMut<'a,T,R:Dim ,Cols:Dim, S:RawStorage<T,R,Cols>+RawStorageMut<T,R,Cols>> {
     mat : &'a mut Matrix<T,R,Cols,S>,
 }
 
 impl<'a,T,R,Cols,S> ParColumnIterMut<'a,T,R,Cols,S> 
 where R: Dim, Cols : Dim, S:RawStorage<T,R,Cols> + RawStorageMut<T,R,Cols> {
-    /// TODO
-    pub fn new(mat : &'a mut Matrix<T,R,Cols,S>) -> Self {
+    /// create a new parallel iterator for the given matrix
+    fn new(mat : &'a mut Matrix<T,R,Cols,S>) -> Self {
         Self {
             mat,
         }
@@ -135,7 +132,7 @@ where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,
     S: Sync,
 {
-    /// TODO
+    /// Mutably iterate through the columns of this matrix in parallel using rayon
     pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
         ParColumnIterMut::new(self)
     }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -148,8 +148,7 @@ where
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 /// # Parallel iterators using `rayon`
 /// *Only availabe if compiled with the feature `par-iter`*
-impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>>
-    Matrix<T, R, Cols, S>
+impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
     S: Sync,
@@ -207,8 +206,10 @@ where
     /// ```
     ///
     /// [`par_column_iter`]: crate::Matrix::par_column_iter
-    pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> 
-    where S: RawStorageMut<T, R, Cols>{
+    pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S>
+    where
+        S: RawStorageMut<T, R, Cols>,
+    {
         ParColumnIterMut::new(self)
     }
 }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -82,7 +82,7 @@ where
     /// This iterates over *immutable* references ot the columns of the matrix,
     /// if *mutable* access to the columns is required, use [`par_column_iter_mut`]
     /// instead.
-    /// 
+    ///
     /// # Example
     /// Using parallel column iterators to calculate the sum of the maximum
     /// elements in each column:
@@ -90,11 +90,11 @@ where
     /// use nalgebra::{dmatrix,DMatrix};
     /// use rayon::prelude::*;
     ///
-    /// let matrix : DMatrix<f64> = 
+    /// let matrix : DMatrix<f64> =
     ///         nalgebra::dmatrix![1.,0.,5.;
     ///                            2.,4.,1.;
     ///                            3.,2.,2.;];
-    /// let sum_of_max :f64 = 
+    /// let sum_of_max :f64 =
     ///         matrix
     ///         .par_column_iter()
     ///         .map(|col|col.max())
@@ -194,10 +194,10 @@ where
     /// Allows mutable access to the columns in parallel using mutable references.
     /// If mutable access to the columns is not required rather use [`par_column_iter`]
     /// instead.
-    /// 
-    /// # Example 
+    ///
+    /// # Example
     /// Normalize each column of a matrix with respect to its own maximum value.
-    /// 
+    ///
     /// ```
     /// use nalgebra::{dmatrix,DMatrix};
     /// use rayon::prelude::*;

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -14,7 +14,7 @@ use rayon::{iter::plumbing::bridge, prelude::*};
 /// A rayon parallel iterator over the colums of a matrix. It is created
 /// using the [`par_column_iter`] method of [`Matrix`].
 ///
-/// *only availabe if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `par-iter`.*
 /// [`par_column_iter`]: crate::Matrix::par_column_iter
 /// [`Matrix`]: crate::Matrix
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
@@ -23,7 +23,7 @@ pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
 }
 
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R, Cols, S> {
-    /// create a new parallel iterator for the given matrix
+    /// Create a new parallel iterator for the given matrix.
     fn new(matrix: &'a Matrix<T, R, Cols, S>) -> Self {
         Self { mat: matrix }
     }
@@ -51,7 +51,7 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *only availabe if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `par-iter`.*
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -76,8 +76,8 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// A rayon parallel iterator through the mutable columns of a matrix
-/// *only availabe if compiled with the feature `par-iter`*
+/// A rayon parallel iterator through the mutable columns of a matrix.
+/// *Only available if compiled with the feature `par-iter`.*
 pub struct ParColumnIterMut<
     'a,
     T,
@@ -96,14 +96,14 @@ where
     Cols: Dim,
     S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>,
 {
-    /// create a new parallel iterator for the given matrix
+    /// create a new parallel iterator for the given matrix.
     fn new(mat: &'a mut Matrix<T, R, Cols, S>) -> Self {
         Self { mat }
     }
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *only availabe if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `par-iter`*
 impl<'a, T, R, Cols, S> ParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -126,7 +126,7 @@ where
 }
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
-/// *only availabe if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `par-iter`*
 impl<'a, T, R, Cols, S> IndexedParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -154,7 +154,7 @@ where
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
 /// # Parallel iterators using `rayon`
-/// *Only availabe if compiled with the feature `par-iter`*
+/// *Only available if compiled with the feature `par-iter`*
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
@@ -190,6 +190,7 @@ where
     pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
         ParColumnIter::new(self)
     }
+
     /// Mutably iterate through the columns of this matrix in parallel using rayon.
     /// Allows mutable access to the columns in parallel using mutable references.
     /// If mutable access to the columns is not required rather use [`par_column_iter`]
@@ -221,9 +222,9 @@ where
     }
 }
 
-/// a private helper newtype that wraps the `ColumnIter` and implements
+/// A private helper newtype that wraps the `ColumnIter` and implements
 /// the rayon `Producer` trait. It's just here so we don't have to make the
-/// rayon trait part of the public interface of the `ColumnIter`
+/// rayon trait part of the public interface of the `ColumnIter`.
 struct ColumnProducer<'a, T, R: Dim, C: Dim, S: RawStorage<T, R, C>>(ColumnIter<'a, T, R, C, S>);
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "par-iter")))]
@@ -238,24 +239,16 @@ where
     type IntoIter = ColumnIter<'a, T, R, Cols, S>;
 
     #[inline]
-    fn split_at(self, index: usize) -> (Self, Self) {
-        // the index is relative to the size of this current iterator
-        // it will always start at zero so it serves as an offset
-        let left_iter = ColumnIter {
-            mat: self.0.mat,
-            range: self.0.range.start..(self.0.range.start + index),
-        };
-
-        let right_iter = ColumnIter {
-            mat: self.0.mat,
-            range: (self.0.range.start + index)..self.0.range.end,
-        };
-        (Self(left_iter), Self(right_iter))
+    fn into_iter(self) -> Self::IntoIter {
+        self.0
     }
 
     #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0
+    fn split_at(self, index: usize) -> (Self, Self) {
+        // The index is relative to the size of this current iterator.
+        // It will always start at zero so it serves as an offset.
+        let (left_iter, right_iter) = self.0.split_at(index);
+        (Self(left_iter), Self(right_iter))
     }
 }
 
@@ -279,20 +272,9 @@ where
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        // the index is relative to the size of this current iterator
-        // it will always start at zero so it serves as an offset
-
-        let left_iter = ColumnIterMut {
-            mat: self.0.mat,
-            range: self.0.range.start..(self.0.range.start + index),
-            phantom: Default::default(),
-        };
-
-        let right_iter = ColumnIterMut {
-            mat: self.0.mat,
-            range: (self.0.range.start + index)..self.0.range.end,
-            phantom: Default::default(),
-        };
+        // The index is relative to the size of this current iterator
+        // it will always start at zero so it serves as an offset.
+        let (left_iter, right_iter) = self.0.split_at(index);
         (Self(left_iter), Self(right_iter))
     }
 }

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -6,7 +6,12 @@ use crate::{
 };
 use rayon::{iter::plumbing::bridge, prelude::*};
 
-/// A rayon parallel iterator over the colums of a matrix
+/// A rayon parallel iterator over the colums of a matrix. It is created
+/// using the [`par_column_iter`] method of [`Matrix`].
+///
+/// [`par_column_iter`]: crate::Matrix::par_column_iter
+/// [`Matrix`]: crate::Matrix
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub struct ParColumnIter<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> {
     mat: &'a Matrix<T, R, Cols, S>,
 }
@@ -18,6 +23,7 @@ impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParColumnIter<'a, T, R
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> ParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -38,6 +44,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> IndexedParallelIterator
     for ParColumnIter<'a, T, R, Cols, S>
 where
@@ -61,6 +68,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols>> Matrix<T, R, Cols, S>
 where
     T: Send + Sync + Scalar,
@@ -72,6 +80,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 /// A rayon parallel iterator through the mutable columns of a matrix
 pub struct ParColumnIterMut<
     'a,
@@ -83,6 +92,7 @@ pub struct ParColumnIterMut<
     mat: &'a mut Matrix<T, R, Cols, S>,
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R, Cols, S> ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -95,6 +105,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R, Cols, S> ParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -116,6 +127,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<'a, T, R, Cols, S> IndexedParallelIterator for ParColumnIterMut<'a, T, R, Cols, S>
 where
     R: Dim,
@@ -141,6 +153,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 impl<T, R: Dim, Cols: Dim, S: RawStorage<T, R, Cols> + RawStorageMut<T, R, Cols>>
     Matrix<T, R, Cols, S>
 where

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -80,7 +80,8 @@ where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,
     S: Sync,
 {
-    fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
+    /// TODO
+    pub fn par_column_iter(&self) -> ParColumnIter<'_, T, R, Cols, S> {
         ParColumnIter::new(self)
     }
 }
@@ -140,18 +141,13 @@ where
     T: Send + Sync + Clone + Debug + PartialEq + 'static,
     S: Sync,
 {
-    fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
+    /// TODO
+    pub fn par_column_iter_mut(&mut self) -> ParColumnIterMut<'_, T, R, Cols, S> {
         ParColumnIterMut::new(self)
     }
 }
 
 
-#[test]
-fn parallel_iterator() {
-    let matrix = DMatrix::<f32>::zeros(3, 4);
-    let res: Vec<_> = matrix.par_column_iter().map(|col| col.len()).collect();
-    assert_eq!(res, vec![3, 3, 3, 3]);
-}
 
 #[test]
 fn test_mut_parallel_iter() {

--- a/src/base/par_iter.rs
+++ b/src/base/par_iter.rs
@@ -1,9 +1,9 @@
-//! this module implements parallelators to make matrices work with
-//! the rayon crate seamlessly
+//! Parallel iterators for matrices compatible with rayon.
 
 use crate::{
     iter::{ColumnIter, ColumnIterMut},
-    Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, U1, Scalar,};
+    Dim, Matrix, MatrixSlice, MatrixSliceMut, RawStorage, RawStorageMut, Scalar, U1,
+};
 use rayon::{iter::plumbing::bridge, prelude::*};
 
 /// A rayon parallel iterator over the colums of a matrix

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1141,111 +1141,116 @@ fn omatrix_to_string() {
 fn column_iteration() {
     // dynamic matrix
     let dmat = nalgebra::dmatrix![
-        13,14,15;
-        23,24,25;
-        33,34,35;
-        ];
+    13,14,15;
+    23,24,25;
+    33,34,35;
+    ];
     let mut col_iter = dmat.column_iter();
-    assert_eq!(col_iter.next(),Some(dmat.column(0)));
-    assert_eq!(col_iter.next(),Some(dmat.column(1)));
-    assert_eq!(col_iter.next(),Some(dmat.column(2)));
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(dmat.column(0)));
+    assert_eq!(col_iter.next(), Some(dmat.column(1)));
+    assert_eq!(col_iter.next(), Some(dmat.column(2)));
+    assert_eq!(col_iter.next(), None);
 
     // statically sized matrix
     let smat: nalgebra::SMatrix<f64, 2, 2> = nalgebra::matrix![1.0, 2.0; 3.0, 4.0];
     let mut col_iter = smat.column_iter();
-    assert_eq!(col_iter.next(),Some(smat.column(0)));
-    assert_eq!(col_iter.next(),Some(smat.column(1)));
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(smat.column(0)));
+    assert_eq!(col_iter.next(), Some(smat.column(1)));
+    assert_eq!(col_iter.next(), None);
 }
 
 #[test]
 fn column_iteration_mut() {
     let mut dmat = nalgebra::dmatrix![
-        13,14,15;
-        23,24,25;
-        33,34,35;
-        ];
+    13,14,15;
+    23,24,25;
+    33,34,35;
+    ];
     let mut cloned = dmat.clone();
     let mut col_iter = dmat.column_iter_mut();
-    assert_eq!(col_iter.next(),Some(cloned.column_mut(0)));
-    assert_eq!(col_iter.next(),Some(cloned.column_mut(1)));
-    assert_eq!(col_iter.next(),Some(cloned.column_mut(2)));
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(cloned.column_mut(0)));
+    assert_eq!(col_iter.next(), Some(cloned.column_mut(1)));
+    assert_eq!(col_iter.next(), Some(cloned.column_mut(2)));
+    assert_eq!(col_iter.next(), None);
 
     // statically sized matrix
     let mut smat: nalgebra::SMatrix<f64, 2, 2> = nalgebra::matrix![1.0, 2.0; 3.0, 4.0];
     let mut cloned = smat.clone();
     let mut col_iter = smat.column_iter_mut();
-    assert_eq!(col_iter.next(),Some(cloned.column_mut(0)));
-    assert_eq!(col_iter.next(),Some(cloned.column_mut(1)));
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(cloned.column_mut(0)));
+    assert_eq!(col_iter.next(), Some(cloned.column_mut(1)));
+    assert_eq!(col_iter.next(), None);
 }
 
 #[test]
 fn column_iteration_double_ended() {
     let dmat = nalgebra::dmatrix![
-        13,14,15,16,17;
-        23,24,25,26,27;
-        33,34,35,36,37;
-        ];
+    13,14,15,16,17;
+    23,24,25,26,27;
+    33,34,35,36,37;
+    ];
     let mut col_iter = dmat.column_iter();
-    assert_eq!(col_iter.next(),Some(dmat.column(0)));
-    assert_eq!(col_iter.next(),Some(dmat.column(1)));
-    assert_eq!(col_iter.next_back(),Some(dmat.column(4)));
-    assert_eq!(col_iter.next_back(),Some(dmat.column(3)));
-    assert_eq!(col_iter.next(),Some(dmat.column(2)));
-    assert_eq!(col_iter.next_back(),None);
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(dmat.column(0)));
+    assert_eq!(col_iter.next(), Some(dmat.column(1)));
+    assert_eq!(col_iter.next_back(), Some(dmat.column(4)));
+    assert_eq!(col_iter.next_back(), Some(dmat.column(3)));
+    assert_eq!(col_iter.next(), Some(dmat.column(2)));
+    assert_eq!(col_iter.next_back(), None);
+    assert_eq!(col_iter.next(), None);
 }
 
 #[test]
 fn parallel_column_iteration() {
+    use nalgebra::dmatrix;
     use rayon::prelude::*;
-    use nalgebra::{dmatrix,dvector};
-    let dmat : DMatrix<f64> = dmatrix![
-        13.,14.;
-        23.,24.;
-        33.,34.;
-        ];
+    let dmat: DMatrix<f64> = dmatrix![
+    13.,14.;
+    23.,24.;
+    33.,34.;
+    ];
     let cloned = dmat.clone();
     // test that correct columns are iterated over
-    dmat.par_column_iter().enumerate().for_each(|(idx,col)| {
-        assert_eq!(col,cloned.column(idx)); 
+    dmat.par_column_iter().enumerate().for_each(|(idx, col)| {
+        assert_eq!(col, cloned.column(idx));
     });
     // test that a more complex expression produces the same
     // result as the serial equivalent
-    let par_result : f64 = dmat.par_column_iter().map(|col| col.norm()).sum();
-    let ser_result : f64= dmat.column_iter().map(|col| col.norm()).sum();
-    assert_eq!(par_result,ser_result);
+    let par_result: f64 = dmat.par_column_iter().map(|col| col.norm()).sum();
+    let ser_result: f64 = dmat.column_iter().map(|col| col.norm()).sum();
+    assert_eq!(par_result, ser_result);
 }
-
 
 #[test]
 fn colum_iteration_mut_double_ended() {
     let dmat = nalgebra::dmatrix![
-        13,14,15,16,17;
-        23,24,25,26,27;
-        33,34,35,36,37;
-        ];
+    13,14,15,16,17;
+    23,24,25,26,27;
+    33,34,35,36,37;
+    ];
     let cloned = dmat.clone();
     let mut col_iter = dmat.column_iter();
-    assert_eq!(col_iter.next(),Some(cloned.column(0)));
-    assert_eq!(col_iter.next(),Some(cloned.column(1)));
-    assert_eq!(col_iter.next_back(),Some(cloned.column(4)));
-    assert_eq!(col_iter.next_back(),Some(cloned.column(3)));
-    assert_eq!(col_iter.next(),Some(cloned.column(2)));
-    assert_eq!(col_iter.next_back(),None);
-    assert_eq!(col_iter.next(),None);
+    assert_eq!(col_iter.next(), Some(cloned.column(0)));
+    assert_eq!(col_iter.next(), Some(cloned.column(1)));
+    assert_eq!(col_iter.next_back(), Some(cloned.column(4)));
+    assert_eq!(col_iter.next_back(), Some(cloned.column(3)));
+    assert_eq!(col_iter.next(), Some(cloned.column(2)));
+    assert_eq!(col_iter.next_back(), None);
+    assert_eq!(col_iter.next(), None);
 }
 
 #[test]
 fn parallel_column_iteration_mut() {
     use rayon::prelude::*;
-    let mut first = DMatrix::<f32>::zeros(400,300);
-    let mut second = DMatrix::<f32>::zeros(400,300);
-    first.column_iter_mut().enumerate().for_each(|(idx,mut col)|col[idx]=1.);
-    second.par_column_iter_mut().enumerate().for_each(|(idx,mut col)| col[idx]=1.);
-    assert_eq!(first,second);
-    assert_eq!(second,DMatrix::identity(400,300));
+    let mut first = DMatrix::<f32>::zeros(400, 300);
+    let mut second = DMatrix::<f32>::zeros(400, 300);
+    first
+        .column_iter_mut()
+        .enumerate()
+        .for_each(|(idx, mut col)| col[idx] = 1.);
+    second
+        .par_column_iter_mut()
+        .enumerate()
+        .for_each(|(idx, mut col)| col[idx] = 1.);
+    assert_eq!(first, second);
+    assert_eq!(second, DMatrix::identity(400, 300));
 }

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1200,7 +1200,7 @@ fn column_iteration_double_ended() {
 }
 
 #[test]
-#[cfg(feature = "rayon")]
+#[cfg(feature = "par-iter")]
 fn parallel_column_iteration() {
     use nalgebra::dmatrix;
     use rayon::prelude::*;
@@ -1222,7 +1222,7 @@ fn parallel_column_iteration() {
 }
 
 #[test]
-#[cfg(feature = "rayon")]
+#[cfg(feature = "par-iter")]
 fn column_iteration_mut_double_ended() {
     let dmat = nalgebra::dmatrix![
     13,14,15,16,17;
@@ -1241,7 +1241,7 @@ fn column_iteration_mut_double_ended() {
 }
 
 #[test]
-#[cfg(feature = "rayon")]
+#[cfg(feature = "par-iter")]
 fn parallel_column_iteration_mut() {
     use rayon::prelude::*;
     let mut first = DMatrix::<f32>::zeros(400, 300);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1237,15 +1237,17 @@ fn parallel_column_iteration() {
     let par_result: f64 = dmat.par_column_iter().map(|col| col.norm()).sum();
     let ser_result: f64 = dmat.column_iter().map(|col| col.norm()).sum();
     assert_eq!(par_result, ser_result);
-    
+
     // repeat this test using mutable iterators
     let mut dmat = dmat;
-    dmat.par_column_iter_mut().enumerate().for_each(|(idx, col)| {
-        assert_eq!(col, cloned.column(idx));
-    });
+    dmat.par_column_iter_mut()
+        .enumerate()
+        .for_each(|(idx, col)| {
+            assert_eq!(col, cloned.column(idx));
+        });
 
     let par_mut_result: f64 = dmat.par_column_iter_mut().map(|col| col.norm()).sum();
-    assert_eq!(par_mut_result,ser_result);
+    assert_eq!(par_mut_result, ser_result);
 }
 
 #[test]

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1218,7 +1218,7 @@ fn column_iterator_double_ended_mut() {
 }
 
 #[test]
-#[cfg(feature = "par-iter")]
+#[cfg(feature = "rayon")]
 fn parallel_column_iteration() {
     use nalgebra::dmatrix;
     use rayon::prelude::*;
@@ -1251,7 +1251,7 @@ fn parallel_column_iteration() {
 }
 
 #[test]
-#[cfg(feature = "par-iter")]
+#[cfg(feature = "rayon")]
 fn column_iteration_mut_double_ended() {
     let dmat = nalgebra::dmatrix![
     13,14,15,16,17;
@@ -1270,7 +1270,7 @@ fn column_iteration_mut_double_ended() {
 }
 
 #[test]
-#[cfg(feature = "par-iter")]
+#[cfg(feature = "rayon")]
 fn parallel_column_iteration_mut() {
     use rayon::prelude::*;
     let mut first = DMatrix::<f32>::zeros(400, 300);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1200,6 +1200,7 @@ fn column_iteration_double_ended() {
 }
 
 #[test]
+#[cfg(feature = "rayon")]
 fn parallel_column_iteration() {
     use nalgebra::dmatrix;
     use rayon::prelude::*;
@@ -1221,6 +1222,7 @@ fn parallel_column_iteration() {
 }
 
 #[test]
+#[cfg(feature = "rayon")]
 fn colum_iteration_mut_double_ended() {
     let dmat = nalgebra::dmatrix![
     13,14,15,16,17;
@@ -1239,6 +1241,7 @@ fn colum_iteration_mut_double_ended() {
 }
 
 #[test]
+#[cfg(feature = "rayon")]
 fn parallel_column_iteration_mut() {
     use rayon::prelude::*;
     let mut first = DMatrix::<f32>::zeros(400, 300);

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1136,3 +1136,92 @@ fn omatrix_to_string() {
         (svec.to_string(), smatr.to_string())
     );
 }
+
+#[test]
+fn column_iteration() {
+    // dynamic matrix
+    let dmat = nalgebra::dmatrix![
+        13,14,15;
+        23,24,25;
+        33,34,35;
+        ];
+    // not using enumerate on purpose
+    let mut idx = 0;
+    for col in dmat.column_iter() {
+        assert_eq!(dmat.column(idx),col);
+        idx += 1;
+    }
+    // statically sized matrix
+    let smat: nalgebra::SMatrix<f64, 2, 2> = nalgebra::matrix![1.0, 2.0; 3.0, 4.0];
+    let mut idx = 0;
+    for col in smat.column_iter() {
+        assert_eq!(smat.column(idx),col);
+        idx += 1;
+    }
+}
+
+#[test]
+fn column_iteration_double_ended() {
+    let dmat = nalgebra::dmatrix![
+        13,14,15,16,17;
+        23,24,25,26,27;
+        33,34,35,36,37;
+        ];
+    let mut col_iter = dmat.column_iter();
+    assert_eq!(col_iter.next(),Some(dmat.column(0)));
+    assert_eq!(col_iter.next(),Some(dmat.column(1)));
+    assert_eq!(col_iter.next_back(),Some(dmat.column(4)));
+    assert_eq!(col_iter.next_back(),Some(dmat.column(3)));
+    assert_eq!(col_iter.next(),Some(dmat.column(2)));
+    assert_eq!(col_iter.next_back(),None);
+    assert_eq!(col_iter.next(),None);
+}
+
+#[test]
+fn parallel_column_iteration() {
+    use rayon::prelude::*;
+    use nalgebra::{dmatrix,dvector};
+    let dmat = dmatrix![
+        13.,14.;
+        23.,24.;
+        33.,34.;
+        ];
+    let cloned = dmat.clone();
+    // test that correct columns are iterated over
+    dmat.par_column_iter().enumerate().for_each(|(idx,col)| {
+        assert_eq!(col,cloned.column(idx)); 
+    });
+    // test that a more complex expression produces the same
+    // result as the serial equivalent
+    let par_result :f64 = dmat.par_column_iter().map(|col| col.norm()).sum();
+    let ser_result = dmat.column_iter().map(|col| col.norm()).sum();
+    assert_eq!(par_result,ser_result);
+}
+
+#[test]
+fn column_iteration_mut() {
+    todo!();
+}
+
+#[test]
+fn colum_iteration_mut_double_ended() {
+    let dmat = nalgebra::dmatrix![
+        13,14,15,16,17;
+        23,24,25,26,27;
+        33,34,35,36,37;
+        ];
+    let cloned = dmat.clone();
+    let mut col_iter = dmat.column_iter();
+    assert_eq!(col_iter.next(),Some(cloned.column(0)));
+    assert_eq!(col_iter.next(),Some(cloned.column(1)));
+    assert_eq!(col_iter.next_back(),Some(cloned.column(4)));
+    assert_eq!(col_iter.next_back(),Some(cloned.column(3)));
+    assert_eq!(col_iter.next(),Some(cloned.column(2)));
+    assert_eq!(col_iter.next_back(),None);
+    assert_eq!(col_iter.next(),None);
+}
+
+#[test]
+fn parallel_column_iteration_mut() {
+    todo!()
+}

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1200,6 +1200,24 @@ fn column_iteration_double_ended() {
 }
 
 #[test]
+fn column_iterator_double_ended_mut() {
+    let mut dmat = nalgebra::dmatrix![
+    13,14,15,16,17;
+    23,24,25,26,27;
+    33,34,35,36,37;
+    ];
+    let mut cloned = dmat.clone();
+    let mut col_iter_mut = dmat.column_iter_mut();
+    assert_eq!(col_iter_mut.next(), Some(cloned.column_mut(0)));
+    assert_eq!(col_iter_mut.next(), Some(cloned.column_mut(1)));
+    assert_eq!(col_iter_mut.next_back(), Some(cloned.column_mut(4)));
+    assert_eq!(col_iter_mut.next_back(), Some(cloned.column_mut(3)));
+    assert_eq!(col_iter_mut.next(), Some(cloned.column_mut(2)));
+    assert_eq!(col_iter_mut.next_back(), None);
+    assert_eq!(col_iter_mut.next(), None);
+}
+
+#[test]
 #[cfg(feature = "par-iter")]
 fn parallel_column_iteration() {
     use nalgebra::dmatrix;
@@ -1219,6 +1237,15 @@ fn parallel_column_iteration() {
     let par_result: f64 = dmat.par_column_iter().map(|col| col.norm()).sum();
     let ser_result: f64 = dmat.column_iter().map(|col| col.norm()).sum();
     assert_eq!(par_result, ser_result);
+    
+    // repeat this test using mutable iterators
+    let mut dmat = dmat;
+    dmat.par_column_iter_mut().enumerate().for_each(|(idx, col)| {
+        assert_eq!(col, cloned.column(idx));
+    });
+
+    let par_mut_result: f64 = dmat.par_column_iter_mut().map(|col| col.norm()).sum();
+    assert_eq!(par_mut_result,ser_result);
 }
 
 #[test]

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1223,7 +1223,7 @@ fn parallel_column_iteration() {
 
 #[test]
 #[cfg(feature = "rayon")]
-fn colum_iteration_mut_double_ended() {
+fn column_iteration_mut_double_ended() {
     let dmat = nalgebra::dmatrix![
     13,14,15,16,17;
     23,24,25,26,27;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,8 +10,8 @@ compile_error!(
 );
 
 // make sure to test the parallel iterators for all builds that do not require no_std
-#[cfg(all(feature = "std", not(feature = "rayon")))]
-compile_error!("Please additionally enable the `rayon` feature to compile and run the tests");
+#[cfg(all(feature = "std", not(feature = "par-iter")))]
+compile_error!("Please additionally enable the `par-iter` feature to compile and run the tests");
 
 #[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,8 +10,8 @@ compile_error!(
 );
 
 // make sure to test the parallel iterators for all builds that do not require no_std
-#[cfg(all(feature = "std", not(feature = "rayon-par")))]
-compile_error!("Please additionally enable the `rayon-par` feature to compile and run the tests");
+#[cfg(all(feature = "std", not(feature = "rayon")))]
+compile_error!("Please additionally enable the `rayon` feature to compile and run the tests");
 
 #[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,8 +10,8 @@ compile_error!(
 );
 
 // make sure to test the parallel iterators for all builds that do not require no_std
-#[cfg(all(feature = "std", not(feature = "rayon")))]
-compile_error!("Please additionally enable the `rayon` feature to compile and run the tests");
+#[cfg(all(feature = "std", not(feature = "rayon-par")))]
+compile_error!("Please additionally enable the `rayon-par` feature to compile and run the tests");
 
 #[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,6 +9,10 @@ compile_error!(
      Example: `cargo test --features debug,compare,rand,macros`"
 );
 
+// make sure to test the parallel iterators for all builds that do not require no_std
+#[cfg(all(feature = "std", not(feature = "rayon")))]
+compile_error!("Please additionally enable the `rayon` feature to compile and run the tests");
+
 #[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]
 extern crate approx;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,10 +9,6 @@ compile_error!(
      Example: `cargo test --features debug,compare,rand,macros`"
 );
 
-// make sure to test the parallel iterators for all builds that do not require no_std
-#[cfg(all(feature = "std", not(feature = "par-iter")))]
-compile_error!("Please additionally enable the `par-iter` feature to compile and run the tests");
-
 #[cfg(all(feature = "debug", feature = "compare", feature = "rand"))]
 #[macro_use]
 extern crate approx;


### PR DESCRIPTION
**Short**: Enable parallel column iterators for matrices with rayon

**Fixes**: #848 

**Changes**:
* Added functions `par_column_iter` and `par_column_iter_mut` to enable iteration over (mutable) columns in parallel
* The serial `ColumnIterMut` is now Send. I changed a few things that I am not sure make the code any more or less safe than before. I'm grateful for a review.
* Both `ColumnIter` and `ColumnIterMut` are now double ended (rayon needs this). This required me to stick another pointer sized integer in there, increasing the size of an iterator by 50%. (from 2 pointer sized members to 3)
* Added tests covering serial and parallel iterators

**Notes**:
* I will want to feature gate this functionality on crate feature `rayon` or `parallel`. I'll do that when I get greenlight on the rest of the code.

**Example Code**
We can now modify the columns of a matrix in parallel like so
```rust
//silly example, I know
let mut matrix = DMatrix::<f32>::zeros(100,100);
matrix
  .par_column_iter_mut()
  .enumerate()
  .for_each(|(idx, mut col)| col[idx] = 1.);
assert_eq!(matrix, DMatrix::identity(100,100));
```

Cheers and thank you,
Geo

