### PR TITLE
fix: remove Scalar trait bound for Matrix PartialEq and Eq

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1859,14 +1859,14 @@ where
 
 impl<T, R: Dim, C: Dim, S> Eq for Matrix<T, R, C, S>
 where
-    T: Scalar + Eq,
+    T: Eq,
     S: RawStorage<T, R, C>,
 {
 }
 
 impl<T, R, R2, C, C2, S, S2> PartialEq<Matrix<T, R2, C2, S2>> for Matrix<T, R, C, S>
 where
-    T: Scalar + PartialEq,
+    T: PartialEq,
     C: Dim,
     C2: Dim,
     R: Dim,


### PR DESCRIPTION
I believe that the Matrix PartialEq implementation does not require that T implements Scalar.

Removing this bound would allow for users to derive PartialEq on custom generic structures without requiring that T: Scalar. For example
```rust
#[derive(PartialEq)]
struct MyCoolStructure<T>{
     m: Vector2<T>
}
```