### PR TITLE
Enable `reshape_generic` for slices + other things

### DIFF
--- a/examples/reshaping.rs
+++ b/examples/reshaping.rs
@@ -2,7 +2,7 @@
 
 extern crate nalgebra as na;
 
-use na::{DMatrix, Dynamic, Matrix2x3, Matrix3x2, Const};
+use na::{DMatrix, Dyn, Matrix2x3, Matrix3x2, Const};
 
 fn main() {
     // Matrices can be reshaped in-place without moving or copying values.
@@ -46,9 +46,9 @@ fn main() {
         ],
     );
 
-    let dm3 = dm1.reshape_generic(Dynamic::new(6), Dynamic::new(2));
+    let dm3 = dm1.reshape_generic(Dyn(6), Dyn(2));
     assert_eq!(dm3, dm2);
 
     // Invalid reshapings of dynamic matrices will panic at run-time.
-    //let dm4 = dm3.reshape_generic(Dynamic::new(6), Dynamic::new(6));
+    //let dm4 = dm3.reshape_generic(Dyn(6), Dyn(6));
 }

--- a/nalgebra-macros/src/lib.rs
+++ b/nalgebra-macros/src/lib.rs
@@ -191,8 +191,8 @@ pub fn dmatrix(stream: TokenStream) -> TokenStream {
     let output = quote! {
         nalgebra::DMatrix::<_>
             ::from_vec_storage(nalgebra::VecStorage::new(
-                nalgebra::Dynamic::new(#row_dim),
-                nalgebra::Dynamic::new(#col_dim),
+                nalgebra::Dyn(#row_dim),
+                nalgebra::Dyn(#col_dim),
                 vec!#array_tokens))
     };
 
@@ -285,7 +285,7 @@ pub fn dvector(stream: TokenStream) -> TokenStream {
     let output = quote! {
         nalgebra::DVector::<_>
             ::from_vec_storage(nalgebra::VecStorage::new(
-                nalgebra::Dynamic::new(#len),
+                nalgebra::Dyn(#len),
                 nalgebra::Const::<1>,
                 vec!#array_tokens))
     };

--- a/nalgebra-sparse/src/ops/impl_std_ops.rs
+++ b/nalgebra-sparse/src/ops/impl_std_ops.rs
@@ -10,7 +10,7 @@ use nalgebra::allocator::Allocator;
 use nalgebra::base::storage::RawStorage;
 use nalgebra::constraint::{DimEq, ShapeConstraint};
 use nalgebra::{
-    ClosedAdd, ClosedDiv, ClosedMul, ClosedSub, DefaultAllocator, Dim, Dynamic, Matrix, OMatrix,
+    ClosedAdd, ClosedDiv, ClosedMul, ClosedSub, DefaultAllocator, Dim, Dyn, Matrix, OMatrix,
     Scalar, U1,
 };
 use num_traits::{One, Zero};
@@ -273,8 +273,8 @@ macro_rules! impl_spmm_cs_dense {
         // Implement ref-ref
         impl_spmm_cs_dense!(&'a $matrix_type_name<T>, &'a Matrix<T, R, C, S>, $spmm_fn, |lhs, rhs| {
             let (_, ncols) = rhs.shape_generic();
-            let nrows = Dynamic::new(lhs.nrows());
-            let mut result = OMatrix::<T, Dynamic, C>::zeros_generic(nrows, ncols);
+            let nrows = Dyn(lhs.nrows());
+            let mut result = OMatrix::<T, Dyn, C>::zeros_generic(nrows, ncols);
             $spmm_fn(T::zero(), &mut result, T::one(), Op::NoOp(lhs), Op::NoOp(rhs));
             result
         });
@@ -302,21 +302,21 @@ macro_rules! impl_spmm_cs_dense {
             R: Dim,
             C: Dim,
             S: RawStorage<T, R, C>,
-            DefaultAllocator: Allocator<T, Dynamic, C>,
+            DefaultAllocator: Allocator<T, Dyn, C>,
             // TODO: Is it possible to simplify these bounds?
             ShapeConstraint:
-                // Bounds so that we can turn OMatrix<T, Dynamic, C> into a DMatrixSliceMut
-                  DimEq<U1, <<DefaultAllocator as Allocator<T, Dynamic, C>>::Buffer as RawStorage<T, Dynamic, C>>::RStride>
-                + DimEq<C, Dynamic>
-                + DimEq<Dynamic, <<DefaultAllocator as Allocator<T, Dynamic, C>>::Buffer as RawStorage<T, Dynamic, C>>::CStride>
+                // Bounds so that we can turn OMatrix<T, Dyn, C> into a DMatrixSliceMut
+                  DimEq<U1, <<DefaultAllocator as Allocator<T, Dyn, C>>::Buffer as RawStorage<T, Dyn, C>>::RStride>
+                + DimEq<C, Dyn>
+                + DimEq<Dyn, <<DefaultAllocator as Allocator<T, Dyn, C>>::Buffer as RawStorage<T, Dyn, C>>::CStride>
                 // Bounds so that we can turn &Matrix<T, R, C, S> into a DMatrixSlice
                 + DimEq<U1, S::RStride>
-                + DimEq<R, Dynamic>
-                + DimEq<Dynamic, S::CStride>
+                + DimEq<R, Dyn>
+                + DimEq<Dyn, S::CStride>
         {
             // We need the column dimension to be generic, so that if RHS is a vector, then
             // we also get a vector (and not a matrix)
-            type Output = OMatrix<T, Dynamic, C>;
+            type Output = OMatrix<T, Dyn, C>;
 
             fn mul(self, rhs: $dense_matrix_type) -> Self::Output {
                 let $lhs = self;

--- a/src/base/alias.rs
+++ b/src/base/alias.rs
@@ -1,5 +1,5 @@
 #[cfg(any(feature = "alloc", feature = "std"))]
-use crate::base::dimension::Dynamic;
+use crate::base::dimension::Dyn;
 use crate::base::dimension::{U1, U2, U3, U4, U5, U6};
 use crate::base::storage::Owned;
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -48,69 +48,69 @@ pub type SMatrix<T, const R: usize, const C: usize> =
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type DMatrix<T> = Matrix<T, Dynamic, Dynamic, VecStorage<T, Dynamic, Dynamic>>;
+pub type DMatrix<T> = Matrix<T, Dyn, Dyn, VecStorage<T, Dyn, Dyn>>;
 
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 1 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx1<T> = Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>>;
+pub type MatrixXx1<T> = Matrix<T, Dyn, U1, VecStorage<T, Dyn, U1>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 2 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx2<T> = Matrix<T, Dynamic, U2, VecStorage<T, Dynamic, U2>>;
+pub type MatrixXx2<T> = Matrix<T, Dyn, U2, VecStorage<T, Dyn, U2>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 3 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx3<T> = Matrix<T, Dynamic, U3, VecStorage<T, Dynamic, U3>>;
+pub type MatrixXx3<T> = Matrix<T, Dyn, U3, VecStorage<T, Dyn, U3>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 4 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx4<T> = Matrix<T, Dynamic, U4, VecStorage<T, Dynamic, U4>>;
+pub type MatrixXx4<T> = Matrix<T, Dyn, U4, VecStorage<T, Dyn, U4>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 5 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx5<T> = Matrix<T, Dynamic, U5, VecStorage<T, Dynamic, U5>>;
+pub type MatrixXx5<T> = Matrix<T, Dyn, U5, VecStorage<T, Dyn, U5>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 6 columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type MatrixXx6<T> = Matrix<T, Dynamic, U6, VecStorage<T, Dynamic, U6>>;
+pub type MatrixXx6<T> = Matrix<T, Dyn, U6, VecStorage<T, Dyn, U6>>;
 
 /// A heap-allocated, row-major, matrix with 1 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix1xX<T> = Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>>;
+pub type Matrix1xX<T> = Matrix<T, U1, Dyn, VecStorage<T, U1, Dyn>>;
 /// A heap-allocated, row-major, matrix with 2 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix2xX<T> = Matrix<T, U2, Dynamic, VecStorage<T, U2, Dynamic>>;
+pub type Matrix2xX<T> = Matrix<T, U2, Dyn, VecStorage<T, U2, Dyn>>;
 /// A heap-allocated, row-major, matrix with 3 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix3xX<T> = Matrix<T, U3, Dynamic, VecStorage<T, U3, Dynamic>>;
+pub type Matrix3xX<T> = Matrix<T, U3, Dyn, VecStorage<T, U3, Dyn>>;
 /// A heap-allocated, row-major, matrix with 4 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix4xX<T> = Matrix<T, U4, Dynamic, VecStorage<T, U4, Dynamic>>;
+pub type Matrix4xX<T> = Matrix<T, U4, Dyn, VecStorage<T, U4, Dyn>>;
 /// A heap-allocated, row-major, matrix with 5 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix5xX<T> = Matrix<T, U5, Dynamic, VecStorage<T, U5, Dynamic>>;
+pub type Matrix5xX<T> = Matrix<T, U5, Dyn, VecStorage<T, U5, Dyn>>;
 /// A heap-allocated, row-major, matrix with 6 rows and a dynamic number of columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type Matrix6xX<T> = Matrix<T, U6, Dynamic, VecStorage<T, U6, Dynamic>>;
+pub type Matrix6xX<T> = Matrix<T, U6, Dyn, VecStorage<T, U6, Dyn>>;
 
 /// A stack-allocated, column-major, 1x1 square matrix.
 ///
@@ -276,7 +276,7 @@ pub type Matrix6x5<T> = Matrix<T, U6, U5, ArrayStorage<T, 6, 5>>;
  */
 /// A dynamically sized column vector.
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type DVector<T> = Matrix<T, Dynamic, U1, VecStorage<T, Dynamic, U1>>;
+pub type DVector<T> = Matrix<T, Dyn, U1, VecStorage<T, Dyn, U1>>;
 
 /// An owned D-dimensional column vector.
 pub type OVector<T, D> = Matrix<T, D, U1, Owned<T, D, U1>>;
@@ -316,7 +316,7 @@ pub type Vector6<T> = Matrix<T, U6, U1, ArrayStorage<T, 6, 1>>;
  */
 /// A dynamically sized row vector.
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub type RowDVector<T> = Matrix<T, U1, Dynamic, VecStorage<T, U1, Dynamic>>;
+pub type RowDVector<T> = Matrix<T, U1, Dyn, VecStorage<T, U1, Dyn>>;
 
 /// An owned D-dimensional row vector.
 pub type RowOVector<T, D> = Matrix<T, U1, D, Owned<T, U1, D>>;

--- a/src/base/alias_slice.rs
+++ b/src/base/alias_slice.rs
@@ -1,4 +1,4 @@
-use crate::base::dimension::{Dynamic, U1, U2, U3, U4, U5, U6};
+use crate::base::dimension::{Dyn, U1, U2, U3, U4, U5, U6};
 use crate::base::matrix_view::{ViewStorage, ViewStorageMut};
 use crate::base::{Const, Matrix};
 use crate::slice_deprecation_note;
@@ -22,8 +22,8 @@ pub type SMatrixSlice<'a, T, const R: usize, const C: usize> =
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[deprecated = slice_deprecation_note!(DMatrixView)]
-pub type DMatrixSlice<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, Dynamic, ViewStorage<'a, T, Dynamic, Dynamic, RStride, CStride>>;
+pub type DMatrixSlice<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, Dyn, ViewStorage<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix slice.
 ///
@@ -251,52 +251,52 @@ pub type MatrixSlice6x5<'a, T, RStride = U1, CStride = U6> =
 /// A column-major matrix slice with 1 row and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView1xX)]
 pub type MatrixSlice1xX<'a, T, RStride = U1, CStride = U1> =
-    Matrix<T, U1, Dynamic, ViewStorage<'a, T, U1, Dynamic, RStride, CStride>>;
+    Matrix<T, U1, Dyn, ViewStorage<'a, T, U1, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 2 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView2xX)]
 pub type MatrixSlice2xX<'a, T, RStride = U1, CStride = U2> =
-    Matrix<T, U2, Dynamic, ViewStorage<'a, T, U2, Dynamic, RStride, CStride>>;
+    Matrix<T, U2, Dyn, ViewStorage<'a, T, U2, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 3 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView3xX)]
 pub type MatrixSlice3xX<'a, T, RStride = U1, CStride = U3> =
-    Matrix<T, U3, Dynamic, ViewStorage<'a, T, U3, Dynamic, RStride, CStride>>;
+    Matrix<T, U3, Dyn, ViewStorage<'a, T, U3, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 4 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView4xX)]
 pub type MatrixSlice4xX<'a, T, RStride = U1, CStride = U4> =
-    Matrix<T, U4, Dynamic, ViewStorage<'a, T, U4, Dynamic, RStride, CStride>>;
+    Matrix<T, U4, Dyn, ViewStorage<'a, T, U4, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 5 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView5xX)]
 pub type MatrixSlice5xX<'a, T, RStride = U1, CStride = U5> =
-    Matrix<T, U5, Dynamic, ViewStorage<'a, T, U5, Dynamic, RStride, CStride>>;
+    Matrix<T, U5, Dyn, ViewStorage<'a, T, U5, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 6 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixView6xX)]
 pub type MatrixSlice6xX<'a, T, RStride = U1, CStride = U6> =
-    Matrix<T, U6, Dynamic, ViewStorage<'a, T, U6, Dynamic, RStride, CStride>>;
+    Matrix<T, U6, Dyn, ViewStorage<'a, T, U6, Dyn, RStride, CStride>>;
 
 /// A column-major matrix slice with a number of rows chosen at runtime and 1 column.
 #[deprecated = slice_deprecation_note!(MatrixViewXx1)]
-pub type MatrixSliceXx1<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorage<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type MatrixSliceXx1<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 2 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewXx2)]
-pub type MatrixSliceXx2<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U2, ViewStorage<'a, T, Dynamic, U2, RStride, CStride>>;
+pub type MatrixSliceXx2<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U2, ViewStorage<'a, T, Dyn, U2, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 3 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewXx3)]
-pub type MatrixSliceXx3<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U3, ViewStorage<'a, T, Dynamic, U3, RStride, CStride>>;
+pub type MatrixSliceXx3<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U3, ViewStorage<'a, T, Dyn, U3, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 4 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewXx4)]
-pub type MatrixSliceXx4<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U4, ViewStorage<'a, T, Dynamic, U4, RStride, CStride>>;
+pub type MatrixSliceXx4<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U4, ViewStorage<'a, T, Dyn, U4, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 5 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewXx5)]
-pub type MatrixSliceXx5<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U5, ViewStorage<'a, T, Dynamic, U5, RStride, CStride>>;
+pub type MatrixSliceXx5<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U5, ViewStorage<'a, T, Dyn, U5, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 6 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewXx6)]
-pub type MatrixSliceXx6<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U6, ViewStorage<'a, T, Dynamic, U6, RStride, CStride>>;
+pub type MatrixSliceXx6<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U6, ViewStorage<'a, T, Dyn, U6, RStride, CStride>>;
 
 /// A column vector slice with dimensions known at compile-time.
 ///
@@ -314,8 +314,8 @@ pub type SVectorSlice<'a, T, const D: usize> =
 
 /// A column vector slice dynamic numbers of rows and columns.
 #[deprecated = slice_deprecation_note!(DVectorView)]
-pub type DVectorSlice<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorage<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type DVectorSlice<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 
 /// A 1D column vector slice.
 ///
@@ -386,8 +386,8 @@ pub type SMatrixSliceMut<'a, T, const R: usize, const C: usize> =
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[deprecated = slice_deprecation_note!(DMatrixViewMut)]
-pub type DMatrixSliceMut<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, Dynamic, ViewStorageMut<'a, T, Dynamic, Dynamic, RStride, CStride>>;
+pub type DMatrixSliceMut<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, Dyn, ViewStorageMut<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix slice.
 ///
@@ -615,52 +615,52 @@ pub type MatrixSliceMut6x5<'a, T, RStride = U1, CStride = U6> =
 /// A column-major matrix slice with 1 row and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut1xX)]
 pub type MatrixSliceMut1xX<'a, T, RStride = U1, CStride = U1> =
-    Matrix<T, U1, Dynamic, ViewStorageMut<'a, T, U1, Dynamic, RStride, CStride>>;
+    Matrix<T, U1, Dyn, ViewStorageMut<'a, T, U1, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 2 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut2xX)]
 pub type MatrixSliceMut2xX<'a, T, RStride = U1, CStride = U2> =
-    Matrix<T, U2, Dynamic, ViewStorageMut<'a, T, U2, Dynamic, RStride, CStride>>;
+    Matrix<T, U2, Dyn, ViewStorageMut<'a, T, U2, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 3 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut3xX)]
 pub type MatrixSliceMut3xX<'a, T, RStride = U1, CStride = U3> =
-    Matrix<T, U3, Dynamic, ViewStorageMut<'a, T, U3, Dynamic, RStride, CStride>>;
+    Matrix<T, U3, Dyn, ViewStorageMut<'a, T, U3, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 4 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut4xX)]
 pub type MatrixSliceMut4xX<'a, T, RStride = U1, CStride = U4> =
-    Matrix<T, U4, Dynamic, ViewStorageMut<'a, T, U4, Dynamic, RStride, CStride>>;
+    Matrix<T, U4, Dyn, ViewStorageMut<'a, T, U4, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 5 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut5xX)]
 pub type MatrixSliceMut5xX<'a, T, RStride = U1, CStride = U5> =
-    Matrix<T, U5, Dynamic, ViewStorageMut<'a, T, U5, Dynamic, RStride, CStride>>;
+    Matrix<T, U5, Dyn, ViewStorageMut<'a, T, U5, Dyn, RStride, CStride>>;
 /// A column-major matrix slice with 6 rows and a number of columns chosen at runtime.
 #[deprecated = slice_deprecation_note!(MatrixViewMut6xX)]
 pub type MatrixSliceMut6xX<'a, T, RStride = U1, CStride = U6> =
-    Matrix<T, U6, Dynamic, ViewStorageMut<'a, T, U6, Dynamic, RStride, CStride>>;
+    Matrix<T, U6, Dyn, ViewStorageMut<'a, T, U6, Dyn, RStride, CStride>>;
 
 /// A column-major matrix slice with a number of rows chosen at runtime and 1 column.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx1)]
-pub type MatrixSliceMutXx1<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorageMut<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type MatrixSliceMutXx1<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 2 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx2)]
-pub type MatrixSliceMutXx2<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U2, ViewStorageMut<'a, T, Dynamic, U2, RStride, CStride>>;
+pub type MatrixSliceMutXx2<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U2, ViewStorageMut<'a, T, Dyn, U2, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 3 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx3)]
-pub type MatrixSliceMutXx3<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U3, ViewStorageMut<'a, T, Dynamic, U3, RStride, CStride>>;
+pub type MatrixSliceMutXx3<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U3, ViewStorageMut<'a, T, Dyn, U3, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 4 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx4)]
-pub type MatrixSliceMutXx4<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U4, ViewStorageMut<'a, T, Dynamic, U4, RStride, CStride>>;
+pub type MatrixSliceMutXx4<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U4, ViewStorageMut<'a, T, Dyn, U4, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 5 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx5)]
-pub type MatrixSliceMutXx5<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U5, ViewStorageMut<'a, T, Dynamic, U5, RStride, CStride>>;
+pub type MatrixSliceMutXx5<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U5, ViewStorageMut<'a, T, Dyn, U5, RStride, CStride>>;
 /// A column-major matrix slice with a number of rows chosen at runtime and 6 columns.
 #[deprecated = slice_deprecation_note!(MatrixViewMutXx6)]
-pub type MatrixSliceMutXx6<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U6, ViewStorageMut<'a, T, Dynamic, U6, RStride, CStride>>;
+pub type MatrixSliceMutXx6<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U6, ViewStorageMut<'a, T, Dyn, U6, RStride, CStride>>;
 
 /// A column vector slice with dimensions known at compile-time.
 ///
@@ -680,8 +680,8 @@ pub type SVectorSliceMut<'a, T, const D: usize> =
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 #[deprecated = slice_deprecation_note!(DVectorViewMut)]
-pub type DVectorSliceMut<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorageMut<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type DVectorSliceMut<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 
 /// A 1D column vector slice.
 ///

--- a/src/base/alias_view.rs
+++ b/src/base/alias_view.rs
@@ -1,4 +1,4 @@
-use crate::base::dimension::{Dynamic, U1, U2, U3, U4, U5, U6};
+use crate::base::dimension::{Dyn, U1, U2, U3, U4, U5, U6};
 use crate::base::matrix_view::{ViewStorage, ViewStorageMut};
 use crate::base::{Const, Matrix};
 
@@ -19,8 +19,8 @@ pub type SMatrixView<'a, T, const R: usize, const C: usize> =
 /// A column-major matrix view dynamic numbers of rows and columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
-pub type DMatrixView<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, Dynamic, ViewStorage<'a, T, Dynamic, Dynamic, RStride, CStride>>;
+pub type DMatrixView<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, Dyn, ViewStorage<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix view.
 ///
@@ -211,41 +211,41 @@ pub type MatrixView6x5<'a, T, RStride = U1, CStride = U6> =
 
 /// A column-major matrix view with 1 row and a number of columns chosen at runtime.
 pub type MatrixView1xX<'a, T, RStride = U1, CStride = U1> =
-    Matrix<T, U1, Dynamic, ViewStorage<'a, T, U1, Dynamic, RStride, CStride>>;
+    Matrix<T, U1, Dyn, ViewStorage<'a, T, U1, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 2 rows and a number of columns chosen at runtime.
 pub type MatrixView2xX<'a, T, RStride = U1, CStride = U2> =
-    Matrix<T, U2, Dynamic, ViewStorage<'a, T, U2, Dynamic, RStride, CStride>>;
+    Matrix<T, U2, Dyn, ViewStorage<'a, T, U2, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 3 rows and a number of columns chosen at runtime.
 pub type MatrixView3xX<'a, T, RStride = U1, CStride = U3> =
-    Matrix<T, U3, Dynamic, ViewStorage<'a, T, U3, Dynamic, RStride, CStride>>;
+    Matrix<T, U3, Dyn, ViewStorage<'a, T, U3, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 4 rows and a number of columns chosen at runtime.
 pub type MatrixView4xX<'a, T, RStride = U1, CStride = U4> =
-    Matrix<T, U4, Dynamic, ViewStorage<'a, T, U4, Dynamic, RStride, CStride>>;
+    Matrix<T, U4, Dyn, ViewStorage<'a, T, U4, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 5 rows and a number of columns chosen at runtime.
 pub type MatrixView5xX<'a, T, RStride = U1, CStride = U5> =
-    Matrix<T, U5, Dynamic, ViewStorage<'a, T, U5, Dynamic, RStride, CStride>>;
+    Matrix<T, U5, Dyn, ViewStorage<'a, T, U5, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 6 rows and a number of columns chosen at runtime.
 pub type MatrixView6xX<'a, T, RStride = U1, CStride = U6> =
-    Matrix<T, U6, Dynamic, ViewStorage<'a, T, U6, Dynamic, RStride, CStride>>;
+    Matrix<T, U6, Dyn, ViewStorage<'a, T, U6, Dyn, RStride, CStride>>;
 
 /// A column-major matrix view with a number of rows chosen at runtime and 1 column.
-pub type MatrixViewXx1<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorage<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type MatrixViewXx1<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 2 columns.
-pub type MatrixViewXx2<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U2, ViewStorage<'a, T, Dynamic, U2, RStride, CStride>>;
+pub type MatrixViewXx2<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U2, ViewStorage<'a, T, Dyn, U2, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 3 columns.
-pub type MatrixViewXx3<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U3, ViewStorage<'a, T, Dynamic, U3, RStride, CStride>>;
+pub type MatrixViewXx3<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U3, ViewStorage<'a, T, Dyn, U3, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 4 columns.
-pub type MatrixViewXx4<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U4, ViewStorage<'a, T, Dynamic, U4, RStride, CStride>>;
+pub type MatrixViewXx4<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U4, ViewStorage<'a, T, Dyn, U4, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 5 columns.
-pub type MatrixViewXx5<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U5, ViewStorage<'a, T, Dynamic, U5, RStride, CStride>>;
+pub type MatrixViewXx5<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U5, ViewStorage<'a, T, Dyn, U5, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 6 columns.
-pub type MatrixViewXx6<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U6, ViewStorage<'a, T, Dynamic, U6, RStride, CStride>>;
+pub type MatrixViewXx6<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U6, ViewStorage<'a, T, Dyn, U6, RStride, CStride>>;
 
 /// A column vector view with dimensions known at compile-time.
 ///
@@ -260,8 +260,8 @@ pub type SVectorView<'a, T, const D: usize> =
     Matrix<T, Const<D>, Const<1>, ViewStorage<'a, T, Const<D>, Const<1>, Const<1>, Const<D>>>;
 
 /// A column vector view dynamic numbers of rows and columns.
-pub type DVectorView<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorage<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type DVectorView<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 
 /// A 1D column vector view.
 ///
@@ -311,8 +311,8 @@ pub type SMatrixViewMut<'a, T, const R: usize, const C: usize> =
 /// A column-major matrix view dynamic numbers of rows and columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
-pub type DMatrixViewMut<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, Dynamic, ViewStorageMut<'a, T, Dynamic, Dynamic, RStride, CStride>>;
+pub type DMatrixViewMut<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, Dyn, ViewStorageMut<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix view.
 ///
@@ -503,41 +503,41 @@ pub type MatrixViewMut6x5<'a, T, RStride = U1, CStride = U6> =
 
 /// A column-major matrix view with 1 row and a number of columns chosen at runtime.
 pub type MatrixViewMut1xX<'a, T, RStride = U1, CStride = U1> =
-    Matrix<T, U1, Dynamic, ViewStorageMut<'a, T, U1, Dynamic, RStride, CStride>>;
+    Matrix<T, U1, Dyn, ViewStorageMut<'a, T, U1, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 2 rows and a number of columns chosen at runtime.
 pub type MatrixViewMut2xX<'a, T, RStride = U1, CStride = U2> =
-    Matrix<T, U2, Dynamic, ViewStorageMut<'a, T, U2, Dynamic, RStride, CStride>>;
+    Matrix<T, U2, Dyn, ViewStorageMut<'a, T, U2, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 3 rows and a number of columns chosen at runtime.
 pub type MatrixViewMut3xX<'a, T, RStride = U1, CStride = U3> =
-    Matrix<T, U3, Dynamic, ViewStorageMut<'a, T, U3, Dynamic, RStride, CStride>>;
+    Matrix<T, U3, Dyn, ViewStorageMut<'a, T, U3, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 4 rows and a number of columns chosen at runtime.
 pub type MatrixViewMut4xX<'a, T, RStride = U1, CStride = U4> =
-    Matrix<T, U4, Dynamic, ViewStorageMut<'a, T, U4, Dynamic, RStride, CStride>>;
+    Matrix<T, U4, Dyn, ViewStorageMut<'a, T, U4, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 5 rows and a number of columns chosen at runtime.
 pub type MatrixViewMut5xX<'a, T, RStride = U1, CStride = U5> =
-    Matrix<T, U5, Dynamic, ViewStorageMut<'a, T, U5, Dynamic, RStride, CStride>>;
+    Matrix<T, U5, Dyn, ViewStorageMut<'a, T, U5, Dyn, RStride, CStride>>;
 /// A column-major matrix view with 6 rows and a number of columns chosen at runtime.
 pub type MatrixViewMut6xX<'a, T, RStride = U1, CStride = U6> =
-    Matrix<T, U6, Dynamic, ViewStorageMut<'a, T, U6, Dynamic, RStride, CStride>>;
+    Matrix<T, U6, Dyn, ViewStorageMut<'a, T, U6, Dyn, RStride, CStride>>;
 
 /// A column-major matrix view with a number of rows chosen at runtime and 1 column.
-pub type MatrixViewMutXx1<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorageMut<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type MatrixViewMutXx1<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 2 columns.
-pub type MatrixViewMutXx2<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U2, ViewStorageMut<'a, T, Dynamic, U2, RStride, CStride>>;
+pub type MatrixViewMutXx2<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U2, ViewStorageMut<'a, T, Dyn, U2, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 3 columns.
-pub type MatrixViewMutXx3<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U3, ViewStorageMut<'a, T, Dynamic, U3, RStride, CStride>>;
+pub type MatrixViewMutXx3<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U3, ViewStorageMut<'a, T, Dyn, U3, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 4 columns.
-pub type MatrixViewMutXx4<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U4, ViewStorageMut<'a, T, Dynamic, U4, RStride, CStride>>;
+pub type MatrixViewMutXx4<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U4, ViewStorageMut<'a, T, Dyn, U4, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 5 columns.
-pub type MatrixViewMutXx5<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U5, ViewStorageMut<'a, T, Dynamic, U5, RStride, CStride>>;
+pub type MatrixViewMutXx5<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U5, ViewStorageMut<'a, T, Dyn, U5, RStride, CStride>>;
 /// A column-major matrix view with a number of rows chosen at runtime and 6 columns.
-pub type MatrixViewMutXx6<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U6, ViewStorageMut<'a, T, Dynamic, U6, RStride, CStride>>;
+pub type MatrixViewMutXx6<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U6, ViewStorageMut<'a, T, Dyn, U6, RStride, CStride>>;
 
 /// A column vector view with dimensions known at compile-time.
 ///
@@ -554,8 +554,8 @@ pub type SVectorViewMut<'a, T, const D: usize> =
 /// A column vector view dynamic numbers of rows and columns.
 ///
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
-pub type DVectorViewMut<'a, T, RStride = U1, CStride = Dynamic> =
-    Matrix<T, Dynamic, U1, ViewStorageMut<'a, T, Dynamic, U1, RStride, CStride>>;
+pub type DVectorViewMut<'a, T, RStride = U1, CStride = Dyn> =
+    Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 
 /// A 1D column vector view.
 ///

--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -15,7 +15,7 @@ use std::mem::MaybeUninit;
 ///
 /// An allocator is said to be:
 ///   − static:  if `R` and `C` both implement `DimName`.
-///   − dynamic: if either one (or both) of `R` or `C` is equal to `Dynamic`.
+///   − dynamic: if either one (or both) of `R` or `C` is equal to `Dyn`.
 ///
 /// Every allocator must be both static and dynamic. Though not all implementations may share the
 /// same `Buffer` type.

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -7,7 +7,7 @@ use crate::base::blas_uninit::{axcpy_uninit, gemm_uninit, gemv_uninit};
 use crate::base::constraint::{
     AreMultipliable, DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint,
 };
-use crate::base::dimension::{Const, Dim, Dynamic, U1, U2, U3, U4};
+use crate::base::dimension::{Const, Dim, Dyn, U1, U2, U3, U4};
 use crate::base::storage::{Storage, StorageMut};
 use crate::base::uninit::Init;
 use crate::base::{
@@ -890,7 +890,7 @@ where
 
         for j in 0..dim1 {
             let val = unsafe { conjugate(y.vget_unchecked(j).clone()) };
-            let subdim = Dynamic::new(dim1 - j);
+            let subdim = Dyn(dim1 - j);
             // TODO: avoid bound checks.
             self.generic_view_mut((j, j), (subdim, Const::<1>)).axpy(
                 alpha.clone() * val,

--- a/src/base/blas_uninit.rs
+++ b/src/base/blas_uninit.rs
@@ -18,7 +18,7 @@ use std::mem;
 use crate::base::constraint::{
     AreMultipliable, DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint,
 };
-use crate::base::dimension::{Dim, Dynamic, U1};
+use crate::base::dimension::{Dim, Dyn, U1};
 use crate::base::storage::{RawStorage, RawStorageMut};
 use crate::base::uninit::InitStatus;
 use crate::base::{Matrix, Scalar, Vector};
@@ -209,16 +209,16 @@ pub unsafe fn gemm_uninit<
 
     #[cfg(feature = "std")]
     {
-        // We assume large matrices will be Dynamic but small matrices static.
+        // We assume large matrices will be Dyn but small matrices static.
         // We could use matrixmultiply for large statically-sized matrices but the performance
         // threshold to activate it would be different from SMALL_DIM because our code optimizes
         // better for statically-sized matrices.
-        if R1::is::<Dynamic>()
-            || C1::is::<Dynamic>()
-            || R2::is::<Dynamic>()
-            || C2::is::<Dynamic>()
-            || R3::is::<Dynamic>()
-            || C3::is::<Dynamic>()
+        if R1::is::<Dyn>()
+            || C1::is::<Dyn>()
+            || R2::is::<Dyn>()
+            || C2::is::<Dyn>()
+            || R3::is::<Dyn>()
+            || C3::is::<Dyn>()
         {
             // matrixmultiply can be used only if the std feature is available.
             let nrows1 = y.nrows();

--- a/src/base/constraint.rs
+++ b/src/base/constraint.rs
@@ -1,6 +1,6 @@
 //! Compatibility constraints between matrix shapes, e.g., for addition or multiplication.
 
-use crate::base::dimension::{Dim, DimName, Dynamic};
+use crate::base::dimension::{Dim, DimName, Dyn};
 
 /// A type used in `where` clauses for enforcing constraints.
 #[derive(Copy, Clone, Debug)]
@@ -25,11 +25,11 @@ impl<D: Dim> DimEq<D, D> for ShapeConstraint {
     type Representative = D;
 }
 
-impl<D: DimName> DimEq<D, Dynamic> for ShapeConstraint {
+impl<D: DimName> DimEq<D, Dyn> for ShapeConstraint {
     type Representative = D;
 }
 
-impl<D: DimName> DimEq<Dynamic, D> for ShapeConstraint {
+impl<D: DimName> DimEq<Dyn, D> for ShapeConstraint {
     type Representative = D;
 }
 
@@ -47,11 +47,11 @@ macro_rules! equality_trait_decl(
             type Representative = D;
         }
 
-        impl<D: DimName> $Trait<D, Dynamic> for ShapeConstraint {
+        impl<D: DimName> $Trait<D, Dyn> for ShapeConstraint {
             type Representative = D;
         }
 
-        impl<D: DimName> $Trait<Dynamic, D> for ShapeConstraint {
+        impl<D: DimName> $Trait<Dyn, D> for ShapeConstraint {
             type Representative = D;
         }
     )*}
@@ -82,10 +82,10 @@ impl<D: Dim> SameDimension<D, D> for ShapeConstraint {
     type Representative = D;
 }
 
-impl<D: DimName> SameDimension<D, Dynamic> for ShapeConstraint {
+impl<D: DimName> SameDimension<D, Dyn> for ShapeConstraint {
     type Representative = D;
 }
 
-impl<D: DimName> SameDimension<Dynamic, D> for ShapeConstraint {
+impl<D: DimName> SameDimension<Dyn, D> for ShapeConstraint {
     type Representative = D;
 }

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -19,7 +19,7 @@ use typenum::{self, Cmp, Greater};
 use simba::scalar::{ClosedAdd, ClosedMul};
 
 use crate::base::allocator::Allocator;
-use crate::base::dimension::{Dim, DimName, Dynamic, ToTypenum};
+use crate::base::dimension::{Dim, DimName, Dyn, ToTypenum};
 use crate::base::storage::RawStorage;
 use crate::base::{
     ArrayStorage, Const, DefaultAllocator, Matrix, OMatrix, OVector, Scalar, Unit, Vector,
@@ -317,12 +317,12 @@ where
     ///
     /// # Example
     /// ```
-    /// # use nalgebra::{Dynamic, DMatrix, Matrix, Const};
+    /// # use nalgebra::{Dyn, DMatrix, Matrix, Const};
     ///
     /// let vec = vec![0, 1, 2, 3, 4, 5];
     /// let vec_ptr = vec.as_ptr();
     ///
-    /// let matrix = Matrix::from_vec_generic(Dynamic::new(vec.len()), Const::<1>, vec);
+    /// let matrix = Matrix::from_vec_generic(Dyn(vec.len()), Const::<1>, vec);
     /// let matrix_storage_ptr = matrix.data.as_vec().as_ptr();
     ///
     /// // `matrix` is backed by exactly the same `Vec` as it was constructed from.
@@ -656,35 +656,35 @@ where
 }
 
 /// # Constructors of matrices with a dynamic number of columns
-impl<T: Scalar, R: DimName> OMatrix<T, R, Dynamic>
+impl<T: Scalar, R: DimName> OMatrix<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dynamic>,
+    DefaultAllocator: Allocator<T, R, Dyn>,
 {
-    impl_constructors!(R, Dynamic;
+    impl_constructors!(R, Dyn;
                    => R: DimName;
-                   R::name(), Dynamic::new(ncols);
+                   R::name(), Dyn(ncols);
                    ncols);
 }
 
 /// # Constructors of dynamic vectors and matrices with a dynamic number of rows
-impl<T: Scalar, C: DimName> OMatrix<T, Dynamic, C>
+impl<T: Scalar, C: DimName> OMatrix<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dynamic, C>,
+    DefaultAllocator: Allocator<T, Dyn, C>,
 {
-    impl_constructors!(Dynamic, C;
+    impl_constructors!(Dyn, C;
                    => C: DimName;
-                   Dynamic::new(nrows), C::name();
+                   Dyn(nrows), C::name();
                    nrows);
 }
 
 /// # Constructors of fully dynamic matrices
-impl<T: Scalar> OMatrix<T, Dynamic, Dynamic>
+impl<T: Scalar> OMatrix<T, Dyn, Dyn>
 where
-    DefaultAllocator: Allocator<T, Dynamic, Dynamic>,
+    DefaultAllocator: Allocator<T, Dyn, Dyn>,
 {
-    impl_constructors!(Dynamic, Dynamic;
+    impl_constructors!(Dyn, Dyn;
                    ;
-                   Dynamic::new(nrows), Dynamic::new(ncols);
+                   Dyn(nrows), Dyn(ncols);
                    nrows, ncols);
 }
 
@@ -790,19 +790,19 @@ impl_constructors_from_data!(data; R, C;                  // Arguments for Matri
 R::name(), C::name();         // Arguments for `_generic` constructors.
 ); // Arguments for non-generic constructors.
 
-impl_constructors_from_data!(data; R, Dynamic;
+impl_constructors_from_data!(data; R, Dyn;
 => R: DimName;
-R::name(), Dynamic::new(data.len() / R::dim());
+R::name(), Dyn(data.len() / R::dim());
 );
 
-impl_constructors_from_data!(data; Dynamic, C;
+impl_constructors_from_data!(data; Dyn, C;
 => C: DimName;
-Dynamic::new(data.len() / C::dim()), C::name();
+Dyn(data.len() / C::dim()), C::name();
 );
 
-impl_constructors_from_data!(data; Dynamic, Dynamic;
+impl_constructors_from_data!(data; Dyn, Dyn;
                             ;
-                            Dynamic::new(nrows), Dynamic::new(ncols);
+                            Dyn(nrows), Dyn(ncols);
                             nrows, ncols);
 
 /*

--- a/src/base/construction_view.rs
+++ b/src/base/construction_view.rs
@@ -1,4 +1,4 @@
-use crate::base::dimension::{Const, Dim, DimName, Dynamic};
+use crate::base::dimension::{Const, Dim, DimName, Dyn};
 use crate::base::matrix_view::{ViewStorage, ViewStorageMut};
 use crate::base::{MatrixView, MatrixViewMut, Scalar};
 
@@ -12,7 +12,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     ///
     /// # Safety
     /// This method is unsafe because the input data array is not checked to contain enough elements.
-    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub unsafe fn from_slice_with_strides_generic_unchecked(
         data: &'a [T],
@@ -33,7 +33,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     /// Creates a matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
     /// Panics if the input data array dose not contain enough elements.
-    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub fn from_slice_with_strides_generic(
         data: &'a [T],
@@ -62,7 +62,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixView<'a, T, R, C> {
     ///
     /// # Safety
     /// This method is unsafe because the input data array is not checked to contain enough elements.
-    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub unsafe fn from_slice_generic_unchecked(
         data: &'a [T],
@@ -78,7 +78,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixView<'a, T, R, C> {
     /// Creates a matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
     /// Panics if the input data array dose not contain enough elements.
-    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub fn from_slice_generic(data: &'a [T], nrows: R, ncols: C) -> Self {
         Self::from_slice_with_strides_generic(data, nrows, ncols, Const::<1>, nrows)
@@ -103,19 +103,19 @@ macro_rules! impl_constructors(
             }
         }
 
-        impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixView<'a, T, $($Dims,)* Dynamic, Dynamic> {
+        impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixView<'a, T, $($Dims,)* Dyn, Dyn> {
             /// Creates a new matrix view with the specified strides from the given data array.
             ///
             /// Panics if `data` does not contain enough elements.
             #[inline]
             pub fn from_slice_with_strides(data: &'a [T], $($args: usize,)* rstride: usize, cstride: usize) -> Self {
-                Self::from_slice_with_strides_generic(data, $($gargs,)* Dynamic::new(rstride), Dynamic::new(cstride))
+                Self::from_slice_with_strides_generic(data, $($gargs,)* Dyn(rstride), Dyn(cstride))
             }
 
             /// Creates, without bound checking, a new matrix view with the specified strides from the given data array.
             #[inline]
             pub unsafe fn from_slice_with_strides_unchecked(data: &'a [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self {
-                Self::from_slice_with_strides_generic_unchecked(data, start, $($gargs,)* Dynamic::new(rstride), Dynamic::new(cstride))
+                Self::from_slice_with_strides_generic_unchecked(data, start, $($gargs,)* Dyn(rstride), Dyn(cstride))
             }
         }
     }
@@ -127,19 +127,19 @@ impl_constructors!(R, C;                         // Arguments for Matrix<T, ...,
 R::name(), C::name();         // Arguments for `_generic` constructors.
 ); // Arguments for non-generic constructors.
 
-impl_constructors!(R, Dynamic;
+impl_constructors!(R, Dyn;
                    => R: DimName;
-                   R::name(), Dynamic::new(ncols);
+                   R::name(), Dyn(ncols);
                    ncols);
 
-impl_constructors!(Dynamic, C;
+impl_constructors!(Dyn, C;
                    => C: DimName;
-                   Dynamic::new(nrows), C::name();
+                   Dyn(nrows), C::name();
                    nrows);
 
-impl_constructors!(Dynamic, Dynamic;
+impl_constructors!(Dyn, Dyn;
                    ;
-                   Dynamic::new(nrows), Dynamic::new(ncols);
+                   Dyn(nrows), Dyn(ncols);
                    nrows, ncols);
 
 /// # Creating mutable matrix views from `&mut [T]`
@@ -150,7 +150,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     ///
     /// # Safety
     /// This method is unsafe because the input data array is not checked to contain enough elements.
-    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub unsafe fn from_slice_with_strides_generic_unchecked(
         data: &'a mut [T],
@@ -171,7 +171,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     /// Creates a mutable matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
     /// Panics if the input data array dose not contain enough elements.
-    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub fn from_slice_with_strides_generic(
         data: &'a mut [T],
@@ -222,7 +222,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixViewMut<'a, T, R, C> {
     ///
     /// # Safety
     /// This method is unsafe because the input data array is not checked to contain enough elements.
-    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub unsafe fn from_slice_generic_unchecked(
         data: &'a mut [T],
@@ -238,7 +238,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixViewMut<'a, T, R, C> {
     /// Creates a mutable matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
     /// Panics if the input data array dose not contain enough elements.
-    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dynamic::new()`.
+    /// The generic types `R` and `C` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
     pub fn from_slice_generic(data: &'a mut [T], nrows: R, ncols: C) -> Self {
         Self::from_slice_with_strides_generic(data, nrows, ncols, Const::<1>, nrows)
@@ -263,21 +263,21 @@ macro_rules! impl_constructors_mut(
             }
         }
 
-        impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixViewMut<'a, T, $($Dims,)* Dynamic, Dynamic> {
+        impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixViewMut<'a, T, $($Dims,)* Dyn, Dyn> {
             /// Creates a new mutable matrix view with the specified strides from the given data array.
             ///
             /// Panics if `data` does not contain enough elements.
             #[inline]
             pub fn from_slice_with_strides_mut(data: &'a mut [T], $($args: usize,)* rstride: usize, cstride: usize) -> Self {
                 Self::from_slice_with_strides_generic(
-                    data, $($gargs,)* Dynamic::new(rstride), Dynamic::new(cstride))
+                    data, $($gargs,)* Dyn(rstride), Dyn(cstride))
             }
 
             /// Creates, without bound checking, a new mutable matrix view with the specified strides from the given data array.
             #[inline]
             pub unsafe fn from_slice_with_strides_unchecked(data: &'a mut [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self {
                 Self::from_slice_with_strides_generic_unchecked(
-                    data, start, $($gargs,)* Dynamic::new(rstride), Dynamic::new(cstride))
+                    data, start, $($gargs,)* Dyn(rstride), Dyn(cstride))
             }
         }
     }
@@ -289,17 +289,17 @@ impl_constructors_mut!(R, C;                         // Arguments for Matrix<T, 
 R::name(), C::name();         // Arguments for `_generic` constructors.
 ); // Arguments for non-generic constructors.
 
-impl_constructors_mut!(R, Dynamic;
+impl_constructors_mut!(R, Dyn;
                        => R: DimName;
-                       R::name(), Dynamic::new(ncols);
+                       R::name(), Dyn(ncols);
                        ncols);
 
-impl_constructors_mut!(Dynamic, C;
+impl_constructors_mut!(Dyn, C;
                        => C: DimName;
-                       Dynamic::new(nrows), C::name();
+                       Dyn(nrows), C::name();
                        nrows);
 
-impl_constructors_mut!(Dynamic, Dynamic;
+impl_constructors_mut!(Dyn, Dyn;
                        ;
-                       Dynamic::new(nrows), Dynamic::new(ncols);
+                       Dyn(nrows), Dyn(ncols);
                        nrows, ncols);

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -9,7 +9,7 @@ use simba::simd::{PrimitiveSimdValue, SimdValue};
 use crate::base::allocator::{Allocator, SameShapeAllocator};
 use crate::base::constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use crate::base::dimension::Dynamic;
+use crate::base::dimension::Dyn;
 use crate::base::dimension::{
     Const, Dim, DimName, U1, U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9,
 };
@@ -302,29 +302,29 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, T, C, RStride, CStride> From<MatrixView<'a, T, Dynamic, C, RStride, CStride>>
-    for Matrix<T, Dynamic, C, VecStorage<T, Dynamic, C>>
+impl<'a, T, C, RStride, CStride> From<MatrixView<'a, T, Dyn, C, RStride, CStride>>
+    for Matrix<T, Dyn, C, VecStorage<T, Dyn, C>>
 where
     T: Scalar,
     C: Dim,
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_view: MatrixView<'a, T, Dynamic, C, RStride, CStride>) -> Self {
+    fn from(matrix_view: MatrixView<'a, T, Dyn, C, RStride, CStride>) -> Self {
         matrix_view.into_owned()
     }
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, T, R, RStride, CStride> From<MatrixView<'a, T, R, Dynamic, RStride, CStride>>
-    for Matrix<T, R, Dynamic, VecStorage<T, R, Dynamic>>
+impl<'a, T, R, RStride, CStride> From<MatrixView<'a, T, R, Dyn, RStride, CStride>>
+    for Matrix<T, R, Dyn, VecStorage<T, R, Dyn>>
 where
     T: Scalar,
     R: DimName,
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_view: MatrixView<'a, T, R, Dynamic, RStride, CStride>) -> Self {
+    fn from(matrix_view: MatrixView<'a, T, R, Dyn, RStride, CStride>) -> Self {
         matrix_view.into_owned()
     }
 }
@@ -343,29 +343,29 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, T, C, RStride, CStride> From<MatrixViewMut<'a, T, Dynamic, C, RStride, CStride>>
-    for Matrix<T, Dynamic, C, VecStorage<T, Dynamic, C>>
+impl<'a, T, C, RStride, CStride> From<MatrixViewMut<'a, T, Dyn, C, RStride, CStride>>
+    for Matrix<T, Dyn, C, VecStorage<T, Dyn, C>>
 where
     T: Scalar,
     C: Dim,
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_view: MatrixViewMut<'a, T, Dynamic, C, RStride, CStride>) -> Self {
+    fn from(matrix_view: MatrixViewMut<'a, T, Dyn, C, RStride, CStride>) -> Self {
         matrix_view.into_owned()
     }
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, T, R, RStride, CStride> From<MatrixViewMut<'a, T, R, Dynamic, RStride, CStride>>
-    for Matrix<T, R, Dynamic, VecStorage<T, R, Dynamic>>
+impl<'a, T, R, RStride, CStride> From<MatrixViewMut<'a, T, R, Dyn, RStride, CStride>>
+    for Matrix<T, R, Dyn, VecStorage<T, R, Dyn>>
 where
     T: Scalar,
     R: DimName,
     RStride: Dim,
     CStride: Dim,
 {
-    fn from(matrix_view: MatrixViewMut<'a, T, R, Dynamic, RStride, CStride>) -> Self {
+    fn from(matrix_view: MatrixViewMut<'a, T, R, Dyn, RStride, CStride>) -> Self {
         matrix_view.into_owned()
     }
 }

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for Dynamic {
     where
         D: Deserializer<'de>,
     {
-        usize::deserialize(deserializer).map(|x| Dynamic(x))
+        usize::deserialize(deserializer).map(|x| Dynamic::new(x))
     }
 }
 

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -310,6 +310,11 @@ macro_rules! from_to_typenum (
         }
 
         impl IsNotStaticOne for $D { }
+
+        /// The constant dimension
+        #[doc = stringify!($VAL)]
+        /// .
+        pub const $D: $D = Const::<$VAL>;
     )*}
 );
 
@@ -323,3 +328,7 @@ from_to_typenum!(
     U111, 111; U112, 112; U113, 113; U114, 114; U115, 115; U116, 116; U117, 117; U118, 118; U119, 119; U120, 120; U121, 121; U122, 122; U123, 123; U124, 124; U125, 125; U126, 126;
     U127, 127
 );
+
+/// The constant dimension 1.
+// Note: We add U1 separately since it's not covered by the from_to_typenum! macro.
+pub const U1: U1 = Const::<1>;

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use crate::base::allocator::{Allocator, Reallocator};
 use crate::base::constraint::{DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use crate::base::dimension::Dynamic;
+use crate::base::dimension::Dyn;
 use crate::base::dimension::{Const, Dim, DimAdd, DimDiff, DimMin, DimMinimum, DimSub, DimSum, U1};
 use crate::base::storage::{RawStorage, RawStorageMut, ReshapableStorage};
 use crate::base::{DefaultAllocator, Matrix, OMatrix, RowVector, Scalar, Vector};
@@ -48,15 +48,15 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Creates a new matrix by extracting the given set of rows from `self`.
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[must_use]
-    pub fn select_rows<'a, I>(&self, irows: I) -> OMatrix<T, Dynamic, C>
+    pub fn select_rows<'a, I>(&self, irows: I) -> OMatrix<T, Dyn, C>
     where
         I: IntoIterator<Item = &'a usize>,
         I::IntoIter: ExactSizeIterator + Clone,
-        DefaultAllocator: Allocator<T, Dynamic, C>,
+        DefaultAllocator: Allocator<T, Dyn, C>,
     {
         let irows = irows.into_iter();
         let ncols = self.shape_generic().1;
-        let mut res = Matrix::uninit(Dynamic::new(irows.len()), ncols);
+        let mut res = Matrix::uninit(Dyn(irows.len()), ncols);
 
         // First, check that all the indices from irows are valid.
         // This will allow us to use unchecked access in the inner loop.
@@ -85,15 +85,15 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Creates a new matrix by extracting the given set of columns from `self`.
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[must_use]
-    pub fn select_columns<'a, I>(&self, icols: I) -> OMatrix<T, R, Dynamic>
+    pub fn select_columns<'a, I>(&self, icols: I) -> OMatrix<T, R, Dyn>
     where
         I: IntoIterator<Item = &'a usize>,
         I::IntoIter: ExactSizeIterator,
-        DefaultAllocator: Allocator<T, R, Dynamic>,
+        DefaultAllocator: Allocator<T, R, Dyn>,
     {
         let icols = icols.into_iter();
         let nrows = self.shape_generic().0;
-        let mut res = Matrix::uninit(nrows, Dynamic::new(icols.len()));
+        let mut res = Matrix::uninit(nrows, Dyn(icols.len()));
 
         for (destination, source) in icols.enumerate() {
             // NOTE: this is basically a copy_frow but wrapping the values insnide of MaybeUninit.
@@ -359,10 +359,10 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 
     /// Removes all columns in `indices`   
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn remove_columns_at(self, indices: &[usize]) -> OMatrix<T, R, Dynamic>
+    pub fn remove_columns_at(self, indices: &[usize]) -> OMatrix<T, R, Dyn>
     where
-        C: DimSub<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, R, Dynamic>,
+        C: DimSub<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, R, Dyn>,
     {
         let mut m = self.into_owned();
         let (nrows, ncols) = m.shape_generic();
@@ -400,7 +400,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         unsafe {
             let new_data = DefaultAllocator::reallocate_copy(
                 nrows,
-                ncols.sub(Dynamic::from_usize(offset)),
+                ncols.sub(Dyn::from_usize(offset)),
                 m.data,
             );
 
@@ -410,10 +410,10 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 
     /// Removes all rows in `indices`   
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn remove_rows_at(self, indices: &[usize]) -> OMatrix<T, Dynamic, C>
+    pub fn remove_rows_at(self, indices: &[usize]) -> OMatrix<T, Dyn, C>
     where
-        R: DimSub<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, Dynamic, C>,
+        R: DimSub<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, Dyn, C>,
     {
         let mut m = self.into_owned();
         let (nrows, ncols) = m.shape_generic();
@@ -448,7 +448,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         //         be assumed to be initialized.
         unsafe {
             let new_data = DefaultAllocator::reallocate_copy(
-                nrows.sub(Dynamic::from_usize(offset / ncols.value())),
+                nrows.sub(Dyn::from_usize(offset / ncols.value())),
                 ncols,
                 m.data,
             );
@@ -474,12 +474,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Removes `n` consecutive columns from this matrix, starting with the `i`-th (included).
     #[inline]
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn remove_columns(self, i: usize, n: usize) -> OMatrix<T, R, Dynamic>
+    pub fn remove_columns(self, i: usize, n: usize) -> OMatrix<T, R, Dyn>
     where
-        C: DimSub<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, R, Dynamic>,
+        C: DimSub<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, R, Dyn>,
     {
-        self.remove_columns_generic(i, Dynamic::new(n))
+        self.remove_columns_generic(i, Dyn(n))
     }
 
     /// Removes `nremove.value()` columns from this matrix, starting with the `i`-th (included).
@@ -569,12 +569,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Removes `n` consecutive rows from this matrix, starting with the `i`-th (included).
     #[inline]
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn remove_rows(self, i: usize, n: usize) -> OMatrix<T, Dynamic, C>
+    pub fn remove_rows(self, i: usize, n: usize) -> OMatrix<T, Dyn, C>
     where
-        R: DimSub<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, Dynamic, C>,
+        R: DimSub<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, Dyn, C>,
     {
-        self.remove_rows_generic(i, Dynamic::new(n))
+        self.remove_rows_generic(i, Dyn(n))
     }
 
     /// Removes `nremove.value()` rows from this matrix, starting with the `i`-th (included).
@@ -659,12 +659,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Inserts `n` columns filled with `val` starting at the `i-th` position.
     #[inline]
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn insert_columns(self, i: usize, n: usize, val: T) -> OMatrix<T, R, Dynamic>
+    pub fn insert_columns(self, i: usize, n: usize, val: T) -> OMatrix<T, R, Dyn>
     where
-        C: DimAdd<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, R, Dynamic>,
+        C: DimAdd<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, R, Dyn>,
     {
-        let mut res = unsafe { self.insert_columns_generic_uninitialized(i, Dynamic::new(n)) };
+        let mut res = unsafe { self.insert_columns_generic_uninitialized(i, Dyn(n)) };
         res.columns_mut(i, n)
             .fill_with(|| MaybeUninit::new(val.clone()));
 
@@ -752,12 +752,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// Inserts `n` rows filled with `val` starting at the `i-th` position.
     #[inline]
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn insert_rows(self, i: usize, n: usize, val: T) -> OMatrix<T, Dynamic, C>
+    pub fn insert_rows(self, i: usize, n: usize, val: T) -> OMatrix<T, Dyn, C>
     where
-        R: DimAdd<Dynamic, Output = Dynamic>,
-        DefaultAllocator: Reallocator<T, R, C, Dynamic, C>,
+        R: DimAdd<Dyn, Output = Dyn>,
+        DefaultAllocator: Reallocator<T, R, C, Dyn, C>,
     {
-        let mut res = unsafe { self.insert_rows_generic_uninitialized(i, Dynamic::new(n)) };
+        let mut res = unsafe { self.insert_rows_generic_uninitialized(i, Dyn(n)) };
         res.rows_mut(i, n)
             .fill_with(|| MaybeUninit::new(val.clone()));
 
@@ -815,11 +815,11 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// The values are copied such that `self[(i, j)] == result[(i, j)]`. If the result has more
     /// rows and/or columns than `self`, then the extra rows or columns are filled with `val`.
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn resize(self, new_nrows: usize, new_ncols: usize, val: T) -> OMatrix<T, Dynamic, Dynamic>
+    pub fn resize(self, new_nrows: usize, new_ncols: usize, val: T) -> OMatrix<T, Dyn, Dyn>
     where
-        DefaultAllocator: Reallocator<T, R, C, Dynamic, Dynamic>,
+        DefaultAllocator: Reallocator<T, R, C, Dyn, Dyn>,
     {
-        self.resize_generic(Dynamic::new(new_nrows), Dynamic::new(new_ncols), val)
+        self.resize_generic(Dyn(new_nrows), Dyn(new_ncols), val)
     }
 
     /// Resizes this matrix vertically, i.e., so that it contains `new_nrows` rows while keeping the same number of columns.
@@ -827,12 +827,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// The values are copied such that `self[(i, j)] == result[(i, j)]`. If the result has more
     /// rows than `self`, then the extra rows are filled with `val`.
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn resize_vertically(self, new_nrows: usize, val: T) -> OMatrix<T, Dynamic, C>
+    pub fn resize_vertically(self, new_nrows: usize, val: T) -> OMatrix<T, Dyn, C>
     where
-        DefaultAllocator: Reallocator<T, R, C, Dynamic, C>,
+        DefaultAllocator: Reallocator<T, R, C, Dyn, C>,
     {
         let ncols = self.shape_generic().1;
-        self.resize_generic(Dynamic::new(new_nrows), ncols, val)
+        self.resize_generic(Dyn(new_nrows), ncols, val)
     }
 
     /// Resizes this matrix horizontally, i.e., so that it contains `new_ncolumns` columns while keeping the same number of columns.
@@ -840,12 +840,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// The values are copied such that `self[(i, j)] == result[(i, j)]`. If the result has more
     /// columns than `self`, then the extra columns are filled with `val`.
     #[cfg(any(feature = "std", feature = "alloc"))]
-    pub fn resize_horizontally(self, new_ncols: usize, val: T) -> OMatrix<T, R, Dynamic>
+    pub fn resize_horizontally(self, new_ncols: usize, val: T) -> OMatrix<T, R, Dyn>
     where
-        DefaultAllocator: Reallocator<T, R, C, R, Dynamic>,
+        DefaultAllocator: Reallocator<T, R, C, R, Dyn>,
     {
         let nrows = self.shape_generic().0;
-        self.resize_generic(nrows, Dynamic::new(new_ncols), val)
+        self.resize_generic(nrows, Dyn(new_ncols), val)
     }
 
     /// Resizes this matrix so that it contains `R2::value()` rows and `C2::value()` columns.
@@ -962,7 +962,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// # Examples
     ///
     /// ```
-    /// # use nalgebra::{Matrix3x2, Matrix2x3, DMatrix, Const, Dynamic};
+    /// # use nalgebra::{Matrix3x2, Matrix2x3, DMatrix, Const, Dyn};
     ///
     /// let m1 = Matrix2x3::new(
     ///     1.1, 1.2, 1.3,
@@ -998,7 +998,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     ///         0.0, 0.0,
     ///     ],
     /// );
-    /// let reshaped = dm1.reshape_generic(Dynamic::new(6), Dynamic::new(2));
+    /// let reshaped = dm1.reshape_generic(Dyn(6), Dyn(2));
     /// assert_eq!(reshaped, dm2);
     /// ```
     pub fn reshape_generic<R2, C2>(
@@ -1018,7 +1018,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 
 /// # In-place resizing
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: Scalar> OMatrix<T, Dynamic, Dynamic> {
+impl<T: Scalar> OMatrix<T, Dyn, Dyn> {
     /// Resizes this matrix in-place.
     ///
     /// The values are copied such that `self[(i, j)] == result[(i, j)]`. If the result has more
@@ -1027,7 +1027,7 @@ impl<T: Scalar> OMatrix<T, Dynamic, Dynamic> {
     /// Defined only for owned fully-dynamic matrices, i.e., `DMatrix`.
     pub fn resize_mut(&mut self, new_nrows: usize, new_ncols: usize, val: T)
     where
-        DefaultAllocator: Reallocator<T, Dynamic, Dynamic, Dynamic, Dynamic>,
+        DefaultAllocator: Reallocator<T, Dyn, Dyn, Dyn, Dyn>,
     {
         // TODO: avoid the clone.
         *self = self.clone().resize(new_nrows, new_ncols, val);
@@ -1035,9 +1035,9 @@ impl<T: Scalar> OMatrix<T, Dynamic, Dynamic> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: Scalar, C: Dim> OMatrix<T, Dynamic, C>
+impl<T: Scalar, C: Dim> OMatrix<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dynamic, C>,
+    DefaultAllocator: Allocator<T, Dyn, C>,
 {
     /// Changes the number of rows of this matrix in-place.
     ///
@@ -1048,7 +1048,7 @@ where
     #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn resize_vertically_mut(&mut self, new_nrows: usize, val: T)
     where
-        DefaultAllocator: Reallocator<T, Dynamic, C, Dynamic, C>,
+        DefaultAllocator: Reallocator<T, Dyn, C, Dyn, C>,
     {
         // TODO: avoid the clone.
         *self = self.clone().resize_vertically(new_nrows, val);
@@ -1056,9 +1056,9 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: Scalar, R: Dim> OMatrix<T, R, Dynamic>
+impl<T: Scalar, R: Dim> OMatrix<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dynamic>,
+    DefaultAllocator: Allocator<T, R, Dyn>,
 {
     /// Changes the number of column of this matrix in-place.
     ///
@@ -1069,7 +1069,7 @@ where
     #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn resize_horizontally_mut(&mut self, new_ncols: usize, val: T)
     where
-        DefaultAllocator: Reallocator<T, R, Dynamic, R, Dynamic>,
+        DefaultAllocator: Reallocator<T, R, Dyn, R, Dyn>,
     {
         // TODO: avoid the clone.
         *self = self.clone().resize_horizontally(new_ncols, val);
@@ -1167,7 +1167,7 @@ unsafe fn extend_rows<T>(data: &mut [T], nrows: usize, ncols: usize, i: usize, n
 /// Extend the number of columns of the `Matrix` with elements from
 /// a given iterator.
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T, R, S> Extend<T> for Matrix<T, R, Dynamic, S>
+impl<T, R, S> Extend<T> for Matrix<T, R, Dyn, S>
 where
     T: Scalar,
     R: Dim,
@@ -1178,7 +1178,7 @@ where
     ///
     /// # Example
     /// ```
-    /// # use nalgebra::{DMatrix, Dynamic, Matrix, OMatrix, Matrix3};
+    /// # use nalgebra::{DMatrix, Dyn, Matrix, OMatrix, Matrix3};
     ///
     /// let data = vec![0, 1, 2,      // column 1
     ///                 3, 4, 5];     // column 2
@@ -1198,7 +1198,7 @@ where
     /// `Matrix`.
     ///
     /// ```should_panic
-    /// # use nalgebra::{DMatrix, Dynamic, OMatrix};
+    /// # use nalgebra::{DMatrix, Dyn, OMatrix};
     /// let data = vec![0, 1, 2,  // column 1
     ///                 3, 4, 5]; // column 2
     ///
@@ -1215,7 +1215,7 @@ where
 /// Extend the number of rows of the `Vector` with elements from
 /// a given iterator.
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T, S> Extend<T> for Matrix<T, Dynamic, U1, S>
+impl<T, S> Extend<T> for Matrix<T, Dyn, U1, S>
 where
     T: Scalar,
     S: Extend<T>,
@@ -1236,7 +1236,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T, R, S, RV, SV> Extend<Vector<T, RV, SV>> for Matrix<T, R, Dynamic, S>
+impl<T, R, S, RV, SV> Extend<Vector<T, RV, SV>> for Matrix<T, R, Dyn, S>
 where
     T: Scalar,
     R: Dim,

--- a/src/base/indexing.rs
+++ b/src/base/indexing.rs
@@ -3,7 +3,7 @@
 
 use crate::base::storage::{RawStorage, RawStorageMut};
 use crate::base::{
-    Const, Dim, DimDiff, DimName, DimSub, Dynamic, Matrix, MatrixView, MatrixViewMut, Scalar, U1,
+    Const, Dim, DimDiff, DimName, DimSub, Dyn, Matrix, MatrixView, MatrixViewMut, Scalar, U1,
 };
 
 use std::ops;
@@ -49,7 +49,7 @@ fn dimrange_usize() {
 }
 
 impl<D: Dim> DimRange<D> for ops::Range<usize> {
-    type Length = Dynamic;
+    type Length = Dyn;
 
     #[inline(always)]
     fn lower(&self, _: D) -> usize {
@@ -58,7 +58,7 @@ impl<D: Dim> DimRange<D> for ops::Range<usize> {
 
     #[inline(always)]
     fn length(&self, _: D) -> Self::Length {
-        Dynamic::new(self.end.saturating_sub(self.start))
+        Dyn(self.end.saturating_sub(self.start))
     }
 
     #[inline(always)]
@@ -74,24 +74,24 @@ fn dimrange_range_usize() {
     assert!(DimRange::contained_by(&(0..1), Const::<1>));
     assert!(DimRange::contained_by(
         &((usize::MAX - 1)..usize::MAX),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert_eq!(
-        DimRange::length(&((usize::MAX - 1)..usize::MAX), Dynamic::new(usize::MAX)),
-        Dynamic::new(1)
+        DimRange::length(&((usize::MAX - 1)..usize::MAX), Dyn(usize::MAX)),
+        Dyn(1)
     );
     assert_eq!(
-        DimRange::length(&(usize::MAX..(usize::MAX - 1)), Dynamic::new(usize::MAX)),
-        Dynamic::new(0)
+        DimRange::length(&(usize::MAX..(usize::MAX - 1)), Dyn(usize::MAX)),
+        Dyn(0)
     );
     assert_eq!(
-        DimRange::length(&(usize::MAX..usize::MAX), Dynamic::new(usize::MAX)),
-        Dynamic::new(0)
+        DimRange::length(&(usize::MAX..usize::MAX), Dyn(usize::MAX)),
+        Dyn(0)
     );
 }
 
 impl<D: Dim> DimRange<D> for ops::RangeFrom<usize> {
-    type Length = Dynamic;
+    type Length = Dyn;
 
     #[inline(always)]
     fn lower(&self, _: D) -> usize {
@@ -116,16 +116,13 @@ fn dimrange_rangefrom_usize() {
     assert!(DimRange::contained_by(&(0..), Const::<1>));
     assert!(DimRange::contained_by(
         &((usize::MAX - 1)..),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert_eq!(
-        DimRange::length(&((usize::MAX - 1)..), Dynamic::new(usize::MAX)),
-        Dynamic::new(1)
+        DimRange::length(&((usize::MAX - 1)..), Dyn(usize::MAX)),
+        Dyn(1)
     );
-    assert_eq!(
-        DimRange::length(&(usize::MAX..), Dynamic::new(usize::MAX)),
-        Dynamic::new(0)
-    );
+    assert_eq!(DimRange::length(&(usize::MAX..), Dyn(usize::MAX)), Dyn(0));
 }
 
 impl<D: Dim, T: Dim> DimRange<D> for ops::RangeFrom<T>
@@ -181,7 +178,7 @@ fn dimrange_rangefull() {
 }
 
 impl<D: Dim> DimRange<D> for ops::RangeInclusive<usize> {
-    type Length = Dynamic;
+    type Length = Dyn;
 
     #[inline(always)]
     fn lower(&self, _: D) -> usize {
@@ -190,7 +187,7 @@ impl<D: Dim> DimRange<D> for ops::RangeInclusive<usize> {
 
     #[inline(always)]
     fn length(&self, _: D) -> Self::Length {
-        Dynamic::new(if self.end() < self.start() {
+        Dyn(if self.end() < self.start() {
             0
         } else {
             self.end().wrapping_sub(self.start().wrapping_sub(1))
@@ -209,33 +206,33 @@ fn dimrange_rangeinclusive_usize() {
     assert!(DimRange::contained_by(&(0..=0), Const::<1>));
     assert!(!DimRange::contained_by(
         &(usize::MAX..=usize::MAX),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert!(!DimRange::contained_by(
         &((usize::MAX - 1)..=usize::MAX),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert!(DimRange::contained_by(
         &((usize::MAX - 1)..=(usize::MAX - 1)),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
-    assert_eq!(DimRange::length(&(0..=0), Const::<1>), Dynamic::new(1));
+    assert_eq!(DimRange::length(&(0..=0), Const::<1>), Dyn(1));
     assert_eq!(
-        DimRange::length(&((usize::MAX - 1)..=usize::MAX), Dynamic::new(usize::MAX)),
-        Dynamic::new(2)
+        DimRange::length(&((usize::MAX - 1)..=usize::MAX), Dyn(usize::MAX)),
+        Dyn(2)
     );
     assert_eq!(
-        DimRange::length(&(usize::MAX..=(usize::MAX - 1)), Dynamic::new(usize::MAX)),
-        Dynamic::new(0)
+        DimRange::length(&(usize::MAX..=(usize::MAX - 1)), Dyn(usize::MAX)),
+        Dyn(0)
     );
     assert_eq!(
-        DimRange::length(&(usize::MAX..=usize::MAX), Dynamic::new(usize::MAX)),
-        Dynamic::new(1)
+        DimRange::length(&(usize::MAX..=usize::MAX), Dyn(usize::MAX)),
+        Dyn(1)
     );
 }
 
 impl<D: Dim> DimRange<D> for ops::RangeTo<usize> {
-    type Length = Dynamic;
+    type Length = Dyn;
 
     #[inline(always)]
     fn lower(&self, _: D) -> usize {
@@ -244,7 +241,7 @@ impl<D: Dim> DimRange<D> for ops::RangeTo<usize> {
 
     #[inline(always)]
     fn length(&self, _: D) -> Self::Length {
-        Dynamic::new(self.end)
+        Dyn(self.end)
     }
 
     #[inline(always)]
@@ -260,20 +257,20 @@ fn dimrange_rangeto_usize() {
     assert!(DimRange::contained_by(&(..0), Const::<1>));
     assert!(DimRange::contained_by(
         &(..(usize::MAX - 1)),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert_eq!(
-        DimRange::length(&(..(usize::MAX - 1)), Dynamic::new(usize::MAX)),
-        Dynamic::new(usize::MAX - 1)
+        DimRange::length(&(..(usize::MAX - 1)), Dyn(usize::MAX)),
+        Dyn(usize::MAX - 1)
     );
     assert_eq!(
-        DimRange::length(&(..usize::MAX), Dynamic::new(usize::MAX)),
-        Dynamic::new(usize::MAX)
+        DimRange::length(&(..usize::MAX), Dyn(usize::MAX)),
+        Dyn(usize::MAX)
     );
 }
 
 impl<D: Dim> DimRange<D> for ops::RangeToInclusive<usize> {
-    type Length = Dynamic;
+    type Length = Dyn;
 
     #[inline(always)]
     fn lower(&self, _: D) -> usize {
@@ -282,7 +279,7 @@ impl<D: Dim> DimRange<D> for ops::RangeToInclusive<usize> {
 
     #[inline(always)]
     fn length(&self, _: D) -> Self::Length {
-        Dynamic::new(self.end + 1)
+        Dyn(self.end + 1)
     }
 
     #[inline(always)]
@@ -296,17 +293,14 @@ fn dimrange_rangetoinclusive_usize() {
     assert!(!DimRange::contained_by(&(..=0), Const::<0>));
     assert!(!DimRange::contained_by(&(..=1), Const::<0>));
     assert!(DimRange::contained_by(&(..=0), Const::<1>));
-    assert!(!DimRange::contained_by(
-        &(..=(usize::MAX)),
-        Dynamic::new(usize::MAX)
-    ));
+    assert!(!DimRange::contained_by(&(..=(usize::MAX)), Dyn(usize::MAX)));
     assert!(DimRange::contained_by(
         &(..=(usize::MAX - 1)),
-        Dynamic::new(usize::MAX)
+        Dyn(usize::MAX)
     ));
     assert_eq!(
-        DimRange::length(&(..=(usize::MAX - 1)), Dynamic::new(usize::MAX)),
-        Dynamic::new(usize::MAX)
+        DimRange::length(&(..=(usize::MAX - 1)), Dyn(usize::MAX)),
+        Dyn(usize::MAX)
     );
 }
 
@@ -742,12 +736,12 @@ macro_rules! impl_index_pairs {
 impl_index_pairs! {
     index R with {
         [<> usize                         =>  U1],
-        [<> ops::Range<usize>             =>  Dynamic],
-        [<> ops::RangeFrom<usize>         =>  Dynamic],
+        [<> ops::Range<usize>             =>  Dyn],
+        [<> ops::RangeFrom<usize>         =>  Dyn],
         [<> ops::RangeFull                =>  R],
-        [<> ops::RangeInclusive<usize>    =>  Dynamic],
-        [<> ops::RangeTo<usize>           =>  Dynamic],
-        [<> ops::RangeToInclusive<usize>  =>  Dynamic],
+        [<> ops::RangeInclusive<usize>    =>  Dyn],
+        [<> ops::RangeTo<usize>           =>  Dyn],
+        [<> ops::RangeToInclusive<usize>  =>  Dyn],
 
         [<I: Dim> ops::RangeFrom<I>
           =>  DimDiff<R, I>
@@ -755,12 +749,12 @@ impl_index_pairs! {
     }
     index C with {
         [<> usize                         =>  U1],
-        [<> ops::Range<usize>             =>  Dynamic],
-        [<> ops::RangeFrom<usize>         =>  Dynamic],
+        [<> ops::Range<usize>             =>  Dyn],
+        [<> ops::RangeFrom<usize>         =>  Dyn],
         [<> ops::RangeFull                =>  C],
-        [<> ops::RangeInclusive<usize>    =>  Dynamic],
-        [<> ops::RangeTo<usize>           =>  Dynamic],
-        [<> ops::RangeToInclusive<usize>  =>  Dynamic],
+        [<> ops::RangeInclusive<usize>    =>  Dyn],
+        [<> ops::RangeTo<usize>           =>  Dyn],
+        [<> ops::RangeToInclusive<usize>  =>  Dyn],
 
         [<J: DimName> ops::RangeFrom<J>
           =>  DimDiff<C, J>

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -32,7 +32,7 @@ use crate::{ArrayStorage, SMatrix, SimdComplexField, Storage, UninitMatrix};
 use crate::storage::IsContiguous;
 use crate::uninit::{Init, InitStatus, Uninit};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use crate::{DMatrix, DVector, Dynamic, RowDVector, VecStorage};
+use crate::{DMatrix, DVector, Dyn, RowDVector, VecStorage};
 use std::mem::MaybeUninit;
 
 /// A square matrix.
@@ -146,13 +146,13 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// - type-level unsigned integer constants (e.g. `U1024`, `U10000`) from the `typenum::` crate.
 /// Using those, you will not get error messages as nice as for numbers smaller than 128 defined on
 /// the `nalgebra::` module.
-/// - the special value `Dynamic` from the `nalgebra::` root module. This indicates that the
+/// - the special value `Dyn` from the `nalgebra::` root module. This indicates that the
 /// specified dimension is not known at compile-time. Note that this will generally imply that the
 /// matrix data storage `S` performs a dynamic allocation and contains extra metadata for the
 /// matrix shape.
 ///
-/// Note that mixing `Dynamic` with type-level unsigned integers is allowed. Actually, a
-/// dynamically-sized column vector should be represented as a `Matrix<T, Dynamic, U1, S>` (given
+/// Note that mixing `Dyn` with type-level unsigned integers is allowed. Actually, a
+/// dynamically-sized column vector should be represented as a `Matrix<T, Dyn, U1, S>` (given
 /// some concrete types for `T` and a compatible data storage type `S`).
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -341,7 +341,7 @@ impl<T> DMatrix<T> {
     ///
     /// This method exists primarily as a workaround for the fact that `from_data` can not
     /// work in `const fn` contexts.
-    pub const fn from_vec_storage(storage: VecStorage<T, Dynamic, Dynamic>) -> Self {
+    pub const fn from_vec_storage(storage: VecStorage<T, Dyn, Dyn>) -> Self {
         // This is sound because the dimensions of the matrix and the storage are guaranteed
         // to be the same
         unsafe { Self::from_data_statically_unchecked(storage) }
@@ -356,7 +356,7 @@ impl<T> DVector<T> {
     ///
     /// This method exists primarily as a workaround for the fact that `from_data` can not
     /// work in `const fn` contexts.
-    pub const fn from_vec_storage(storage: VecStorage<T, Dynamic, U1>) -> Self {
+    pub const fn from_vec_storage(storage: VecStorage<T, Dyn, U1>) -> Self {
         // This is sound because the dimensions of the matrix and the storage are guaranteed
         // to be the same
         unsafe { Self::from_data_statically_unchecked(storage) }
@@ -371,7 +371,7 @@ impl<T> RowDVector<T> {
     ///
     /// This method exists primarily as a workaround for the fact that `from_data` can not
     /// work in `const fn` contexts.
-    pub const fn from_vec_storage(storage: VecStorage<T, U1, Dynamic>) -> Self {
+    pub const fn from_vec_storage(storage: VecStorage<T, U1, Dyn>) -> Self {
         // This is sound because the dimensions of the matrix and the storage are guaranteed
         // to be the same
         unsafe { Self::from_data_statically_unchecked(storage) }
@@ -417,7 +417,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         (nrows.value(), ncols.value())
     }
 
-    /// The shape of this matrix wrapped into their representative types (`Const` or `Dynamic`).
+    /// The shape of this matrix wrapped into their representative types (`Const` or `Dyn`).
     #[inline]
     #[must_use]
     pub fn shape_generic(&self) -> (R, C) {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -4,7 +4,7 @@ use std::slice;
 
 use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
-use crate::base::dimension::{Const, Dim, DimName, Dynamic, IsNotStaticOne, U1};
+use crate::base::dimension::{Const, Dim, DimName, Dyn, IsNotStaticOne, U1};
 use crate::base::iter::MatrixIter;
 use crate::base::storage::{IsContiguous, Owned, RawStorage, RawStorageMut, Storage};
 use crate::base::{Matrix, Scalar};
@@ -60,8 +60,8 @@ macro_rules! view_storage_impl (
             }
         }
 
-        // Dynamic is arbitrary. It's just to be able to call the constructors with `Slice::`
-        impl<'a, T, R: Dim, C: Dim> $T<'a, T, R, C, Dynamic, Dynamic> {
+        // Dyn is arbitrary. It's just to be able to call the constructors with `Slice::`
+        impl<'a, T, R: Dim, C: Dim> $T<'a, T, R, C, Dyn, Dyn> {
             /// Create a new matrix view without bounds checking.
             #[inline]
             pub unsafe fn new_unchecked<RStor, CStor, S>(storage: $SRef, start: (usize, usize), shape: (R, C))
@@ -180,7 +180,7 @@ macro_rules! storage_impl(
             #[inline]
             fn is_contiguous(&self) -> bool {
                 // Common cases that can be deduced at compile-time even if one of the dimensions
-                // is Dynamic.
+                // is Dyn.
                 if (RStride::is::<U1>() && C::is::<U1>()) || // Column vector.
                    (CStride::is::<U1>() && R::is::<U1>()) {  // Row vector.
                     true
@@ -325,24 +325,24 @@ macro_rules! matrix_view_impl (
 
         /// Returns a view containing the `n` first elements of the i-th row of this matrix.
         #[inline]
-        pub fn $row_part($me: $Me, i: usize, n: usize) -> $MatrixView<'_, T, U1, Dynamic, S::RStride, S::CStride> {
-            $me.$generic_view((i, 0), (Const::<1>, Dynamic::new(n)))
+        pub fn $row_part($me: $Me, i: usize, n: usize) -> $MatrixView<'_, T, U1, Dyn, S::RStride, S::CStride> {
+            $me.$generic_view((i, 0), (Const::<1>, Dyn(n)))
         }
 
         /// Extracts from this matrix a set of consecutive rows.
         #[inline]
         pub fn $rows($me: $Me, first_row: usize, nrows: usize)
-            -> $MatrixView<'_, T, Dynamic, C, S::RStride, S::CStride> {
+            -> $MatrixView<'_, T, Dyn, C, S::RStride, S::CStride> {
 
-            $me.$rows_generic(first_row, Dynamic::new(nrows))
+            $me.$rows_generic(first_row, Dyn(nrows))
         }
 
         /// Extracts from this matrix a set of consecutive rows regularly skipping `step` rows.
         #[inline]
         pub fn $rows_with_step($me: $Me, first_row: usize, nrows: usize, step: usize)
-            -> $MatrixView<'_, T, Dynamic, C, Dynamic, S::CStride> {
+            -> $MatrixView<'_, T, Dyn, C, Dyn, S::CStride> {
 
-            $me.$rows_generic_with_step(first_row, Dynamic::new(nrows), step)
+            $me.$rows_generic_with_step(first_row, Dyn(nrows), step)
         }
 
         /// Extracts a compile-time number of consecutive rows from this matrix.
@@ -357,7 +357,7 @@ macro_rules! matrix_view_impl (
         /// rows.
         #[inline]
         pub fn $fixed_rows_with_step<const RVIEW: usize>($me: $Me, first_row: usize, step: usize)
-            -> $MatrixView<'_, T, Const<RVIEW>, C, Dynamic, S::CStride> {
+            -> $MatrixView<'_, T, Const<RVIEW>, C, Dyn, S::CStride> {
 
             $me.$rows_generic_with_step(first_row, Const::<RVIEW>, step)
         }
@@ -383,14 +383,14 @@ macro_rules! matrix_view_impl (
         /// argument may or may not be values known at compile-time.
         #[inline]
         pub fn $rows_generic_with_step<RView>($me: $Me, row_start: usize, nrows: RView, step: usize)
-            -> $MatrixView<'_, T, RView, C, Dynamic, S::CStride>
+            -> $MatrixView<'_, T, RView, C, Dyn, S::CStride>
             where RView: Dim {
 
             let my_shape   = $me.shape_generic();
             let my_strides = $me.data.strides();
             $me.assert_view_index((row_start, 0), (nrows.value(), my_shape.1.value()), (step, 0));
 
-            let strides = (Dynamic::new((step + 1) * my_strides.0.value()), my_strides.1);
+            let strides = (Dyn((step + 1) * my_strides.0.value()), my_strides.1);
             let shape   = (nrows, my_shape.1);
 
             unsafe {
@@ -412,25 +412,25 @@ macro_rules! matrix_view_impl (
 
         /// Returns a view containing the `n` first elements of the i-th column of this matrix.
         #[inline]
-        pub fn $column_part($me: $Me, i: usize, n: usize) -> $MatrixView<'_, T, Dynamic, U1, S::RStride, S::CStride> {
-            $me.$generic_view((0, i), (Dynamic::new(n), Const::<1>))
+        pub fn $column_part($me: $Me, i: usize, n: usize) -> $MatrixView<'_, T, Dyn, U1, S::RStride, S::CStride> {
+            $me.$generic_view((0, i), (Dyn(n), Const::<1>))
         }
 
         /// Extracts from this matrix a set of consecutive columns.
         #[inline]
         pub fn $columns($me: $Me, first_col: usize, ncols: usize)
-            -> $MatrixView<'_, T, R, Dynamic, S::RStride, S::CStride> {
+            -> $MatrixView<'_, T, R, Dyn, S::RStride, S::CStride> {
 
-            $me.$columns_generic(first_col, Dynamic::new(ncols))
+            $me.$columns_generic(first_col, Dyn(ncols))
         }
 
         /// Extracts from this matrix a set of consecutive columns regularly skipping `step`
         /// columns.
         #[inline]
         pub fn $columns_with_step($me: $Me, first_col: usize, ncols: usize, step: usize)
-            -> $MatrixView<'_, T, R, Dynamic, S::RStride, Dynamic> {
+            -> $MatrixView<'_, T, R, Dyn, S::RStride, Dyn> {
 
-            $me.$columns_generic_with_step(first_col, Dynamic::new(ncols), step)
+            $me.$columns_generic_with_step(first_col, Dyn(ncols), step)
         }
 
         /// Extracts a compile-time number of consecutive columns from this matrix.
@@ -445,7 +445,7 @@ macro_rules! matrix_view_impl (
         /// `step` columns.
         #[inline]
         pub fn $fixed_columns_with_step<const CVIEW: usize>($me: $Me, first_col: usize, step: usize)
-            -> $MatrixView<'_, T, R, Const<CVIEW>, S::RStride, Dynamic> {
+            -> $MatrixView<'_, T, R, Const<CVIEW>, S::RStride, Dyn> {
 
             $me.$columns_generic_with_step(first_col, Const::<CVIEW>, step)
         }
@@ -471,14 +471,14 @@ macro_rules! matrix_view_impl (
         /// or may not be values known at compile-time.
         #[inline]
         pub fn $columns_generic_with_step<CView: Dim>($me: $Me, first_col: usize, ncols: CView, step: usize)
-            -> $MatrixView<'_, T, R, CView, S::RStride, Dynamic> {
+            -> $MatrixView<'_, T, R, CView, S::RStride, Dyn> {
 
             let my_shape   = $me.shape_generic();
             let my_strides = $me.data.strides();
 
             $me.assert_view_index((0, first_col), (my_shape.0.value(), ncols.value()), (0, step));
 
-            let strides = (my_strides.0, Dynamic::new((step + 1) * my_strides.1.value()));
+            let strides = (my_strides.0, Dyn((step + 1) * my_strides.1.value()));
             let shape   = (my_shape.0, ncols);
 
             unsafe {
@@ -497,7 +497,7 @@ macro_rules! matrix_view_impl (
         #[inline]
         #[deprecated = slice_deprecation_note!($view)]
         pub fn $slice($me: $Me, start: (usize, usize), shape: (usize, usize))
-            -> $MatrixView<'_, T, Dynamic, Dynamic, S::RStride, S::CStride> {
+            -> $MatrixView<'_, T, Dyn, Dyn, S::RStride, S::CStride> {
             $me.$view(start, shape)
         }
 
@@ -505,10 +505,10 @@ macro_rules! matrix_view_impl (
         /// consecutive elements.
         #[inline]
         pub fn $view($me: $Me, start: (usize, usize), shape: (usize, usize))
-            -> $MatrixView<'_, T, Dynamic, Dynamic, S::RStride, S::CStride> {
+            -> $MatrixView<'_, T, Dyn, Dyn, S::RStride, S::CStride> {
 
             $me.assert_view_index(start, shape, (0, 0));
-            let shape = (Dynamic::new(shape.0), Dynamic::new(shape.1));
+            let shape = (Dyn(shape.0), Dyn(shape.1));
 
             unsafe {
                 let data = $ViewStorage::new_unchecked($data, start, shape);
@@ -523,7 +523,7 @@ macro_rules! matrix_view_impl (
         #[inline]
         #[deprecated = slice_deprecation_note!($view_with_steps)]
         pub fn $slice_with_steps($me: $Me, start: (usize, usize), shape: (usize, usize), steps: (usize, usize))
-            -> $MatrixView<'_, T, Dynamic, Dynamic, Dynamic, Dynamic> {
+            -> $MatrixView<'_, T, Dyn, Dyn, Dyn, Dyn> {
             $me.$view_with_steps(start, shape, steps)
         }
 
@@ -533,8 +533,8 @@ macro_rules! matrix_view_impl (
         /// original matrix.
         #[inline]
         pub fn $view_with_steps($me: $Me, start: (usize, usize), shape: (usize, usize), steps: (usize, usize))
-            -> $MatrixView<'_, T, Dynamic, Dynamic, Dynamic, Dynamic> {
-            let shape = (Dynamic::new(shape.0), Dynamic::new(shape.1));
+            -> $MatrixView<'_, T, Dyn, Dyn, Dyn, Dyn> {
+            let shape = (Dyn(shape.0), Dyn(shape.1));
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
@@ -569,7 +569,7 @@ macro_rules! matrix_view_impl (
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view_with_steps)]
         pub fn $fixed_slice_with_steps<const RVIEW: usize, const CVIEW: usize>($me: $Me, start: (usize, usize), steps: (usize, usize))
-            -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, Dynamic, Dynamic> {
+            -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, Dyn, Dyn> {
             $me.$fixed_view_with_steps(start, steps)
         }
 
@@ -579,7 +579,7 @@ macro_rules! matrix_view_impl (
         /// the original matrix.
         #[inline]
         pub fn $fixed_view_with_steps<const RVIEW: usize, const CVIEW: usize>($me: $Me, start: (usize, usize), steps: (usize, usize))
-            -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, Dynamic, Dynamic> {
+            -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, Dyn, Dyn> {
             let shape = (Const::<RVIEW>, Const::<CVIEW>);
             $me.$generic_view_with_steps(start, shape, steps)
         }
@@ -616,7 +616,7 @@ macro_rules! matrix_view_impl (
                                                          start: (usize, usize),
                                                          shape: (RView, CView),
                                                          steps: (usize, usize))
-            -> $MatrixView<'_, T, RView, CView, Dynamic, Dynamic>
+            -> $MatrixView<'_, T, RView, CView, Dyn, Dyn>
             where RView: Dim,
                   CView: Dim {
             $me.$generic_view_with_steps(start, shape, steps)
@@ -628,15 +628,15 @@ macro_rules! matrix_view_impl (
                                                          start: (usize, usize),
                                                          shape: (RView, CView),
                                                          steps: (usize, usize))
-            -> $MatrixView<'_, T, RView, CView, Dynamic, Dynamic>
+            -> $MatrixView<'_, T, RView, CView, Dyn, Dyn>
             where RView: Dim,
                   CView: Dim {
 
             $me.assert_view_index(start, (shape.0.value(), shape.1.value()), steps);
 
             let my_strides = $me.data.strides();
-            let strides    = (Dynamic::new((steps.0 + 1) * my_strides.0.value()),
-                              Dynamic::new((steps.1 + 1) * my_strides.1.value()));
+            let strides    = (Dyn((steps.0 + 1) * my_strides.0.value()),
+                              Dyn((steps.1 + 1) * my_strides.1.value()));
 
             unsafe {
                 let data = $ViewStorage::new_with_strides_unchecked($data, start, shape, strides);
@@ -860,7 +860,7 @@ impl<D: Dim> DimRange<D> for usize {
 }
 
 impl<D: Dim> DimRange<D> for Range<usize> {
-    type Size = Dynamic;
+    type Size = Dyn;
 
     #[inline(always)]
     fn begin(&self, _: D) -> usize {
@@ -874,12 +874,12 @@ impl<D: Dim> DimRange<D> for Range<usize> {
 
     #[inline(always)]
     fn size(&self, _: D) -> Self::Size {
-        Dynamic::new(self.end - self.start)
+        Dyn(self.end - self.start)
     }
 }
 
 impl<D: Dim> DimRange<D> for RangeFrom<usize> {
-    type Size = Dynamic;
+    type Size = Dyn;
 
     #[inline(always)]
     fn begin(&self, _: D) -> usize {
@@ -893,12 +893,12 @@ impl<D: Dim> DimRange<D> for RangeFrom<usize> {
 
     #[inline(always)]
     fn size(&self, dim: D) -> Self::Size {
-        Dynamic::new(dim.value() - self.start)
+        Dyn(dim.value() - self.start)
     }
 }
 
 impl<D: Dim> DimRange<D> for RangeTo<usize> {
-    type Size = Dynamic;
+    type Size = Dyn;
 
     #[inline(always)]
     fn begin(&self, _: D) -> usize {
@@ -912,7 +912,7 @@ impl<D: Dim> DimRange<D> for RangeTo<usize> {
 
     #[inline(always)]
     fn size(&self, _: D) -> Self::Size {
-        Dynamic::new(self.end)
+        Dyn(self.end)
     }
 }
 
@@ -936,7 +936,7 @@ impl<D: Dim> DimRange<D> for RangeFull {
 }
 
 impl<D: Dim> DimRange<D> for RangeInclusive<usize> {
-    type Size = Dynamic;
+    type Size = Dyn;
 
     #[inline(always)]
     fn begin(&self, _: D) -> usize {
@@ -950,7 +950,7 @@ impl<D: Dim> DimRange<D> for RangeInclusive<usize> {
 
     #[inline(always)]
     fn size(&self, _: D) -> Self::Size {
-        Dynamic::new(*self.end() + 1 - *self.start())
+        Dyn(*self.end() + 1 - *self.start())
     }
 }
 

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -11,7 +11,7 @@ use crate::base::blas_uninit::gemm_uninit;
 use crate::base::constraint::{
     AreMultipliable, DimEq, SameNumberOfColumns, SameNumberOfRows, ShapeConstraint,
 };
-use crate::base::dimension::{Dim, DimMul, DimName, DimProd, Dynamic};
+use crate::base::dimension::{Dim, DimMul, DimName, DimProd, Dyn};
 use crate::base::storage::{Storage, StorageMut};
 use crate::base::uninit::Uninit;
 use crate::base::{DefaultAllocator, Matrix, MatrixSum, OMatrix, Scalar, VectorView};
@@ -374,10 +374,10 @@ where
     }
 }
 
-impl<T, C: Dim> iter::Sum for OMatrix<T, Dynamic, C>
+impl<T, C: Dim> iter::Sum for OMatrix<T, Dyn, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, Dynamic, C>,
+    DefaultAllocator: Allocator<T, Dyn, C>,
 {
     /// # Example
     /// ```
@@ -395,7 +395,7 @@ where
     /// # use nalgebra::DMatrix;
     /// iter::empty::<DMatrix<f64>>().sum::<DMatrix<f64>>(); // panics!
     /// ```
-    fn sum<I: Iterator<Item = OMatrix<T, Dynamic, C>>>(mut iter: I) -> OMatrix<T, Dynamic, C> {
+    fn sum<I: Iterator<Item = OMatrix<T, Dyn, C>>>(mut iter: I) -> OMatrix<T, Dyn, C> {
         if let Some(first) = iter.next() {
             iter.fold(first, |acc, x| acc + x)
         } else {
@@ -414,10 +414,10 @@ where
     }
 }
 
-impl<'a, T, C: Dim> iter::Sum<&'a OMatrix<T, Dynamic, C>> for OMatrix<T, Dynamic, C>
+impl<'a, T, C: Dim> iter::Sum<&'a OMatrix<T, Dyn, C>> for OMatrix<T, Dyn, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, Dynamic, C>,
+    DefaultAllocator: Allocator<T, Dyn, C>,
 {
     /// # Example
     /// ```
@@ -435,7 +435,7 @@ where
     /// # use nalgebra::DMatrix;
     /// iter::empty::<&DMatrix<f64>>().sum::<DMatrix<f64>>(); // panics!
     /// ```
-    fn sum<I: Iterator<Item = &'a OMatrix<T, Dynamic, C>>>(mut iter: I) -> OMatrix<T, Dynamic, C> {
+    fn sum<I: Iterator<Item = &'a OMatrix<T, Dyn, C>>>(mut iter: I) -> OMatrix<T, Dyn, C> {
         if let Some(first) = iter.next() {
             iter.fold(first.clone(), |acc, x| acc + x)
         } else {

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use crate::base::allocator::Allocator;
 use crate::base::constraint::{SameNumberOfRows, ShapeConstraint};
 use crate::base::default_allocator::DefaultAllocator;
-use crate::base::dimension::{Dim, DimName, Dynamic, U1};
+use crate::base::dimension::{Dim, DimName, Dyn, U1};
 use crate::base::storage::{IsContiguous, Owned, RawStorage, RawStorageMut, ReshapableStorage};
 use crate::base::{Scalar, Vector};
 
@@ -188,13 +188,13 @@ impl<T, R: Dim, C: Dim> From<VecStorage<T, R, C>> for Vec<T> {
 
 /*
  *
- * Dynamic − Static
- * Dynamic − Dynamic
+ * Dyn − Static
+ * Dyn − Dyn
  *
  */
-unsafe impl<T, C: Dim> RawStorage<T, Dynamic, C> for VecStorage<T, Dynamic, C> {
+unsafe impl<T, C: Dim> RawStorage<T, Dyn, C> for VecStorage<T, Dyn, C> {
     type RStride = U1;
-    type CStride = Dynamic;
+    type CStride = Dyn;
 
     #[inline]
     fn ptr(&self) -> *const T {
@@ -202,7 +202,7 @@ unsafe impl<T, C: Dim> RawStorage<T, Dynamic, C> for VecStorage<T, Dynamic, C> {
     }
 
     #[inline]
-    fn shape(&self) -> (Dynamic, C) {
+    fn shape(&self) -> (Dyn, C) {
         (self.nrows, self.ncols)
     }
 
@@ -222,28 +222,28 @@ unsafe impl<T, C: Dim> RawStorage<T, Dynamic, C> for VecStorage<T, Dynamic, C> {
     }
 }
 
-unsafe impl<T: Scalar, C: Dim> Storage<T, Dynamic, C> for VecStorage<T, Dynamic, C>
+unsafe impl<T: Scalar, C: Dim> Storage<T, Dyn, C> for VecStorage<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dynamic, C, Buffer = Self>,
+    DefaultAllocator: Allocator<T, Dyn, C, Buffer = Self>,
 {
     #[inline]
-    fn into_owned(self) -> Owned<T, Dynamic, C>
+    fn into_owned(self) -> Owned<T, Dyn, C>
     where
-        DefaultAllocator: Allocator<T, Dynamic, C>,
+        DefaultAllocator: Allocator<T, Dyn, C>,
     {
         self
     }
 
     #[inline]
-    fn clone_owned(&self) -> Owned<T, Dynamic, C>
+    fn clone_owned(&self) -> Owned<T, Dyn, C>
     where
-        DefaultAllocator: Allocator<T, Dynamic, C>,
+        DefaultAllocator: Allocator<T, Dyn, C>,
     {
         self.clone()
     }
 }
 
-unsafe impl<T, R: DimName> RawStorage<T, R, Dynamic> for VecStorage<T, R, Dynamic> {
+unsafe impl<T, R: DimName> RawStorage<T, R, Dyn> for VecStorage<T, R, Dyn> {
     type RStride = U1;
     type CStride = R;
 
@@ -253,7 +253,7 @@ unsafe impl<T, R: DimName> RawStorage<T, R, Dynamic> for VecStorage<T, R, Dynami
     }
 
     #[inline]
-    fn shape(&self) -> (R, Dynamic) {
+    fn shape(&self) -> (R, Dyn) {
         (self.nrows, self.ncols)
     }
 
@@ -273,22 +273,22 @@ unsafe impl<T, R: DimName> RawStorage<T, R, Dynamic> for VecStorage<T, R, Dynami
     }
 }
 
-unsafe impl<T: Scalar, R: DimName> Storage<T, R, Dynamic> for VecStorage<T, R, Dynamic>
+unsafe impl<T: Scalar, R: DimName> Storage<T, R, Dyn> for VecStorage<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dynamic, Buffer = Self>,
+    DefaultAllocator: Allocator<T, R, Dyn, Buffer = Self>,
 {
     #[inline]
-    fn into_owned(self) -> Owned<T, R, Dynamic>
+    fn into_owned(self) -> Owned<T, R, Dyn>
     where
-        DefaultAllocator: Allocator<T, R, Dynamic>,
+        DefaultAllocator: Allocator<T, R, Dyn>,
     {
         self
     }
 
     #[inline]
-    fn clone_owned(&self) -> Owned<T, R, Dynamic>
+    fn clone_owned(&self) -> Owned<T, R, Dyn>
     where
-        DefaultAllocator: Allocator<T, R, Dynamic>,
+        DefaultAllocator: Allocator<T, R, Dyn>,
     {
         self.clone()
     }
@@ -299,7 +299,7 @@ where
  * RawStorageMut, ContiguousStorage.
  *
  */
-unsafe impl<T, C: Dim> RawStorageMut<T, Dynamic, C> for VecStorage<T, Dynamic, C> {
+unsafe impl<T, C: Dim> RawStorageMut<T, Dyn, C> for VecStorage<T, Dyn, C> {
     #[inline]
     fn ptr_mut(&mut self) -> *mut T {
         self.data.as_mut_ptr()
@@ -313,15 +313,15 @@ unsafe impl<T, C: Dim> RawStorageMut<T, Dynamic, C> for VecStorage<T, Dynamic, C
 
 unsafe impl<T, R: Dim, C: Dim> IsContiguous for VecStorage<T, R, C> {}
 
-impl<T, C1, C2> ReshapableStorage<T, Dynamic, C1, Dynamic, C2> for VecStorage<T, Dynamic, C1>
+impl<T, C1, C2> ReshapableStorage<T, Dyn, C1, Dyn, C2> for VecStorage<T, Dyn, C1>
 where
     T: Scalar,
     C1: Dim,
     C2: Dim,
 {
-    type Output = VecStorage<T, Dynamic, C2>;
+    type Output = VecStorage<T, Dyn, C2>;
 
-    fn reshape_generic(self, nrows: Dynamic, ncols: C2) -> Self::Output {
+    fn reshape_generic(self, nrows: Dyn, ncols: C2) -> Self::Output {
         assert_eq!(nrows.value() * ncols.value(), self.data.len());
         VecStorage {
             data: self.data,
@@ -331,15 +331,15 @@ where
     }
 }
 
-impl<T, C1, R2> ReshapableStorage<T, Dynamic, C1, R2, Dynamic> for VecStorage<T, Dynamic, C1>
+impl<T, C1, R2> ReshapableStorage<T, Dyn, C1, R2, Dyn> for VecStorage<T, Dyn, C1>
 where
     T: Scalar,
     C1: Dim,
     R2: DimName,
 {
-    type Output = VecStorage<T, R2, Dynamic>;
+    type Output = VecStorage<T, R2, Dyn>;
 
-    fn reshape_generic(self, nrows: R2, ncols: Dynamic) -> Self::Output {
+    fn reshape_generic(self, nrows: R2, ncols: Dyn) -> Self::Output {
         assert_eq!(nrows.value() * ncols.value(), self.data.len());
         VecStorage {
             data: self.data,
@@ -349,7 +349,7 @@ where
     }
 }
 
-unsafe impl<T, R: DimName> RawStorageMut<T, R, Dynamic> for VecStorage<T, R, Dynamic> {
+unsafe impl<T, R: DimName> RawStorageMut<T, R, Dyn> for VecStorage<T, R, Dyn> {
     #[inline]
     fn ptr_mut(&mut self) -> *mut T {
         self.data.as_mut_ptr()
@@ -361,15 +361,15 @@ unsafe impl<T, R: DimName> RawStorageMut<T, R, Dynamic> for VecStorage<T, R, Dyn
     }
 }
 
-impl<T, R1, C2> ReshapableStorage<T, R1, Dynamic, Dynamic, C2> for VecStorage<T, R1, Dynamic>
+impl<T, R1, C2> ReshapableStorage<T, R1, Dyn, Dyn, C2> for VecStorage<T, R1, Dyn>
 where
     T: Scalar,
     R1: DimName,
     C2: Dim,
 {
-    type Output = VecStorage<T, Dynamic, C2>;
+    type Output = VecStorage<T, Dyn, C2>;
 
-    fn reshape_generic(self, nrows: Dynamic, ncols: C2) -> Self::Output {
+    fn reshape_generic(self, nrows: Dyn, ncols: C2) -> Self::Output {
         assert_eq!(nrows.value() * ncols.value(), self.data.len());
         VecStorage {
             data: self.data,
@@ -379,15 +379,15 @@ where
     }
 }
 
-impl<T, R1, R2> ReshapableStorage<T, R1, Dynamic, R2, Dynamic> for VecStorage<T, R1, Dynamic>
+impl<T, R1, R2> ReshapableStorage<T, R1, Dyn, R2, Dyn> for VecStorage<T, R1, Dyn>
 where
     T: Scalar,
     R1: DimName,
     R2: DimName,
 {
-    type Output = VecStorage<T, R2, Dynamic>;
+    type Output = VecStorage<T, R2, Dyn>;
 
-    fn reshape_generic(self, nrows: R2, ncols: Dynamic) -> Self::Output {
+    fn reshape_generic(self, nrows: R2, ncols: Dyn) -> Self::Output {
         assert_eq!(nrows.value() * ncols.value(), self.data.len());
         VecStorage {
             data: self.data,
@@ -397,7 +397,7 @@ where
     }
 }
 
-impl<T, R: Dim> Extend<T> for VecStorage<T, R, Dynamic> {
+impl<T, R: Dim> Extend<T> for VecStorage<T, R, Dyn> {
     /// Extends the number of columns of the `VecStorage` with elements
     /// from the given iterator.
     ///
@@ -407,13 +407,13 @@ impl<T, R: Dim> Extend<T> for VecStorage<T, R, Dynamic> {
     /// `VecStorage`.
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.data.extend(iter);
-        self.ncols = Dynamic::new(self.data.len() / self.nrows.value());
+        self.ncols = Dyn(self.data.len() / self.nrows.value());
         assert!(self.data.len() % self.nrows.value() == 0,
           "The number of elements produced by the given iterator was not a multiple of the number of rows.");
     }
 }
 
-impl<'a, T: 'a + Copy, R: Dim> Extend<&'a T> for VecStorage<T, R, Dynamic> {
+impl<'a, T: 'a + Copy, R: Dim> Extend<&'a T> for VecStorage<T, R, Dyn> {
     /// Extends the number of columns of the `VecStorage` with elements
     /// from the given iterator.
     ///
@@ -426,7 +426,7 @@ impl<'a, T: 'a + Copy, R: Dim> Extend<&'a T> for VecStorage<T, R, Dynamic> {
     }
 }
 
-impl<T, R, RV, SV> Extend<Vector<T, RV, SV>> for VecStorage<T, R, Dynamic>
+impl<T, R, RV, SV> Extend<Vector<T, RV, SV>> for VecStorage<T, R, Dyn>
 where
     T: Scalar,
     R: Dim,
@@ -450,15 +450,15 @@ where
             assert_eq!(nrows, vector.shape().0);
             self.data.extend(vector.iter().cloned());
         }
-        self.ncols = Dynamic::new(self.data.len() / nrows);
+        self.ncols = Dyn(self.data.len() / nrows);
     }
 }
 
-impl<T> Extend<T> for VecStorage<T, Dynamic, U1> {
+impl<T> Extend<T> for VecStorage<T, Dyn, U1> {
     /// Extends the number of rows of the `VecStorage` with elements
     /// from the given iterator.
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.data.extend(iter);
-        self.nrows = Dynamic::new(self.data.len());
+        self.nrows = Dyn(self.data.len());
     }
 }

--- a/src/debug/random_orthogonal.rs
+++ b/src/debug/random_orthogonal.rs
@@ -4,7 +4,7 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use crate::base::allocator::Allocator;
-use crate::base::dimension::{Dim, Dynamic};
+use crate::base::dimension::{Dim, Dyn};
 use crate::base::Scalar;
 use crate::base::{DefaultAllocator, OMatrix};
 use crate::linalg::givens::GivensRotation;
@@ -12,7 +12,7 @@ use simba::scalar::ComplexField;
 
 /// A random orthogonal matrix.
 #[derive(Clone, Debug)]
-pub struct RandomOrthogonal<T: Scalar, D: Dim = Dynamic>
+pub struct RandomOrthogonal<T: Scalar, D: Dim = Dyn>
 where
     DefaultAllocator: Allocator<T, D, D>,
 {

--- a/src/debug/random_sdp.rs
+++ b/src/debug/random_sdp.rs
@@ -4,7 +4,7 @@ use crate::base::storage::Owned;
 use quickcheck::{Arbitrary, Gen};
 
 use crate::base::allocator::Allocator;
-use crate::base::dimension::{Dim, Dynamic};
+use crate::base::dimension::{Dim, Dyn};
 use crate::base::Scalar;
 use crate::base::{DefaultAllocator, OMatrix};
 use simba::scalar::ComplexField;
@@ -13,7 +13,7 @@ use crate::debug::RandomOrthogonal;
 
 /// A random, well-conditioned, symmetric definite-positive matrix.
 #[derive(Clone, Debug)]
-pub struct RandomSDP<T: Scalar, D: Dim = Dynamic>
+pub struct RandomSDP<T: Scalar, D: Dim = Dyn>
 where
     DefaultAllocator: Allocator<T, D, D>,
 {

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -304,7 +304,7 @@ where
     }
 }
 
-// impl<T: ComplexField, D: DimMin<D, Output = D> + DimSub<Dynamic>> Bidiagonal<T, D, D>
+// impl<T: ComplexField, D: DimMin<D, Output = D> + DimSub<Dyn>> Bidiagonal<T, D, D>
 //     where DefaultAllocator: Allocator<T, D, D> +
 //                             Allocator<T, D> {
 //     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.

--- a/src/linalg/eigen.rs
+++ b/src/linalg/eigen.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 use std::ops::MulAssign;
 
 use crate::allocator::Allocator;
-use crate::base::dimension::{Dim, DimDiff, DimSub, Dynamic, U1, U2, U3};
+use crate::base::dimension::{Dim, DimDiff, DimSub, Dyn, U1, U2, U3};
 use crate::base::storage::Storage;
 use crate::base::{
     DefaultAllocator, Hessenberg, OMatrix, OVector, SquareMatrix, Unit, Vector2, Vector3,
@@ -52,8 +52,8 @@ where
 
 impl<T: ComplexField, D: Dim> Eigen<T, D>
 where
-    D: DimSub<U1>,                                   // For Hessenberg.
-    ShapeConstraint: DimEq<Dynamic, DimDiff<D, U1>>, // For Hessenberg.
+    D: DimSub<U1>,                               // For Hessenberg.
+    ShapeConstraint: DimEq<Dyn, DimDiff<D, U1>>, // For Hessenberg.
     DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
         + Allocator<T, DimDiff<D, U1>>
         + Allocator<T, D, D>

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -7,7 +7,7 @@ use simba::scalar::ClosedNeg;
 use crate::allocator::Allocator;
 use crate::base::{DefaultAllocator, Matrix, OVector, Scalar};
 #[cfg(any(feature = "std", feature = "alloc"))]
-use crate::dimension::Dynamic;
+use crate::dimension::Dyn;
 use crate::dimension::{Const, Dim, DimName};
 use crate::storage::StorageMut;
 
@@ -51,14 +51,14 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl PermutationSequence<Dynamic>
+impl PermutationSequence<Dyn>
 where
-    DefaultAllocator: Allocator<(usize, usize), Dynamic>,
+    DefaultAllocator: Allocator<(usize, usize), Dyn>,
 {
     /// Creates a new dynamically-allocated sequence of `n` identity permutations.
     #[inline]
     pub fn identity(n: usize) -> Self {
-        Self::identity_generic(Dynamic::new(n))
+        Self::identity_generic(Dyn(n))
     }
 }
 

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -8,7 +8,7 @@ use simba::scalar::{ComplexField, RealField};
 use std::cmp;
 
 use crate::allocator::Allocator;
-use crate::base::dimension::{Const, Dim, DimDiff, DimSub, Dynamic, U1, U2};
+use crate::base::dimension::{Const, Dim, DimDiff, DimSub, Dyn, U1, U2};
 use crate::base::storage::Storage;
 use crate::base::{DefaultAllocator, OMatrix, OVector, SquareMatrix, Unit, Vector2, Vector3};
 
@@ -174,12 +174,11 @@ where
                         {
                             let krows = cmp::min(k + 4, end + 1);
                             let mut work = work.rows_mut(0, krows);
-                            refl.reflect(&mut t.generic_view_mut(
-                                (k, k),
-                                (Const::<3>, Dynamic::new(dim.value() - k)),
-                            ));
+                            refl.reflect(
+                                &mut t.generic_view_mut((k, k), (Const::<3>, Dyn(dim.value() - k))),
+                            );
                             refl.reflect_rows(
-                                &mut t.generic_view_mut((0, k), (Dynamic::new(krows), Const::<3>)),
+                                &mut t.generic_view_mut((0, k), (Dyn(krows), Const::<3>)),
                                 &mut work,
                             );
                         }
@@ -212,13 +211,10 @@ where
                     {
                         let mut work = work.rows_mut(0, end + 1);
                         refl.reflect(
-                            &mut t.generic_view_mut(
-                                (m, m),
-                                (Const::<2>, Dynamic::new(dim.value() - m)),
-                            ),
+                            &mut t.generic_view_mut((m, m), (Const::<2>, Dyn(dim.value() - m))),
                         );
                         refl.reflect_rows(
-                            &mut t.generic_view_mut((0, m), (Dynamic::new(end + 1), Const::<2>)),
+                            &mut t.generic_view_mut((0, m), (Dyn(end + 1), Const::<2>)),
                             &mut work,
                         );
                     }
@@ -231,12 +227,14 @@ where
                 // Decouple the 2x2 block if it has real eigenvalues.
                 if let Some(rot) = compute_2x2_basis(&t.fixed_view::<2, 2>(start, start)) {
                     let inv_rot = rot.inverse();
-                    inv_rot.rotate(&mut t.generic_view_mut(
-                        (start, start),
-                        (Const::<2>, Dynamic::new(dim.value() - start)),
-                    ));
+                    inv_rot.rotate(
+                        &mut t.generic_view_mut(
+                            (start, start),
+                            (Const::<2>, Dyn(dim.value() - start)),
+                        ),
+                    );
                     rot.rotate_rows(
-                        &mut t.generic_view_mut((0, start), (Dynamic::new(end + 1), Const::<2>)),
+                        &mut t.generic_view_mut((0, start), (Dyn(end + 1), Const::<2>)),
                     );
                     t[(end, start)] = T::zero();
 

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -53,11 +53,11 @@
 //! with [matrix](fn.matrix.html) as follows:
 //!
 //! ```
-//! use nalgebra::{Dynamic, OMatrix, Const};
+//! use nalgebra::{Dyn, OMatrix, Const};
 //! use nalgebra::proptest::matrix;
 //! use proptest::prelude::*;
 //!
-//! type MyMatrix = OMatrix<i32, Const::<3>, Dynamic>;
+//! type MyMatrix = OMatrix<i32, Const::<3>, Dyn>;
 //!
 //! /// Returns a strategy for pairs of matrices with `U3` rows and the same number of
 //! /// columns.
@@ -93,7 +93,7 @@
 //! If you don't care about the dimensions of matrices, you can write tests like these:
 //!
 //! ```
-//! use nalgebra::{DMatrix, DVector, Dynamic, Matrix3, OMatrix, Vector3, U3};
+//! use nalgebra::{DMatrix, DVector, Dyn, Matrix3, OMatrix, Vector3, U3};
 //! use proptest::prelude::*;
 //!
 //! proptest! {
@@ -108,7 +108,7 @@
 //!     # /*
 //!     #[test]
 //!     # */
-//!     fn test_static_and_mixed(matrix: Matrix3<i32>, matrix2: OMatrix<i32, U3, Dynamic>) {
+//!     fn test_static_and_mixed(matrix: Matrix3<i32>, matrix2: OMatrix<i32, U3, Dyn>) {
 //!         // Test some property involving these matrices
 //!     }
 //!
@@ -141,7 +141,7 @@
 //! PROPTEST_MAX_SHRINK_ITERS=100000 cargo test my_failing_test
 //! ```
 use crate::allocator::Allocator;
-use crate::{Const, DefaultAllocator, Dim, DimName, Dynamic, OMatrix, Scalar, U1};
+use crate::{Const, DefaultAllocator, Dim, DimName, Dyn, OMatrix, Scalar, U1};
 use proptest::arbitrary::Arbitrary;
 use proptest::collection::vec;
 use proptest::strategy::{BoxedStrategy, Just, NewTree, Strategy, ValueTree};
@@ -167,9 +167,9 @@ pub struct MatrixParameters<NParameters, R, C> {
 /// of matrices with `proptest`. In most cases, you do not need to concern yourself with
 /// `DimRange` directly, as it supports conversion from other types such as `U3` or inclusive
 /// ranges such as `5 ..= 6`. The latter example corresponds to dimensions from (inclusive)
-/// `Dynamic::new(5)` to `Dynamic::new(6)` (inclusive).
+/// `Dyn(5)` to `Dyn(6)` (inclusive).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DimRange<D = Dynamic>(RangeInclusive<D>);
+pub struct DimRange<D = Dyn>(RangeInclusive<D>);
 
 impl<D: Dim> DimRange<D> {
     /// The lower bound for dimensions generated.
@@ -195,9 +195,9 @@ impl<D: Dim> From<RangeInclusive<D>> for DimRange<D> {
     }
 }
 
-impl From<RangeInclusive<usize>> for DimRange<Dynamic> {
+impl From<RangeInclusive<usize>> for DimRange<Dyn> {
     fn from(range: RangeInclusive<usize>) -> Self {
-        DimRange::from(Dynamic::new(*range.start())..=Dynamic::new(*range.end()))
+        DimRange::from(Dyn(*range.start())..=Dyn(*range.end()))
     }
 }
 
@@ -208,14 +208,14 @@ impl<D: Dim> DimRange<D> {
     }
 }
 
-impl From<usize> for DimRange<Dynamic> {
+impl From<usize> for DimRange<Dyn> {
     fn from(dim: usize) -> Self {
-        DimRange::from(Dynamic::new(dim))
+        DimRange::from(Dyn(dim))
     }
 }
 
-/// The default range used for Dynamic dimensions when generating arbitrary matrices.
-fn dynamic_dim_range() -> DimRange<Dynamic> {
+/// The default range used for Dyn dimensions when generating arbitrary matrices.
+fn dynamic_dim_range() -> DimRange<Dyn> {
     DimRange::from(0..=6)
 }
 
@@ -225,7 +225,7 @@ fn dynamic_dim_range() -> DimRange<Dynamic> {
 /// ## Examples
 /// ```
 /// use nalgebra::proptest::matrix;
-/// use nalgebra::{OMatrix, Const, Dynamic};
+/// use nalgebra::{OMatrix, Const, Dyn};
 /// use proptest::prelude::*;
 ///
 /// proptest! {
@@ -234,7 +234,7 @@ fn dynamic_dim_range() -> DimRange<Dynamic> {
 ///     # */
 ///     fn my_test(a in matrix(0 .. 5i32, Const::<3>, 0 ..= 5)) {
 ///         // Let's make sure we've got the correct type first
-///         let a: OMatrix<_, Const::<3>, Dynamic> = a;
+///         let a: OMatrix<_, Const::<3>, Dyn> = a;
 ///         prop_assert!(a.nrows() == 3);
 ///         prop_assert!(a.ncols() <= 5);
 ///         prop_assert!(a.iter().all(|x_ij| *x_ij >= 0 && *x_ij < 5));
@@ -347,7 +347,7 @@ where
     }
 }
 
-impl<NParameters, R> Default for MatrixParameters<NParameters, R, Dynamic>
+impl<NParameters, R> Default for MatrixParameters<NParameters, R, Dyn>
 where
     NParameters: Default,
     R: DimName,
@@ -361,7 +361,7 @@ where
     }
 }
 
-impl<NParameters, C> Default for MatrixParameters<NParameters, Dynamic, C>
+impl<NParameters, C> Default for MatrixParameters<NParameters, Dyn, C>
 where
     NParameters: Default,
     C: DimName,
@@ -375,7 +375,7 @@ where
     }
 }
 
-impl<NParameters> Default for MatrixParameters<NParameters, Dynamic, Dynamic>
+impl<NParameters> Default for MatrixParameters<NParameters, Dyn, Dyn>
 where
     NParameters: Default,
 {

--- a/src/sparse/cs_matrix.rs
+++ b/src/sparse/cs_matrix.rs
@@ -7,7 +7,7 @@ use std::slice;
 
 use crate::allocator::Allocator;
 use crate::sparse::cs_utils;
-use crate::{Const, DefaultAllocator, Dim, Dynamic, Matrix, OVector, Scalar, Vector, U1};
+use crate::{Const, DefaultAllocator, Dim, Dyn, Matrix, OVector, Scalar, Vector, U1};
 
 pub struct ColumnEntries<'a, T> {
     curr: usize,
@@ -236,16 +236,16 @@ impl<T: Scalar, R: Dim, C: Dim> CsStorageMut<T, R, C> for CsVecStorage<T, R, C> 
 pub struct CsSliceStorage<'a, T: Scalar, R: Dim, C: DimAdd<U1>> {
     shape: (R, C),
     p: VectorSlice<usize, DimSum<C, U1>>,
-    i: VectorSlice<usize, Dynamic>,
-    vals: VectorSlice<T, Dynamic>,
+    i: VectorSlice<usize, Dyn>,
+    vals: VectorSlice<T, Dyn>,
 }*/
 
 /// A compressed sparse column matrix.
 #[derive(Clone, Debug, PartialEq)]
 pub struct CsMatrix<
     T: Scalar,
-    R: Dim = Dynamic,
-    C: Dim = Dynamic,
+    R: Dim = Dyn,
+    C: Dim = Dyn,
     S: CsStorage<T, R, C> = CsVecStorage<T, R, C>,
 > {
     pub(crate) data: S,
@@ -253,7 +253,7 @@ pub struct CsMatrix<
 }
 
 /// A column compressed sparse vector.
-pub type CsVector<T, R = Dynamic, S = CsVecStorage<T, R, U1>> = CsMatrix<T, R, U1, S>;
+pub type CsVector<T, R = Dyn, S = CsVecStorage<T, R, U1>> = CsMatrix<T, R, U1, S>;
 
 impl<T: Scalar, R: Dim, C: Dim> CsMatrix<T, R, C>
 where
@@ -342,8 +342,8 @@ impl<T: Scalar + Zero + ClosedAdd> CsMatrix<T> {
         vals: Vec<T>,
     ) -> Self
     {
-        let nrows = Dynamic::new(nrows);
-        let ncols = Dynamic::new(ncols);
+        let nrows = Dyn(nrows);
+        let ncols = Dyn(ncols);
         let p = DVector::from_data(VecStorage::new(ncols, U1, p));
         Self::from_parts_generic(nrows, ncols, p, i, vals)
     }

--- a/src/sparse/cs_matrix_conversion.rs
+++ b/src/sparse/cs_matrix_conversion.rs
@@ -5,7 +5,7 @@ use crate::allocator::Allocator;
 use crate::sparse::cs_utils;
 use crate::sparse::{CsMatrix, CsStorage};
 use crate::storage::Storage;
-use crate::{DefaultAllocator, Dim, Dynamic, Matrix, OMatrix, Scalar};
+use crate::{DefaultAllocator, Dim, Dyn, Matrix, OMatrix, Scalar};
 
 impl<'a, T: Scalar + Zero + ClosedAdd> CsMatrix<T> {
     /// Creates a column-compressed sparse matrix from a sparse matrix in triplet form.
@@ -16,7 +16,7 @@ impl<'a, T: Scalar + Zero + ClosedAdd> CsMatrix<T> {
         icols: &[usize],
         vals: &[T],
     ) -> Self {
-        Self::from_triplet_generic(Dynamic::new(nrows), Dynamic::new(ncols), irows, icols, vals)
+        Self::from_triplet_generic(Dyn(nrows), Dyn(ncols), irows, icols, vals)
     }
 }
 

--- a/tests/core/edition.rs
+++ b/tests/core/edition.rs
@@ -2,7 +2,7 @@ use na::{
     DMatrix, Matrix, Matrix3, Matrix3x4, Matrix3x5, Matrix4, Matrix4x3, Matrix4x5, Matrix5,
     Matrix5x3, Matrix5x4,
 };
-use na::{Dynamic, U3, U5};
+use na::{Dyn, U3, U5};
 
 #[test]
 #[rustfmt::skip]
@@ -257,7 +257,7 @@ fn remove_columns() {
     assert_eq!(m.remove_fixed_columns::<2>(2), expected_b3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, U3, Dynamic, _> = m.remove_columns(3, 2);
+    let computed: Matrix<_, U3, Dyn, _> = m.remove_columns(3, 2);
     assert!(computed.eq(&expected_b2));
 
     /*
@@ -391,7 +391,7 @@ fn remove_rows() {
     assert_eq!(m.remove_fixed_rows::<2>(2), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, Dynamic, U3, _> = m.remove_rows(3, 2);
+    let computed: Matrix<_, Dyn, U3, _> = m.remove_rows(3, 2);
     assert!(computed.eq(&expected2));
 }
 
@@ -508,7 +508,7 @@ fn insert_columns() {
     assert_eq!(m.insert_fixed_columns::<2>(2, 0), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, U5, Dynamic, _> = m.insert_columns(3, 2, 0);
+    let computed: Matrix<_, U5, Dyn, _> = m.insert_columns(3, 2, 0);
     assert!(computed.eq(&expected2));
 }
 
@@ -581,7 +581,7 @@ fn insert_rows() {
     assert_eq!(m.insert_fixed_rows::<2>(2, 0), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, Dynamic, U5, _> = m.insert_rows(3, 2, 0);
+    let computed: Matrix<_, Dyn, U5, _> = m.insert_rows(3, 2, 0);
     assert!(computed.eq(&expected2));
 }
 

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -7,6 +7,7 @@ mod matrix;
 mod matrix_view;
 #[cfg(feature = "mint")]
 mod mint;
+mod reshape;
 #[cfg(feature = "rkyv-serialize-no-std")]
 mod rkyv;
 mod serde;

--- a/tests/core/reshape.rs
+++ b/tests/core/reshape.rs
@@ -1,6 +1,6 @@
 use na::{
-    Const, DMatrix, DMatrixSlice, DMatrixSliceMut, Dyn, Dynamic, Matrix, MatrixSlice,
-    MatrixSliceMut, SMatrix, SMatrixSlice, SMatrixSliceMut, VecStorage, U3, U4,
+    Const, DMatrix, DMatrixView, DMatrixViewMut, Dyn, Dynamic, Matrix, MatrixView, MatrixViewMut,
+    SMatrix, SMatrixView, SMatrixViewMut, VecStorage, U3, U4,
 };
 use nalgebra_macros::matrix;
 use simba::scalar::SupersetOf;
@@ -59,22 +59,22 @@ fn reshape_slice() {
     }
 
     // Static "source slice"
-    test_reshape!(SMatrixSlice<_, 4, 3> => SMatrixSlice<_, 3, 4>, U3, U4);
-    test_reshape!(SMatrixSlice<_, 4, 3> => DMatrixSlice<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(SMatrixSlice<_, 4, 3> => MatrixSlice<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(SMatrixSlice<_, 4, 3> => MatrixSlice<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
-    test_reshape!(SMatrixSliceMut<_, 4, 3> => SMatrixSliceMut<_, 3, 4>, U3, U4);
-    test_reshape!(SMatrixSliceMut<_, 4, 3> => DMatrixSliceMut<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(SMatrixSliceMut<_, 4, 3> => MatrixSliceMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(SMatrixSliceMut<_, 4, 3> => MatrixSliceMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(SMatrixView<_, 4, 3> => SMatrixView<_, 3, 4>, U3, U4);
+    test_reshape!(SMatrixView<_, 4, 3> => DMatrixView<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(SMatrixViewMut<_, 4, 3> => SMatrixViewMut<_, 3, 4>, U3, U4);
+    test_reshape!(SMatrixViewMut<_, 4, 3> => DMatrixViewMut<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
 
     // Dynamic "source slice"
-    test_reshape!(DMatrixSlice<_> => SMatrixSlice<_, 3, 4>, U3, U4);
-    test_reshape!(DMatrixSlice<_> => DMatrixSlice<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(DMatrixSlice<_> => MatrixSlice<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(DMatrixSlice<_> => MatrixSlice<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
-    test_reshape!(DMatrixSliceMut<_> => SMatrixSliceMut<_, 3, 4>, U3, U4);
-    test_reshape!(DMatrixSliceMut<_> => DMatrixSliceMut<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(DMatrixSliceMut<_> => MatrixSliceMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(DMatrixSliceMut<_> => MatrixSliceMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(DMatrixView<_> => SMatrixView<_, 3, 4>, U3, U4);
+    test_reshape!(DMatrixView<_> => DMatrixView<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(DMatrixView<_> => MatrixView<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(DMatrixView<_> => MatrixView<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(DMatrixViewMut<_> => SMatrixViewMut<_, 3, 4>, U3, U4);
+    test_reshape!(DMatrixViewMut<_> => DMatrixViewMut<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
 }

--- a/tests/core/reshape.rs
+++ b/tests/core/reshape.rs
@@ -1,6 +1,6 @@
 use na::{
-    Const, DMatrix, DMatrixView, DMatrixViewMut, Dyn, Dyn, Matrix, MatrixView, MatrixViewMut,
-    SMatrix, SMatrixView, SMatrixViewMut, VecStorage, U3, U4,
+    Const, DMatrix, DMatrixView, DMatrixViewMut, Dyn, Matrix, MatrixView, MatrixViewMut, SMatrix,
+    SMatrixView, SMatrixViewMut, VecStorage, U3, U4,
 };
 use nalgebra_macros::matrix;
 use simba::scalar::SupersetOf;

--- a/tests/core/reshape.rs
+++ b/tests/core/reshape.rs
@@ -1,5 +1,5 @@
 use na::{
-    Const, DMatrix, DMatrixView, DMatrixViewMut, Dyn, Dynamic, Matrix, MatrixView, MatrixViewMut,
+    Const, DMatrix, DMatrixView, DMatrixViewMut, Dyn, Dyn, Matrix, MatrixView, MatrixViewMut,
     SMatrix, SMatrixView, SMatrixViewMut, VecStorage, U3, U4,
 };
 use nalgebra_macros::matrix;
@@ -60,21 +60,21 @@ fn reshape_slice() {
 
     // Static "source slice"
     test_reshape!(SMatrixView<_, 4, 3> => SMatrixView<_, 3, 4>, U3, U4);
-    test_reshape!(SMatrixView<_, 4, 3> => DMatrixView<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(SMatrixView<_, 4, 3> => DMatrixView<_>, Dyn(3), Dyn(4));
+    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Const<3>, Dyn>, U3, Dyn(4));
+    test_reshape!(SMatrixView<_, 4, 3> => MatrixView<_, Dyn, Const<4>>, Dyn(3), U4);
     test_reshape!(SMatrixViewMut<_, 4, 3> => SMatrixViewMut<_, 3, 4>, U3, U4);
-    test_reshape!(SMatrixViewMut<_, 4, 3> => DMatrixViewMut<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(SMatrixViewMut<_, 4, 3> => DMatrixViewMut<_>, Dyn(3), Dyn(4));
+    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Const<3>, Dyn>, U3, Dyn(4));
+    test_reshape!(SMatrixViewMut<_, 4, 3> => MatrixViewMut<_, Dyn, Const<4>>, Dyn(3), U4);
 
-    // Dynamic "source slice"
+    // Dyn "source slice"
     test_reshape!(DMatrixView<_> => SMatrixView<_, 3, 4>, U3, U4);
-    test_reshape!(DMatrixView<_> => DMatrixView<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(DMatrixView<_> => MatrixView<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(DMatrixView<_> => MatrixView<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(DMatrixView<_> => DMatrixView<_>, Dyn(3), Dyn(4));
+    test_reshape!(DMatrixView<_> => MatrixView<_, Const<3>, Dyn>, U3, Dyn(4));
+    test_reshape!(DMatrixView<_> => MatrixView<_, Dyn, Const<4>>, Dyn(3), U4);
     test_reshape!(DMatrixViewMut<_> => SMatrixViewMut<_, 3, 4>, U3, U4);
-    test_reshape!(DMatrixViewMut<_> => DMatrixViewMut<_>, Dynamic::new(3), Dynamic::new(4));
-    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
-    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(DMatrixViewMut<_> => DMatrixViewMut<_>, Dyn(3), Dyn(4));
+    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Const<3>, Dyn>, U3, Dyn(4));
+    test_reshape!(DMatrixViewMut<_> => MatrixViewMut<_, Dyn, Const<4>>, Dyn(3), U4);
 }

--- a/tests/core/reshape.rs
+++ b/tests/core/reshape.rs
@@ -1,0 +1,80 @@
+use na::{
+    Const, DMatrix, DMatrixSlice, DMatrixSliceMut, Dyn, Dynamic, Matrix, MatrixSlice,
+    MatrixSliceMut, SMatrix, SMatrixSlice, SMatrixSliceMut, VecStorage, U3, U4,
+};
+use nalgebra_macros::matrix;
+use simba::scalar::SupersetOf;
+
+const MATRIX: SMatrix<i32, 4, 3> = matrix![
+     1,  2,  3;
+     4,  5,  6;
+     7,  8,  9;
+    10, 11, 12
+];
+
+const RESHAPED_MATRIX: SMatrix<i32, 3, 4> = matrix![
+    1, 10,  8,  6;
+    4,  2, 11,  9;
+    7,  5,  3, 12
+];
+
+// Helper alias for making it easier to specify dynamically allocated matrices with
+// different dimension types (unlike DMatrix)
+type GenericDMatrix<T, R, C> = Matrix<T, R, C, VecStorage<T, R, C>>;
+
+#[test]
+fn reshape_owned() {
+    macro_rules! test_reshape {
+        ($in_matrix:ty => $out_matrix:ty, $rows:expr, $cols:expr) => {{
+            // This is a pretty weird way to convert, but Matrix implements SubsetOf
+            let matrix: $in_matrix = MATRIX.to_subset().unwrap();
+            let reshaped: $out_matrix = matrix.reshape_generic($rows, $cols);
+            assert_eq!(reshaped, RESHAPED_MATRIX);
+        }};
+    }
+
+    test_reshape!(SMatrix<_, 4, 3> => SMatrix<_, 3, 4>, U3, U4);
+    test_reshape!(GenericDMatrix<_, U4, Dyn> => GenericDMatrix<_, Dyn, Dyn>, Dyn(3), Dyn(4));
+    test_reshape!(GenericDMatrix<_, U4, Dyn> => GenericDMatrix<_, U3, Dyn>, U3, Dyn(4));
+    test_reshape!(GenericDMatrix<_, U4, Dyn> => GenericDMatrix<_, Dyn, U4>, Dyn(3), U4);
+    test_reshape!(DMatrix<_> => DMatrix<_>, Dyn(3), Dyn(4));
+}
+
+#[test]
+fn reshape_slice() {
+    macro_rules! test_reshape {
+        ($in_slice:ty => $out_slice:ty, $rows:expr, $cols:expr) => {
+            // We test both that types check out by being explicit about types
+            // and the actual contents of the matrix
+            {
+                // By constructing the slice from a mutable reference we can obtain *either*
+                // an immutable slice or a mutable slice, which simplifies the testing of both
+                // types of mutability
+                let mut source_matrix = MATRIX.clone();
+                let slice: $in_slice = Matrix::from(&mut source_matrix);
+                let reshaped: $out_slice = slice.reshape_generic($rows, $cols);
+                assert_eq!(reshaped, RESHAPED_MATRIX);
+            }
+        };
+    }
+
+    // Static "source slice"
+    test_reshape!(SMatrixSlice<_, 4, 3> => SMatrixSlice<_, 3, 4>, U3, U4);
+    test_reshape!(SMatrixSlice<_, 4, 3> => DMatrixSlice<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(SMatrixSlice<_, 4, 3> => MatrixSlice<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(SMatrixSlice<_, 4, 3> => MatrixSlice<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(SMatrixSliceMut<_, 4, 3> => SMatrixSliceMut<_, 3, 4>, U3, U4);
+    test_reshape!(SMatrixSliceMut<_, 4, 3> => DMatrixSliceMut<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(SMatrixSliceMut<_, 4, 3> => MatrixSliceMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(SMatrixSliceMut<_, 4, 3> => MatrixSliceMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+
+    // Dynamic "source slice"
+    test_reshape!(DMatrixSlice<_> => SMatrixSlice<_, 3, 4>, U3, U4);
+    test_reshape!(DMatrixSlice<_> => DMatrixSlice<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(DMatrixSlice<_> => MatrixSlice<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(DMatrixSlice<_> => MatrixSlice<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+    test_reshape!(DMatrixSliceMut<_> => SMatrixSliceMut<_, 3, 4>, U3, U4);
+    test_reshape!(DMatrixSliceMut<_> => DMatrixSliceMut<_>, Dynamic::new(3), Dynamic::new(4));
+    test_reshape!(DMatrixSliceMut<_> => MatrixSliceMut<_, Const<3>, Dynamic>, U3, Dynamic::new(4));
+    test_reshape!(DMatrixSliceMut<_> => MatrixSliceMut<_, Dynamic, Const<4>>, Dynamic::new(3), U4);
+}

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -15,7 +15,7 @@ macro_rules! gen_tests(
     ($module: ident, $scalar: ty) => {
         mod $module {
             use na::debug::RandomSDP;
-            use na::dimension::{Const, Dynamic};
+            use na::dimension::{Const, Dyn};
             use na::{DMatrix, DVector, Matrix4x3, Vector4};
             use rand::random;
             use simba::scalar::ComplexField;
@@ -28,7 +28,7 @@ macro_rules! gen_tests(
             proptest! {
                 #[test]
                 fn cholesky(n in PROPTEST_MATRIX_DIM) {
-                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
                     let l = m.clone().cholesky().unwrap().unpack();
                     prop_assert!(relative_eq!(m, &l * l.adjoint(), epsilon = 1.0e-7));
                 }
@@ -44,7 +44,7 @@ macro_rules! gen_tests(
 
                 #[test]
                 fn cholesky_solve(n in PROPTEST_MATRIX_DIM, nb in PROPTEST_MATRIX_DIM) {
-                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
 
                     let chol = m.clone().cholesky().unwrap();
                     let b1 = DVector::<$scalar>::new_random(n).map(|e| e.0);
@@ -73,7 +73,7 @@ macro_rules! gen_tests(
 
                 #[test]
                 fn cholesky_inverse(n in PROPTEST_MATRIX_DIM) {
-                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
                     let m1 = m.clone().cholesky().unwrap().inverse();
                     let id1 = &m  * &m1;
                     let id2 = &m1 * &m;
@@ -93,7 +93,7 @@ macro_rules! gen_tests(
 
                 #[test]
                 fn cholesky_determinant(n in PROPTEST_MATRIX_DIM) {
-                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
                     let lu_det = m.clone().lu().determinant();
                     assert_relative_eq!(lu_det.imaginary(), 0., epsilon = 1.0e-7);
                     let chol_det = m.cholesky().unwrap().determinant();
@@ -137,7 +137,7 @@ macro_rules! gen_tests(
                 fn cholesky_insert_column(n in PROPTEST_MATRIX_DIM) {
                     let n = n.max(1).min(10);
                     let j = random::<usize>() % n;
-                    let m_updated = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m_updated = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
 
                     // build m and col from m_updated
                     let col = m_updated.column(j);
@@ -154,7 +154,7 @@ macro_rules! gen_tests(
                 fn cholesky_remove_column(n in PROPTEST_MATRIX_DIM) {
                     let n = n.max(1).min(10);
                     let j = random::<usize>() % n;
-                    let m = RandomSDP::new(Dynamic::new(n), || random::<$scalar>().0).unwrap();
+                    let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
 
                     // remove column from cholesky decomposition and rebuild m
                     let chol = m.clone().cholesky().unwrap().remove_column(j);

--- a/tests/linalg/convolution.rs
+++ b/tests/linalg/convolution.rs
@@ -16,7 +16,7 @@ fn convolve_same_check() {
 
     assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
 
-    // Dynamic Tests
+    // Dyn Tests
     let actual_d = DVector::from_vec(vec![1.0, 4.0, 7.0, 10.0]);
     let expected_d = DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0])
         .convolve_same(DVector::from_vec(vec![1.0, 2.0]));
@@ -54,7 +54,7 @@ fn convolve_full_check() {
 
     assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
 
-    // Dynamic Tests
+    // Dyn Tests
     let actual_d = DVector::from_vec(vec![1.0, 4.0, 7.0, 10.0, 8.0]);
     let expected_d = DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0])
         .convolve_full(DVector::from_vec(vec![1.0, 2.0]));
@@ -90,7 +90,7 @@ fn convolve_valid_check() {
 
     assert!(relative_eq!(actual_s, expected_s, epsilon = 1.0e-7));
 
-    // Dynamic Tests
+    // Dyn Tests
     let actual_d = DVector::from_vec(vec![4.0, 7.0, 10.0]);
     let expected_d = DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0])
         .convolve_valid(DVector::from_vec(vec![1.0, 2.0]));

--- a/tests/linalg/full_piv_lu.rs
+++ b/tests/linalg/full_piv_lu.rs
@@ -253,7 +253,7 @@ fn remove_columns() {
     assert_eq!(m.remove_fixed_columns::<U2>(2), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, U3, Dynamic, _> = m.remove_columns(3, 2);
+    let computed: Matrix<_, U3, Dyn, _> = m.remove_columns(3, 2);
     assert!(computed.eq(&expected2));
 }
 
@@ -309,7 +309,7 @@ fn remove_rows() {
     assert_eq!(m.remove_fixed_rows::<U2>(2), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, Dynamic, U3, _> = m.remove_rows(3, 2);
+    let computed: Matrix<_, Dyn, U3, _> = m.remove_rows(3, 2);
     assert!(computed.eq(&expected2));
 }
 
@@ -374,7 +374,7 @@ fn insert_columns() {
     assert_eq!(m.insert_fixed_columns::<U2>(2, 0), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, U5, Dynamic, _> = m.insert_columns(3, 2, 0);
+    let computed: Matrix<_, U5, Dyn, _> = m.insert_columns(3, 2, 0);
     assert!(computed.eq(&expected2));
 }
 
@@ -434,7 +434,7 @@ fn insert_rows() {
     assert_eq!(m.insert_fixed_rows::<2>(2, 0), expected3);
 
     // The following is just to verify that the return type dimensions is correctly inferred.
-    let computed: Matrix<_, Dynamic, U5, _> = m.insert_rows(3, 2, 0);
+    let computed: Matrix<_, Dyn, U5, _> = m.insert_rows(3, 2, 0);
     assert!(computed.eq(&expected2));
 }
 

--- a/tests/proptest/mod.rs
+++ b/tests/proptest/mod.rs
@@ -101,11 +101,11 @@ pub fn dvector() -> impl Strategy<Value = DVector<f64>> {
 
 pub fn dmatrix_<ScalarStrategy>(
     scalar_strategy: ScalarStrategy,
-) -> impl Strategy<Value = OMatrix<ScalarStrategy::Value, Dynamic, Dynamic>>
+) -> impl Strategy<Value = OMatrix<ScalarStrategy::Value, Dyn, Dyn>>
 where
     ScalarStrategy: Strategy + Clone + 'static,
     ScalarStrategy::Value: Scalar,
-    DefaultAllocator: Allocator<ScalarStrategy::Value, Dynamic, Dynamic>,
+    DefaultAllocator: Allocator<ScalarStrategy::Value, Dyn, Dyn>,
 {
     matrix(scalar_strategy, PROPTEST_MATRIX_DIM, PROPTEST_MATRIX_DIM)
 }
@@ -114,7 +114,7 @@ where
 // where
 //     RangeInclusive<T>: Strategy<Value = T>,
 //     T: Scalar + PartialEq + Copy,
-//     DefaultAllocator: Allocator<T, Dynamic>,
+//     DefaultAllocator: Allocator<T, Dyn>,
 // {
 //     vector(range, PROPTEST_MATRIX_DIM)
 // }
@@ -213,9 +213,9 @@ fn test_matrix_output_types() {
     // Test that the dimension types are correct for the given inputs
     let _: MatrixStrategy<_, U3, U4> = matrix(-5..5, Const::<3>, Const::<4>);
     let _: MatrixStrategy<_, U3, U3> = matrix(-5..5, Const::<3>, Const::<3>);
-    let _: MatrixStrategy<_, U3, Dynamic> = matrix(-5..5, Const::<3>, 1..=5);
-    let _: MatrixStrategy<_, Dynamic, U3> = matrix(-5..5, 1..=5, Const::<3>);
-    let _: MatrixStrategy<_, Dynamic, Dynamic> = matrix(-5..5, 1..=5, 1..=5);
+    let _: MatrixStrategy<_, U3, Dyn> = matrix(-5..5, Const::<3>, 1..=5);
+    let _: MatrixStrategy<_, Dyn, U3> = matrix(-5..5, 1..=5, Const::<3>);
+    let _: MatrixStrategy<_, Dyn, Dyn> = matrix(-5..5, 1..=5, 1..=5);
 }
 
 // Below we have some tests to ensure that specific instances of OMatrix are usable
@@ -225,10 +225,10 @@ proptest! {
     fn ensure_arbitrary_test_compiles_matrix3(_: Matrix3<i32>) {}
 
     #[test]
-    fn ensure_arbitrary_test_compiles_matrixmn_u3_dynamic(_: OMatrix<i32, U3, Dynamic>) {}
+    fn ensure_arbitrary_test_compiles_matrixmn_u3_dynamic(_: OMatrix<i32, U3, Dyn>) {}
 
     #[test]
-    fn ensure_arbitrary_test_compiles_matrixmn_dynamic_u3(_: OMatrix<i32, Dynamic, U3>) {}
+    fn ensure_arbitrary_test_compiles_matrixmn_dynamic_u3(_: OMatrix<i32, Dyn, U3>) {}
 
     #[test]
     fn ensure_arbitrary_test_compiles_dmatrix(_: DMatrix<i32>) {}


### PR DESCRIPTION
This PR consists of 3 commits, which can be split out as different PRs as necessary:

- Add `U0, U1, ...` constants alongside the `U0, U1, ...` types. This lets us write `U4` instead of `U4::name()` or `Const::<4>` when we need const dimensions. It used to be like this before we got const generics, but it got lost in the transition. I don't think there's any implied breakage from this.
- Rename `Dynamic` to `Dyn` and make `Dyn` a tuple struct. 
  - This hasn't really been discussed much before, but it's a simple change so I thought I'd give it a go and see what people think.
  - This means we can write `Dyn(3)` instead of `Dynamic::new(3)`, which is very verbose.
  - It also makes error messages like `Matrix<T, _, Dynamic, VecStorage<...>>`  more concise, which might make them easier to read.
  - To avoid breakage, a type alias `Dynamic = Dyn` is also provided.
  - We might consider deprecating `Dynamic`.
- Implement `ReshapableStorage` for matrix slices (only for unit strides at the moment), which was missing.
  - This means we can use `slice.reshape_generic(...)` on slices as well, something I've needed many times.
  - I discovered that there were no real tests for the existing `reshape_generic` functionality, so I added some.

This PR can either be merged before #1178, in which case I'd update #1178, or it can be merged afterwards, in which case I'll update this PR with the new view terminology.