### PR TITLE
Add ln_determinant to Cholesky

### DIFF
--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -1,8 +1,7 @@
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Serialize};
 
-use num::One;
-use num::Zero;
+use num::{One, Zero};
 use simba::scalar::ComplexField;
 use simba::simd::SimdComplexField;
 

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -41,7 +41,6 @@ where
 impl<T: SimdComplexField, D: Dim> Cholesky<T, D>
 where
     DefaultAllocator: Allocator<T, D, D>,
-    T::SimdRealField: Zero,
 {
     /// Computes the Cholesky decomposition of `matrix` without checking that the matrix is definite-positive.
     ///


### PR DESCRIPTION
This PR implements a function that returns natural logarithm of determinant similar to the one in [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.linalg.slogdet.html) and in [ndarray-linalg](https://docs.rs/ndarray-linalg/latest/ndarray_linalg/cholesky/trait.DeterminantC.html#tymethod.ln_detc).