### PR TITLE
replace matrixmultiply with gemm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [features]
 default = [ "std", "macros" ]
-std     = [ "matrixmultiply", "simba/std" ]
+std     = [ "gemm", "simba/std" ]
 sparse  = [ ]
 debug   = [ "approx/num-complex", "rand" ]
 alloc   = [ ]
@@ -80,7 +80,7 @@ approx         = { version = "0.5", default-features = false }
 simba          = { version = "0.7", default-features = false }
 alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.4", default-features = false, optional = true }
-matrixmultiply = { version = "0.3", optional = true }
+gemm           = { version = "0.11", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
 rkyv           = { version = "~0.7.1", optional = true }
 bytecheck      = { version = "~0.6.1", optional = true }


### PR DESCRIPTION
this PR replaces the `matrixmultiply` dependency with `gemm`, which is a crate i developed for high performance matrix multiplication. its single threaded performance is about 10-20% better than `matrixmultiply` for medium/large matrices. and its multithreaded performance is competitive with [blis](https://github.com/flame/blis) and intel mkl (and about 10% faster than eigen on my machine)

the multithread parallelism isn't implemented in this PR. since i'm not sure how to expose it in `nalgebra` (global variable, thread_local, per call basis?)

`gemm` also has a `nightly` feature that enables avx512 for extra performance, which is also not implemented in this PR since i don't know how we want to expose it either.