### PR TITLE
Allow trailing punctuation in macros

### DIFF
--- a/nalgebra-macros/src/lib.rs
+++ b/nalgebra-macros/src/lib.rs
@@ -223,7 +223,7 @@ impl Parse for Vector {
                 elements: Vec::new(),
             })
         } else {
-            let elements = MatrixRowSyntax::parse_separated_nonempty(input)?
+            let elements = MatrixRowSyntax::parse_terminated(input)?
                 .into_iter()
                 .collect();
             Ok(Self { elements })

--- a/nalgebra-macros/tests/tests.rs
+++ b/nalgebra-macros/tests/tests.rs
@@ -94,6 +94,12 @@ fn dmatrix_small_dims_exhaustive() {
                DMatrix::from_row_slice(4, 4,  &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]));
 }
 
+#[test]
+fn matrix_trailing_semi() {
+    matrix![1, 2;];
+    dmatrix![1, 2;];
+}
+
 // Skip rustfmt because it just makes the test bloated without making it more readable
 #[rustfmt::skip]
 #[test]
@@ -149,6 +155,13 @@ fn dvector_small_dims_exhaustive() {
     assert_eq_and_type!(dvector![1, 2, 3, 4], DVector::from_column_slice(&[1, 2, 3, 4]));
     assert_eq_and_type!(dvector![1, 2, 3, 4, 5], DVector::from_column_slice(&[1, 2, 3, 4, 5]));
     assert_eq_and_type!(dvector![1, 2, 3, 4, 5, 6], DVector::from_column_slice(&[1, 2, 3, 4, 5, 6]));
+}
+
+#[test]
+fn vector_trailing_comma() {
+    vector![1, 2,];
+    point![1, 2,];
+    dvector![1, 2,];
 }
 
 #[test]


### PR DESCRIPTION
When splitting e.g. fields over multiple lines it is quite common to add a
trailing comma in the last line in rust code.

This pr makes it so that this is allowed now:

```rust
vector![
    some_longer_expression() + something,
    some_longer_expression() + something_else,
    some_longer_expression() + another_thing,
    some_longer_expression() + 42,
];
```

I also added a test verifying that this was already the case with `matrix!`.
