### PR TITLE
Fix error[E0658] in point_construction.rs

### DIFF
--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "arbitrary")]
+#[cfg_attr(feature = "nightly", feature(const_fn_trait_bound))]
 use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};


### PR DESCRIPTION
Workaround for error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable. Fixes #1166