### PR TITLE
Remove unnecessary normalization in `Rotation3::face_towards`

### DIFF
--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -478,9 +478,10 @@ where
         SB: Storage<T, U3>,
         SC: Storage<T, U3>,
     {
+        // Gram–Schmidt process
         let zaxis = dir.normalize();
         let xaxis = up.cross(&zaxis).normalize();
-        let yaxis = zaxis.cross(&xaxis).normalize();
+        let yaxis = zaxis.cross(&xaxis);
 
         Self::from_matrix_unchecked(SMatrix::<T, 3, 3>::new(
             xaxis.x.clone(),


### PR DESCRIPTION
`zaxis` and `xaxis` are already normalized which means `zaxis.cross(&xaxis)` should already be normalized.