### PR TITLE
chore: remove explicit bytecheck dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ convert-glam024 = [ "glam024" ]
 serde-serialize-no-std = [ "serde", "num-complex/serde" ]
 serde-serialize        = [ "serde-serialize-no-std", "serde/std" ]
 rkyv-serialize-no-std  = [ "rkyv/size_32" ]
-rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "rkyv/validation", "bytecheck" ]
+rkyv-serialize         = [ "rkyv-serialize-no-std", "rkyv/std", "rkyv/validation" ]
 
 # Randomness
 ## To use rand in a #[no-std] environment, enable the
@@ -85,8 +85,7 @@ alga           = { version = "0.9", default-features = false, optional = true }
 rand_distr     = { version = "0.4", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde          = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
-rkyv           = { version = "0.7", default-features = false, optional = true }
-bytecheck      = { version = "~0.6.1", optional = true }
+rkyv           = { version = "0.7.41", default-features = false, optional = true }
 mint           = { version = "0.5", optional = true }
 quickcheck     = { version = "1", optional = true }
 pest           = { version = "2", optional = true }

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde-serialize-no-std")]
 use std::marker::PhantomData;
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 use crate::base::allocator::Allocator;
 use crate::base::default_allocator::DefaultAllocator;
 use crate::base::dimension::{Const, ToTypenum};

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -8,6 +8,8 @@ use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Sub};
 use typenum::{self, Diff, Max, Maximum, Min, Minimum, Prod, Quot, Sum, Unsigned};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "rkyv-serialize-no-std")]
 use super::rkyv_wrappers::CustomPhantom;
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
 #[cfg(feature = "rkyv-serialize-no-std")]
 use rkyv::{with::With, Archive, Archived};
 

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -9,6 +9,9 @@ use crate::base::DefaultAllocator;
 use crate::storage::RawStorage;
 use crate::{Dim, Matrix, OMatrix, RealField, Scalar, SimdComplexField, SimdRealField};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A wrapper that ensures the underlying algebraic entity has a unit norm.
 ///
 /// **It is likely that the only piece of documentation that you need in this page are:**

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -1,6 +1,9 @@
 // The macros break if the references are taken out, for some reason.
 #![allow(clippy::op_ref)]
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 use crate::{
     Isometry3, Matrix4, Normed, OVector, Point3, Quaternion, Scalar, SimdRealField, Translation3,
     Unit, UnitQuaternion, Vector3, Zero, U8,

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -14,6 +14,9 @@ use crate::base::storage::Owned;
 use crate::base::{Const, DefaultAllocator, OMatrix, SVector, Scalar, Unit};
 use crate::geometry::{AbstractRotation, Point, Translation};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A direct isometry, i.e., a rotation followed by a translation (aka. a rigid-body motion).
 ///
 /// This is also known as an element of a Special Euclidean (SE) group.

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -17,6 +17,9 @@ use crate::base::{Matrix4, Vector, Vector3};
 
 use crate::geometry::{Point3, Projective3};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A 3D orthographic projection stored as a homogeneous 4x4 matrix.
 #[repr(C)]
 #[cfg_attr(

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -18,6 +18,9 @@ use crate::base::{Matrix4, Vector, Vector3};
 
 use crate::geometry::{Point3, Projective3};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A 3D perspective projection stored as a homogeneous 4x4 matrix.
 #[repr(C)]
 #[cfg_attr(

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -4,6 +4,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::hash;
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
 #[cfg(feature = "serde-serialize-no-std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -19,6 +19,9 @@ use crate::base::{
 
 use crate::geometry::{Point3, Rotation};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A quaternion. See the type alias `UnitQuaternion = Unit<Quaternion>` for a quaternion
 /// that may be used as a rotation.
 #[repr(C)]

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -17,6 +17,9 @@ use crate::base::dimension::{DimNameAdd, DimNameSum, U1};
 use crate::base::{Const, DefaultAllocator, OMatrix, SMatrix, SVector, Scalar, Unit};
 use crate::geometry::Point;
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A rotation matrix.
 ///
 /// This is also known as an element of a Special Orthogonal (SO) group.

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -15,6 +15,9 @@ use crate::ClosedMul;
 
 use crate::geometry::Point;
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A scale which supports non-uniform scaling.
 #[repr(C)]
 #[cfg_attr(

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -15,6 +15,9 @@ use crate::base::storage::Owned;
 use crate::base::{Const, DefaultAllocator, OMatrix, SVector, Scalar};
 use crate::geometry::{AbstractRotation, Isometry, Point, Translation};
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A similarity, i.e., an uniform scaling, followed by a rotation, followed by a translation.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -15,6 +15,9 @@ use crate::base::{Const, DefaultAllocator, OMatrix, SVector, Scalar};
 
 use crate::geometry::Point;
 
+#[cfg(feature = "rkyv-serialize")]
+use rkyv::bytecheck;
+
 /// A translation.
 #[repr(C)]
 #[cfg_attr(


### PR DESCRIPTION
The explicit `bytecheck` dependency is unnecessary as we can access it through `rkyv` directly. This makes keeping dependency version in sync easier.
This replaces #1258.