### PR TITLE
Serialize statically sized matrices as tuples

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -5,7 +5,7 @@ use std::ops::Mul;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::de::{Error, SeqAccess, Visitor};
 #[cfg(feature = "serde-serialize-no-std")]
-use serde::ser::SerializeSeq;
+use serde::ser::SerializeTuple;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde-serialize-no-std")]
@@ -189,7 +189,7 @@ where
     where
         S: Serializer,
     {
-        let mut serializer = serializer.serialize_seq(Some(R * C))?;
+        let mut serializer = serializer.serialize_tuple(R * C)?;
 
         for e in self.as_slice().iter() {
             serializer.serialize_element(e)?;
@@ -208,7 +208,7 @@ where
     where
         D: Deserializer<'a>,
     {
-        deserializer.deserialize_seq(ArrayStorageVisitor::new())
+        deserializer.deserialize_tuple(R * C, ArrayStorageVisitor::new())
     }
 }
 


### PR DESCRIPTION
Breaking change. Consistent with how serde serializes plain arrays. Saves a length tag in common serialization formats (e.g. bincode, punchcard).