### PR TITLE
Add simple cargo doc step to CI

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -137,3 +137,9 @@ jobs:
       - run: cargo build --no-default-features --features cuda --target=nvptx64-nvidia-cuda
         env: 
           CUDA_ARCH: "350"
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate documentation
+      run: cargo doc


### PR DESCRIPTION
This adds a simple `cargo doc` step to CI for the repo.

Pending discussion of more complex options for `cargo doc`, this should address #1151.