### PR TITLE
DOC: Fix compiler warning in the first example in lib.rs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ explicitly, and call free-functions using the `na::` prefix:
 
 ```
 #[macro_use]
-extern crate approx; // For the macro relative_eq!
+extern crate approx; // For the macro assert_relative_eq!
 extern crate nalgebra as na;
 use na::{Vector3, Rotation3};
 
@@ -36,8 +36,8 @@ fn main() {
     let angle = 1.57;
     let b     = Rotation3::from_axis_angle(&axis, angle);
 
-    relative_eq!(b.axis().unwrap(), axis);
-    relative_eq!(b.angle(), angle);
+    assert_relative_eq!(b.axis().unwrap(), axis);
+    assert_relative_eq!(b.angle(), angle);
 }
 ```
 


### PR DESCRIPTION
This change fixes the following compiler warnings that occur with the very first demo in lib.rs:
```
warning: unused return value of `Relative::<A, B>::eq` that must be used
  --> src/main.rs:11:5
   |
11 |     relative_eq!(b.axis().unwrap(), axis);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this warning originates in the macro `relative_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unused return value of `Relative::<A, B>::eq` that must be used
  --> src/main.rs:12:5
   |
12 |     relative_eq!(b.angle(), angle);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this warning originates in the macro `relative_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `nalgebra-experiments` (bin "nalgebra-experiments") generated 2 warnings
```