### PR TITLE
Use parenthesis for exclusive lower bound

### DIFF
--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1323,7 +1323,7 @@ where
         }
     }
 
-    /// The rotation axis and angle in ]0, pi] of this unit quaternion.
+    /// The rotation axis and angle in (0, pi] of this unit quaternion.
     ///
     /// Returns `None` if the angle is zero.
     ///

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -877,7 +877,7 @@ impl<T: SimdRealField> Rotation3<T> {
         }
     }
 
-    /// The rotation axis and angle in ]0, pi] of this rotation matrix.
+    /// The rotation axis and angle in (0, pi] of this rotation matrix.
     ///
     /// Returns `None` if the angle is zero.
     ///

--- a/src/geometry/unit_complex.rs
+++ b/src/geometry/unit_complex.rs
@@ -132,7 +132,7 @@ where
         Vector1::new(self.angle())
     }
 
-    /// The rotation axis and angle in ]0, pi] of this complex number.
+    /// The rotation axis and angle in (0, pi] of this complex number.
     ///
     /// This is generally used in the context of generic programming. Using
     /// the `.angle()` method instead is more common.


### PR DESCRIPTION
Changes `]0, pi]` to `(0, pi]`.

Replaces PR #1173 and resolves Issue #1164.