### PR TITLE
docs: Use intradoc links rather than HTML.

### DIFF
--- a/nalgebra-glm/src/aliases.rs
+++ b/nalgebra-glm/src/aliases.rs
@@ -5,38 +5,38 @@ use na::{
 
 /// A matrix with components of type `T`. It has `R` rows, and `C` columns.
 ///
-/// In this library, vectors, represented as [`TVec`](type.TVec.html) and
+/// In this library, vectors, represented as [`TVec`] and
 /// friends, are also matrices. Operations that operate on a matrix will
 /// also work on a vector.
 ///
 /// # See also:
 ///
-/// * [`TMat2`](type.TMat2.html)
-/// * [`TMat2x2`](type.TMat2x2.html)
-/// * [`TMat2x3`](type.TMat2x3.html)
-/// * [`TMat2x4`](type.TMat2x4.html)
-/// * [`TMat3`](type.TMat3.html)
-/// * [`TMat3x2`](type.TMat3x2.html)
-/// * [`TMat3x3`](type.TMat3x3.html)
-/// * [`TMat3x4`](type.TMat3x4.html)
-/// * [`TMat4`](type.TMat4.html)
-/// * [`TMat4x2`](type.TMat4x2.html)
-/// * [`TMat4x3`](type.TMat4x3.html)
-/// * [`TMat4x4`](type.TMat4x4.html)
-/// * [`TVec`](type.TVec.html)
+/// * [`TMat2`]
+/// * [`TMat2x2`]
+/// * [`TMat2x3`]
+/// * [`TMat2x4`]
+/// * [`TMat3`]
+/// * [`TMat3x2`]
+/// * [`TMat3x3`]
+/// * [`TMat3x4`]
+/// * [`TMat4`]
+/// * [`TMat4x2`]
+/// * [`TMat4x3`]
+/// * [`TMat4x4`]
+/// * [`TVec`]
 pub type TMat<T, const R: usize, const C: usize> = SMatrix<T, R, C>;
 /// A column vector with components of type `T`. It has `D` rows (and one column).
 ///
 /// In this library, vectors are represented as a single column matrix, so
-/// operations on [`TMat`](type.TMat.html) are also valid on vectors.
+/// operations on [`TMat`] are also valid on vectors.
 ///
 /// # See also:
 ///
-/// * [`TMat`](type.TMat.html)
-/// * [`TVec1`](type.TVec1.html)
-/// * [`TVec2`](type.TVec2.html)
-/// * [`TVec3`](type.TVec3.html)
-/// * [`TVec4`](type.TVec4.html)
+/// * [`TMat`]
+/// * [`TVec1`]
+/// * [`TVec2`]
+/// * [`TVec3`]
+/// * [`TVec4`]
 pub type TVec<T, const R: usize> = SVector<T, R>;
 /// A quaternion with components of type `T`.
 pub type Qua<T> = Quaternion<T>;
@@ -47,28 +47,28 @@ pub type Qua<T> = Quaternion<T>;
 ///
 /// ## Constructors:
 ///
-/// * [`make_vec1`](fn.make_vec1.html)
-/// * [`vec1`](fn.vec1.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec4_to_vec1`](fn.vec4_to_vec1.html)
+/// * [`make_vec1()`](crate::make_vec1)
+/// * [`vec1()`](crate::vec1)
+/// * [`vec2_to_vec1()`](crate::vec2_to_vec1)
+/// * [`vec3_to_vec1()`](crate::vec3_to_vec1)
+/// * [`vec4_to_vec1()`](crate::vec4_to_vec1)
 ///
 /// ## Related types:
 ///
-/// * [`BVec1`](type.BVec1.html)
-/// * [`DVec1`](type.DVec1.html)
-/// * [`IVec1`](type.IVec1.html)
-/// * [`I16Vec1`](type.I16Vec1.html)
-/// * [`I32Vec1`](type.I32Vec1.html)
-/// * [`I64Vec1`](type.I64Vec1.html)
-/// * [`I8Vec1`](type.I8Vec1.html)
-/// * [`TVec`](type.TVec.html)
-/// * [`UVec1`](type.UVec1.html)
-/// * [`U16Vec1`](type.U16Vec1.html)
-/// * [`U32Vec1`](type.U32Vec1.html)
-/// * [`U64Vec1`](type.U64Vec1.html)
-/// * [`U8Vec1`](type.U8Vec1.html)
-/// * [`Vec1`](type.Vec1.html)
+/// * [`BVec1`]
+/// * [`DVec1`]
+/// * [`IVec1`]
+/// * [`I16Vec1`]
+/// * [`I32Vec1`]
+/// * [`I64Vec1`]
+/// * [`I8Vec1`]
+/// * [`TVec`]
+/// * [`UVec1`]
+/// * [`U16Vec1`]
+/// * [`U32Vec1`]
+/// * [`U64Vec1`]
+/// * [`U8Vec1`]
+/// * [`Vec1`]
 pub type TVec1<T> = TVec<T, 1>;
 /// A 2D vector with components of type `T`.
 ///
@@ -76,29 +76,28 @@ pub type TVec1<T> = TVec<T, 1>;
 ///
 /// ## Constructors:
 ///
-/// * [`make_vec2`](fn.make_vec2.html)
-/// * [`vec2`](fn.vec2.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec4_to_vec2`](fn.vec4_to_vec2.html)
+/// * [`make_vec2()`](crate::make_vec2)
+/// * [`vec2()`](crate::vec2)
+/// * [`vec1_to_vec2()`](crate::vec1_to_vec2)
+/// * [`vec3_to_vec2()`](crate::vec3_to_vec2)
+/// * [`vec4_to_vec2()`](crate::vec4_to_vec2)
 ///
 /// ## Related types:
 ///
-/// * [`vec2`](fn.vec2.html)
-/// * [`BVec2`](type.BVec2.html)
-/// * [`DVec2`](type.DVec2.html)
-/// * [`IVec2`](type.IVec2.html)
-/// * [`I16Vec2`](type.I16Vec2.html)
-/// * [`I32Vec2`](type.I32Vec2.html)
-/// * [`I64Vec2`](type.I64Vec2.html)
-/// * [`I8Vec2`](type.I8Vec2.html)
-/// * [`TVec`](type.TVec.html)
-/// * [`UVec2`](type.UVec2.html)
-/// * [`U16Vec2`](type.U16Vec2.html)
-/// * [`U32Vec2`](type.U32Vec2.html)
-/// * [`U64Vec2`](type.U64Vec2.html)
-/// * [`U8Vec2`](type.U8Vec2.html)
-/// * [`Vec2`](type.Vec2.html)
+/// * [`BVec2`]
+/// * [`DVec2`]
+/// * [`IVec2`]
+/// * [`I16Vec2`]
+/// * [`I32Vec2`]
+/// * [`I64Vec2`]
+/// * [`I8Vec2`]
+/// * [`TVec`]
+/// * [`UVec2`]
+/// * [`U16Vec2`]
+/// * [`U32Vec2`]
+/// * [`U64Vec2`]
+/// * [`U8Vec2`]
+/// * [`Vec2`]
 pub type TVec2<T> = TVec<T, 2>;
 /// A 3D vector with components of type `T`.
 ///
@@ -106,29 +105,28 @@ pub type TVec2<T> = TVec<T, 2>;
 ///
 /// ## Constructors:
 ///
-/// * [`make_vec3`](fn.make_vec3.html)
-/// * [`vec3`](fn.vec3.html)
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec4_to_vec3`](fn.vec4_to_vec3.html)
+/// * [`make_vec3()`](crate::make_vec3)
+/// * [`vec3()`](crate::vec3)
+/// * [`vec1_to_vec3()`](crate::vec1_to_vec3)
+/// * [`vec2_to_vec3()`](crate::vec2_to_vec3)
+/// * [`vec4_to_vec3()`](crate::vec4_to_vec3)
 ///
 /// ## Related types:
 ///
-/// * [`vec3`](fn.vec3.html)
-/// * [`BVec3`](type.BVec3.html)
-/// * [`DVec3`](type.DVec3.html)
-/// * [`IVec3`](type.IVec3.html)
-/// * [`I16Vec3`](type.I16Vec3.html)
-/// * [`I32Vec3`](type.I32Vec3.html)
-/// * [`I64Vec3`](type.I64Vec3.html)
-/// * [`I8Vec3`](type.I8Vec3.html)
-/// * [`TVec`](type.TVec.html)
-/// * [`UVec3`](type.UVec3.html)
-/// * [`U16Vec3`](type.U16Vec3.html)
-/// * [`U32Vec3`](type.U32Vec3.html)
-/// * [`U64Vec3`](type.U64Vec3.html)
-/// * [`U8Vec3`](type.U8Vec3.html)
-/// * [`Vec3`](type.Vec3.html)
+/// * [`BVec3`]
+/// * [`DVec3`]
+/// * [`IVec3`]
+/// * [`I16Vec3`]
+/// * [`I32Vec3`]
+/// * [`I64Vec3`]
+/// * [`I8Vec3`]
+/// * [`TVec`]
+/// * [`UVec3`]
+/// * [`U16Vec3`]
+/// * [`U32Vec3`]
+/// * [`U64Vec3`]
+/// * [`U8Vec3`]
+/// * [`Vec3`]
 pub type TVec3<T> = TVec<T, 3>;
 /// A 4D vector with components of type `T`.
 ///
@@ -136,28 +134,27 @@ pub type TVec3<T> = TVec<T, 3>;
 ///
 /// ## Constructors:
 ///
-/// * [`make_vec4`](fn.make_vec4.html)
-/// * [`vec4`](fn.vec4.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
+/// * [`make_vec4()`](crate::make_vec4)
+/// * [`vec4()`](crate::vec4)
+/// * [`vec1_to_vec4()`](crate::vec1_to_vec4)
+/// * [`vec2_to_vec4()`](crate::vec2_to_vec4)
+/// * [`vec3_to_vec4()`](crate::vec3_to_vec4)
 ///
 /// ## Related types:
 ///
-/// * [`vec4`](fn.vec4.html)
-/// * [`BVec4`](type.BVec4.html)
-/// * [`DVec4`](type.DVec4.html)
-/// * [`IVec4`](type.IVec4.html)
-/// * [`I16Vec4`](type.I16Vec4.html)
-/// * [`I32Vec4`](type.I32Vec4.html)
-/// * [`I64Vec4`](type.I64Vec4.html)
-/// * [`I8Vec4`](type.I8Vec4.html)
-/// * [`UVec4`](type.UVec4.html)
-/// * [`U16Vec4`](type.U16Vec4.html)
-/// * [`U32Vec4`](type.U32Vec4.html)
-/// * [`U64Vec4`](type.U64Vec4.html)
-/// * [`U8Vec4`](type.U8Vec4.html)
-/// * [`Vec4`](type.Vec4.html)
+/// * [`BVec4`]
+/// * [`DVec4`]
+/// * [`IVec4`]
+/// * [`I16Vec4`]
+/// * [`I32Vec4`]
+/// * [`I64Vec4`]
+/// * [`I8Vec4`]
+/// * [`UVec4`]
+/// * [`U16Vec4`]
+/// * [`U32Vec4`]
+/// * [`U64Vec4`]
+/// * [`U8Vec4`]
+/// * [`Vec4`]
 pub type TVec4<T> = TVec<T, 4>;
 /// A 1D vector with boolean components.
 pub type BVec1 = TVec1<bool>;

--- a/nalgebra-glm/src/common.rs
+++ b/nalgebra-glm/src/common.rs
@@ -20,7 +20,7 @@ use crate::RealNumber;
 ///
 /// # See also:
 ///
-/// * [`sign`](fn.sign.html)
+/// * [`sign()`]
 pub fn abs<T: Number, const R: usize, const C: usize>(x: &TMat<T, R, C>) -> TMat<T, R, C> {
     x.abs()
 }
@@ -37,11 +37,11 @@ pub fn abs<T: Number, const R: usize, const C: usize>(x: &TMat<T, R, C>) -> TMat
 ///
 /// # See also:
 ///
-/// * [`ceil`](fn.ceil.html)
-/// * [`floor`](fn.floor.html)
-/// * [`fract`](fn.fract.html)
-/// * [`round`](fn.round.html)
-/// * [`trunc`](fn.trunc.html)
+/// * [`ceil()`]
+/// * [`floor()`]
+/// * [`fract()`]
+/// * [`round()`]
+/// * [`trunc()`]
 pub fn ceil<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| x.ceil())
 }
@@ -65,8 +65,8 @@ pub fn ceil<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`clamp`](fn.clamp.html)
-/// * [`clamp_vec`](fn.clamp_vec.html)
+/// * [`clamp()`]
+/// * [`clamp_vec()`]
 pub fn clamp_scalar<T: Number>(x: T, min_val: T, max_val: T) -> T {
     na::clamp(x, min_val, max_val)
 }
@@ -89,8 +89,8 @@ pub fn clamp_scalar<T: Number>(x: T, min_val: T, max_val: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`clamp_scalar`](fn.clamp_scalar.html)
-/// * [`clamp_vec`](fn.clamp_vec.html)
+/// * [`clamp_scalar()`]
+/// * [`clamp_vec()`]
 pub fn clamp<T: Number, const D: usize>(x: &TVec<T, D>, min_val: T, max_val: T) -> TVec<T, D> {
     x.map(|x| na::clamp(x, min_val, max_val))
 }
@@ -120,8 +120,8 @@ pub fn clamp<T: Number, const D: usize>(x: &TVec<T, D>, min_val: T, max_val: T) 
 ///
 /// # See also:
 ///
-/// * [`clamp_scalar`](fn.clamp_scalar.html)
-/// * [`clamp`](fn.clamp.html)
+/// * [`clamp_scalar()`]
+/// * [`clamp()`]
 pub fn clamp_vec<T: Number, const D: usize>(
     x: &TVec<T, D>,
     min_val: &TVec<T, D>,
@@ -136,13 +136,13 @@ pub fn clamp_vec<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn float_bits_to_int(v: f32) -> i32 {
     unsafe { mem::transmute(v) }
 }
@@ -153,13 +153,13 @@ pub fn float_bits_to_int(v: f32) -> i32 {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn float_bits_to_int_vec<const D: usize>(v: &TVec<f32, D>) -> TVec<i32, D> {
     v.map(float_bits_to_int)
 }
@@ -170,13 +170,13 @@ pub fn float_bits_to_int_vec<const D: usize>(v: &TVec<f32, D>) -> TVec<i32, D> {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn float_bits_to_uint(v: f32) -> u32 {
     unsafe { mem::transmute(v) }
 }
@@ -187,13 +187,13 @@ pub fn float_bits_to_uint(v: f32) -> u32 {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn float_bits_to_uint_vec<const D: usize>(v: &TVec<f32, D>) -> TVec<u32, D> {
     v.map(float_bits_to_uint)
 }
@@ -210,10 +210,10 @@ pub fn float_bits_to_uint_vec<const D: usize>(v: &TVec<f32, D>) -> TVec<u32, D> 
 ///
 /// # See also:
 ///
-/// * [`ceil`](fn.ceil.html)
-/// * [`fract`](fn.fract.html)
-/// * [`round`](fn.round.html)
-/// * [`trunc`](fn.trunc.html)
+/// * [`ceil()`]
+/// * [`fract()`]
+/// * [`round()`]
+/// * [`trunc()`]
 pub fn floor<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| x.floor())
 }
@@ -236,10 +236,10 @@ pub fn floor<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`ceil`](fn.ceil.html)
-/// * [`floor`](fn.floor.html)
-/// * [`round`](fn.round.html)
-/// * [`trunc`](fn.trunc.html)
+/// * [`ceil()`]
+/// * [`floor()`]
+/// * [`round()`]
+/// * [`trunc()`]
 pub fn fract<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| x.fract())
 }
@@ -258,13 +258,13 @@ pub fn fract<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn int_bits_to_float(v: i32) -> f32 {
     f32::from_bits(v as u32)
 }
@@ -275,13 +275,13 @@ pub fn int_bits_to_float(v: i32) -> f32 {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`uint_bits_to_float()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn int_bits_to_float_vec<const D: usize>(v: &TVec<i32, D>) -> TVec<f32, D> {
     v.map(int_bits_to_float)
 }
@@ -315,8 +315,8 @@ pub fn int_bits_to_float_vec<const D: usize>(v: &TVec<i32, D>) -> TVec<f32, D> {
 ///
 /// # See also:
 ///
-/// * [`mix`](fn.mix.html)
-/// * [`mix_vec`](fn.mix_vec.html)
+/// * [`mix()`]
+/// * [`mix_vec()`]
 pub fn mix_scalar<T: Number>(x: T, y: T, a: T) -> T {
     x * (T::one() - a) + y * a
 }
@@ -336,8 +336,8 @@ pub fn mix_scalar<T: Number>(x: T, y: T, a: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`mix_scalar`](fn.mix_scalar.html)
-/// * [`mix_vec`](fn.mix_vec.html)
+/// * [`mix_scalar()`]
+/// * [`mix_vec()`]
 pub fn mix<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>, a: T) -> TVec<T, D> {
     x * (T::one() - a) + y * a
 }
@@ -359,8 +359,8 @@ pub fn mix<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>, a: T) -> T
 ///
 /// # See also:
 ///
-/// * [`mix_scalar`](fn.mix_scalar.html)
-/// * [`mix`](fn.mix.html)
+/// * [`mix_scalar()`]
+/// * [`mix()`]
 pub fn mix_vec<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -383,8 +383,8 @@ pub fn mix_vec<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`lerp`](fn.lerp.html)
-/// * [`lerp_vec`](fn.lerp_vec.html)
+/// * [`lerp()`]
+/// * [`lerp_vec()`]
 pub fn lerp_scalar<T: Number>(x: T, y: T, a: T) -> T {
     mix_scalar(x, y, a)
 }
@@ -405,8 +405,8 @@ pub fn lerp_scalar<T: Number>(x: T, y: T, a: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`lerp_scalar`](fn.lerp_scalar.html)
-/// * [`lerp_vec`](fn.lerp_vec.html)
+/// * [`lerp_scalar()`]
+/// * [`lerp_vec()`]
 pub fn lerp<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>, a: T) -> TVec<T, D> {
     mix(x, y, a)
 }
@@ -429,8 +429,8 @@ pub fn lerp<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>, a: T) -> 
 ///
 /// # See also:
 ///
-/// * [`lerp_scalar`](fn.lerp_scalar.html)
-/// * [`lerp`](fn.lerp.html)
+/// * [`lerp_scalar()`]
+/// * [`lerp()`]
 pub fn lerp_vec<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -445,7 +445,7 @@ pub fn lerp_vec<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`modf`](fn.modf.html)
+/// * [`modf()`]
 pub fn modf_vec<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<T, D> {
     x.zip_map(y, |x, y| x % y)
 }
@@ -454,7 +454,7 @@ pub fn modf_vec<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TV
 ///
 /// # See also:
 ///
-/// * [`modf_vec`](fn.modf_vec.html)
+/// * [`modf_vec()`]
 pub fn modf<T: Number>(x: T, i: T) -> T {
     x % i
 }
@@ -473,10 +473,10 @@ pub fn modf<T: Number>(x: T, i: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`ceil`](fn.ceil.html)
-/// * [`floor`](fn.floor.html)
-/// * [`fract`](fn.fract.html)
-/// * [`trunc`](fn.trunc.html)
+/// * [`ceil()`]
+/// * [`floor()`]
+/// * [`fract()`]
+/// * [`trunc()`]
 pub fn round<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| x.round())
 }
@@ -497,7 +497,7 @@ pub fn round<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`abs`](fn.abs.html)
+/// * [`abs()`]
 ///
 pub fn sign<T: Number, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| if x.is_zero() { T::zero() } else { x.signum() })
@@ -545,10 +545,10 @@ pub fn step_vec<T: Number, const D: usize>(edge: &TVec<T, D>, x: &TVec<T, D>) ->
 ///
 /// # See also:
 ///
-/// * [`ceil`](fn.ceil.html)
-/// * [`floor`](fn.floor.html)
-/// * [`fract`](fn.fract.html)
-/// * [`round`](fn.round.html)
+/// * [`ceil()`]
+/// * [`floor()`]
+/// * [`fract()`]
+/// * [`round()`]
 pub fn trunc<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
     x.map(|x| x.trunc())
 }
@@ -559,13 +559,13 @@ pub fn trunc<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float`](fn.uint_bits_to_float.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float()`]
 pub fn uint_bits_to_float_scalar(v: u32) -> f32 {
     f32::from_bits(v)
 }
@@ -576,13 +576,13 @@ pub fn uint_bits_to_float_scalar(v: u32) -> f32 {
 ///
 /// # See also:
 ///
-/// * [`float_bits_to_int`](fn.float_bits_to_int.html)
-/// * [`float_bits_to_int_vec`](fn.float_bits_to_int_vec.html)
-/// * [`float_bits_to_uint`](fn.float_bits_to_uint.html)
-/// * [`float_bits_to_uint_vec`](fn.float_bits_to_uint_vec.html)
-/// * [`int_bits_to_float`](fn.int_bits_to_float.html)
-/// * [`int_bits_to_float_vec`](fn.int_bits_to_float_vec.html)
-/// * [`uint_bits_to_float_scalar`](fn.uint_bits_to_float_scalar.html)
+/// * [`float_bits_to_int()`]
+/// * [`float_bits_to_int_vec()`]
+/// * [`float_bits_to_uint()`]
+/// * [`float_bits_to_uint_vec()`]
+/// * [`int_bits_to_float()`]
+/// * [`int_bits_to_float_vec()`]
+/// * [`uint_bits_to_float_scalar()`]
 pub fn uint_bits_to_float<const D: usize>(v: &TVec<u32, D>) -> TVec<f32, D> {
     v.map(uint_bits_to_float_scalar)
 }

--- a/nalgebra-glm/src/exponential.rs
+++ b/nalgebra-glm/src/exponential.rs
@@ -5,7 +5,7 @@ use crate::RealNumber;
 ///
 /// # See also:
 ///
-/// * [`exp2`](fn.exp2.html)
+/// * [`exp2()`]
 pub fn exp<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| x.exp())
 }
@@ -14,7 +14,7 @@ pub fn exp<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`exp`](fn.exp.html)
+/// * [`exp()`]
 pub fn exp2<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| x.exp2())
 }
@@ -23,7 +23,7 @@ pub fn exp2<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`sqrt`](fn.sqrt.html)
+/// * [`sqrt()`]
 pub fn inversesqrt<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| T::one() / x.sqrt())
 }
@@ -32,7 +32,7 @@ pub fn inversesqrt<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> 
 ///
 /// # See also:
 ///
-/// * [`log2`](fn.log2.html)
+/// * [`log2()`]
 pub fn log<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| x.ln())
 }
@@ -41,7 +41,7 @@ pub fn log<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`log`](fn.log.html)
+/// * [`log()`]
 pub fn log2<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| x.log2())
 }
@@ -55,10 +55,10 @@ pub fn pow<T: RealNumber, const D: usize>(base: &TVec<T, D>, exponent: &TVec<T, 
 ///
 /// # See also:
 ///
-/// * [`exp`](fn.exp.html)
-/// * [`exp2`](fn.exp2.html)
-/// * [`inversesqrt`](fn.inversesqrt.html)
-/// * [`pow`](fn.pow.html)
+/// * [`exp()`]
+/// * [`exp2()`]
+/// * [`inversesqrt()`]
+/// * [`pow`]
 pub fn sqrt<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> TVec<T, D> {
     v.map(|x| x.sqrt())
 }

--- a/nalgebra-glm/src/ext/matrix_projection.rs
+++ b/nalgebra-glm/src/ext/matrix_projection.rs
@@ -41,11 +41,11 @@ pub fn pick_matrix<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project_no`](fn.project_no.html)
-/// * [`project_zo`](fn.project_zo.html)
-/// * [`unproject`](fn.unproject.html)
-/// * [`unproject_no`](fn.unproject_no.html)
-/// * [`unproject_zo`](fn.unproject_zo.html)
+/// * [`project_no()`]
+/// * [`project_zo()`]
+/// * [`unproject()`]
+/// * [`unproject_no()`]
+/// * [`unproject_zo()`]
 pub fn project<T: RealNumber>(
     obj: &TVec3<T>,
     model: &TMat4<T>,
@@ -68,11 +68,11 @@ pub fn project<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project`](fn.project.html)
-/// * [`project_zo`](fn.project_zo.html)
-/// * [`unproject`](fn.unproject.html)
-/// * [`unproject_no`](fn.unproject_no.html)
-/// * [`unproject_zo`](fn.unproject_zo.html)
+/// * [`project()`]
+/// * [`project_zo()`]
+/// * [`unproject()`]
+/// * [`unproject_no()`]
+/// * [`unproject_zo()`]
 pub fn project_no<T: RealNumber>(
     obj: &TVec3<T>,
     model: &TMat4<T>,
@@ -96,11 +96,11 @@ pub fn project_no<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project`](fn.project.html)
-/// * [`project_no`](fn.project_no.html)
-/// * [`unproject`](fn.unproject.html)
-/// * [`unproject_no`](fn.unproject_no.html)
-/// * [`unproject_zo`](fn.unproject_zo.html)
+/// * [`project()`]
+/// * [`project_no()`]
+/// * [`unproject()`]
+/// * [`unproject_no()`]
+/// * [`unproject_zo()`]
 pub fn project_zo<T: RealNumber>(
     obj: &TVec3<T>,
     model: &TMat4<T>,
@@ -129,11 +129,11 @@ pub fn project_zo<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project`](fn.project.html)
-/// * [`project_no`](fn.project_no.html)
-/// * [`project_zo`](fn.project_zo.html)
-/// * [`unproject_no`](fn.unproject_no.html)
-/// * [`unproject_zo`](fn.unproject_zo.html)
+/// * [`project()`]
+/// * [`project_no()`]
+/// * [`project_zo()`]
+/// * [`unproject_no()`]
+/// * [`unproject_zo()`]
 pub fn unproject<T: RealNumber>(
     win: &TVec3<T>,
     model: &TMat4<T>,
@@ -156,11 +156,11 @@ pub fn unproject<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project`](fn.project.html)
-/// * [`project_no`](fn.project_no.html)
-/// * [`project_zo`](fn.project_zo.html)
-/// * [`unproject`](fn.unproject.html)
-/// * [`unproject_zo`](fn.unproject_zo.html)
+/// * [`project()`]
+/// * [`project_no()`]
+/// * [`project_zo()`]
+/// * [`unproject()`]
+/// * [`unproject_zo()`]
 pub fn unproject_no<T: RealNumber>(
     win: &TVec3<T>,
     model: &TMat4<T>,
@@ -193,11 +193,11 @@ pub fn unproject_no<T: RealNumber>(
 ///
 /// # See also:
 ///
-/// * [`project`](fn.project.html)
-/// * [`project_no`](fn.project_no.html)
-/// * [`project_zo`](fn.project_zo.html)
-/// * [`unproject`](fn.unproject.html)
-/// * [`unproject_no`](fn.unproject_no.html)
+/// * [`project()`]
+/// * [`project_no()`]
+/// * [`project_zo()`]
+/// * [`unproject()`]
+/// * [`unproject_no()`]
 pub fn unproject_zo<T: RealNumber>(
     win: &TVec3<T>,
     model: &TMat4<T>,

--- a/nalgebra-glm/src/ext/matrix_transform.rs
+++ b/nalgebra-glm/src/ext/matrix_transform.rs
@@ -18,8 +18,8 @@ pub fn identity<T: Number, const D: usize>() -> TMat<T, D, D> {
 ///
 /// # See also:
 ///
-/// * [`look_at_lh`](fn.look_at_lh.html)
-/// * [`look_at_rh`](fn.look_at_rh.html)
+/// * [`look_at_lh()`]
+/// * [`look_at_rh()`]
 pub fn look_at<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T>) -> TMat4<T> {
     look_at_rh(eye, center, up)
 }
@@ -34,8 +34,8 @@ pub fn look_at<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T>) 
 ///
 /// # See also:
 ///
-/// * [`look_at`](fn.look_at.html)
-/// * [`look_at_rh`](fn.look_at_rh.html)
+/// * [`look_at()`]
+/// * [`look_at_rh()`]
 pub fn look_at_lh<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T>) -> TMat4<T> {
     TMat::look_at_lh(&Point3::from(*eye), &Point3::from(*center), up)
 }
@@ -50,8 +50,8 @@ pub fn look_at_lh<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T
 ///
 /// # See also:
 ///
-/// * [`look_at`](fn.look_at.html)
-/// * [`look_at_lh`](fn.look_at_lh.html)
+/// * [`look_at()`]
+/// * [`look_at_lh()`]
 pub fn look_at_rh<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T>) -> TMat4<T> {
     TMat::look_at_rh(&Point3::from(*eye), &Point3::from(*center), up)
 }
@@ -66,11 +66,11 @@ pub fn look_at_rh<T: RealNumber>(eye: &TVec3<T>, center: &TVec3<T>, up: &TVec3<T
 ///
 /// # See also:
 ///
-/// * [`rotate_x`](fn.rotate_x.html)
-/// * [`rotate_y`](fn.rotate_y.html)
-/// * [`rotate_z`](fn.rotate_z.html)
-/// * [`scale`](fn.scale.html)
-/// * [`translate`](fn.translate.html)
+/// * [`rotate_x()`]
+/// * [`rotate_y()`]
+/// * [`rotate_z()`]
+/// * [`scale()`]
+/// * [`translate()`]
 pub fn rotate<T: RealNumber>(m: &TMat4<T>, angle: T, axis: &TVec3<T>) -> TMat4<T> {
     m * Rotation3::from_axis_angle(&Unit::new_normalize(*axis), angle).to_homogeneous()
 }
@@ -84,11 +84,11 @@ pub fn rotate<T: RealNumber>(m: &TMat4<T>, angle: T, axis: &TVec3<T>) -> TMat4<T
 ///
 /// # See also:
 ///
-/// * [`rotate`](fn.rotate.html)
-/// * [`rotate_y`](fn.rotate_y.html)
-/// * [`rotate_z`](fn.rotate_z.html)
-/// * [`scale`](fn.scale.html)
-/// * [`translate`](fn.translate.html)
+/// * [`rotate()`]
+/// * [`rotate_y()`]
+/// * [`rotate_z()`]
+/// * [`scale()`]
+/// * [`translate()`]
 pub fn rotate_x<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
     rotate(m, angle, &TVec::x())
 }
@@ -102,11 +102,11 @@ pub fn rotate_x<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate`](fn.rotate.html)
-/// * [`rotate_x`](fn.rotate_x.html)
-/// * [`rotate_z`](fn.rotate_z.html)
-/// * [`scale`](fn.scale.html)
-/// * [`translate`](fn.translate.html)
+/// * [`rotate()`]
+/// * [`rotate_x()`]
+/// * [`rotate_z()`]
+/// * [`scale()`]
+/// * [`translate()`]
 pub fn rotate_y<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
     rotate(m, angle, &TVec::y())
 }
@@ -120,11 +120,11 @@ pub fn rotate_y<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate`](fn.rotate.html)
-/// * [`rotate_x`](fn.rotate_x.html)
-/// * [`rotate_y`](fn.rotate_y.html)
-/// * [`scale`](fn.scale.html)
-/// * [`translate`](fn.translate.html)
+/// * [`rotate()`]
+/// * [`rotate_x()`]
+/// * [`rotate_y()`]
+/// * [`scale()`]
+/// * [`translate()`]
 pub fn rotate_z<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
     rotate(m, angle, &TVec::z())
 }
@@ -138,11 +138,11 @@ pub fn rotate_z<T: RealNumber>(m: &TMat4<T>, angle: T) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate`](fn.rotate.html)
-/// * [`rotate_x`](fn.rotate_x.html)
-/// * [`rotate_y`](fn.rotate_y.html)
-/// * [`rotate_z`](fn.rotate_z.html)
-/// * [`translate`](fn.translate.html)
+/// * [`rotate()`]
+/// * [`rotate_x()`]
+/// * [`rotate_y()`]
+/// * [`rotate_z()`]
+/// * [`translate()`]
 pub fn scale<T: Number>(m: &TMat4<T>, v: &TVec3<T>) -> TMat4<T> {
     m.prepend_nonuniform_scaling(v)
 }
@@ -156,11 +156,11 @@ pub fn scale<T: Number>(m: &TMat4<T>, v: &TVec3<T>) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate`](fn.rotate.html)
-/// * [`rotate_x`](fn.rotate_x.html)
-/// * [`rotate_y`](fn.rotate_y.html)
-/// * [`rotate_z`](fn.rotate_z.html)
-/// * [`scale`](fn.scale.html)
+/// * [`rotate()`]
+/// * [`rotate_x()`]
+/// * [`rotate_y()`]
+/// * [`rotate_z()`]
+/// * [`scale()`]
 pub fn translate<T: Number>(m: &TMat4<T>, v: &TVec3<T>) -> TMat4<T> {
     m.prepend_translation(v)
 }

--- a/nalgebra-glm/src/ext/scalar_common.rs
+++ b/nalgebra-glm/src/ext/scalar_common.rs
@@ -12,9 +12,9 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`max4_scalar`](fn.max4_scalar.html)
-/// * [`min3_scalar`](fn.min3_scalar.html)
-/// * [`min4_scalar`](fn.min4_scalar.html)
+/// * [`max4_scalar()`]
+/// * [`min3_scalar()`]
+/// * [`min4_scalar()`]
 pub fn max2_scalar<T: Number>(a: T, b: T) -> T {
     if a >= b {
         a
@@ -35,9 +35,9 @@ pub fn max2_scalar<T: Number>(a: T, b: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`max4_scalar`](fn.max4_scalar.html)
-/// * [`min3_scalar`](fn.min3_scalar.html)
-/// * [`min4_scalar`](fn.min4_scalar.html)
+/// * [`max4_scalar()`]
+/// * [`min3_scalar()`]
+/// * [`min4_scalar()`]
 pub fn min2_scalar<T: Number>(a: T, b: T) -> T {
     if a <= b {
         a
@@ -58,9 +58,9 @@ pub fn min2_scalar<T: Number>(a: T, b: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`max4_scalar`](fn.max4_scalar.html)
-/// * [`min3_scalar`](fn.min3_scalar.html)
-/// * [`min4_scalar`](fn.min4_scalar.html)
+/// * [`max4_scalar()`]
+/// * [`min3_scalar()`]
+/// * [`min4_scalar()`]
 pub fn max3_scalar<T: Number>(a: T, b: T, c: T) -> T {
     max2_scalar(max2_scalar(a, b), c)
 }
@@ -77,9 +77,9 @@ pub fn max3_scalar<T: Number>(a: T, b: T, c: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`max3_scalar`](fn.max3_scalar.html)
-/// * [`min3_scalar`](fn.min3_scalar.html)
-/// * [`min4_scalar`](fn.min4_scalar.html)
+/// * [`max3_scalar()`]
+/// * [`min3_scalar()`]
+/// * [`min4_scalar()`]
 pub fn max4_scalar<T: Number>(a: T, b: T, c: T, d: T) -> T {
     max2_scalar(max2_scalar(a, b), max2_scalar(c, d))
 }
@@ -96,9 +96,9 @@ pub fn max4_scalar<T: Number>(a: T, b: T, c: T, d: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`max3_scalar`](fn.max3_scalar.html)
-/// * [`max4_scalar`](fn.max4_scalar.html)
-/// * [`min4_scalar`](fn.min4_scalar.html)
+/// * [`max3_scalar()`]
+/// * [`max4_scalar()`]
+/// * [`min4_scalar()`]
 pub fn min3_scalar<T: Number>(a: T, b: T, c: T) -> T {
     min2_scalar(min2_scalar(a, b), c)
 }
@@ -115,9 +115,9 @@ pub fn min3_scalar<T: Number>(a: T, b: T, c: T) -> T {
 ///
 /// # See also:
 ///
-/// * [`max3_scalar`](fn.max3_scalar.html)
-/// * [`max4_scalar`](fn.max4_scalar.html)
-/// * [`min3_scalar`](fn.min3_scalar.html)
+/// * [`max3_scalar()`]
+/// * [`max4_scalar()`]
+/// * [`min3_scalar()`]
 pub fn min4_scalar<T: Number>(a: T, b: T, c: T, d: T) -> T {
     min2_scalar(min2_scalar(a, b), min2_scalar(c, d))
 }

--- a/nalgebra-glm/src/ext/scalar_constants.rs
+++ b/nalgebra-glm/src/ext/scalar_constants.rs
@@ -10,18 +10,18 @@ pub fn epsilon<T: AbsDiffEq<Epsilon = T>>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`](crate::four_over_pi)
+/// * [`half_pi()`](crate::half_pi)
+/// * [`one_over_pi()`](crate::one_over_pi)
+/// * [`one_over_two_pi()`](crate::one_over_two_pi)
+/// * [`quarter_pi()`](crate::quarter_pi)
+/// * [`root_half_pi()`](crate::root_half_pi)
+/// * [`root_pi()`](crate::root_pi)
+/// * [`root_two_pi()`](crate::root_two_pi)
+/// * [`three_over_two_pi()`](crate::three_over_two_pi)
+/// * [`two_over_pi()`](crate::two_over_pi)
+/// * [`two_over_root_pi()`](crate::two_over_root_pi)
+/// * [`two_pi()`](crate::two_pi)
 pub fn pi<T: RealNumber>() -> T {
     T::pi()
 }

--- a/nalgebra-glm/src/ext/vector_common.rs
+++ b/nalgebra-glm/src/ext/vector_common.rs
@@ -5,15 +5,15 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn max<T: Number, const D: usize>(a: &TVec<T, D>, b: T) -> TVec<T, D> {
     a.map(|a| crate::max2_scalar(a, b))
 }
@@ -22,15 +22,15 @@ pub fn max<T: Number, const D: usize>(a: &TVec<T, D>, b: T) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn max2<T: Number, const D: usize>(a: &TVec<T, D>, b: &TVec<T, D>) -> TVec<T, D> {
     a.zip_map(b, |a, b| crate::max2_scalar(a, b))
 }
@@ -39,15 +39,15 @@ pub fn max2<T: Number, const D: usize>(a: &TVec<T, D>, b: &TVec<T, D>) -> TVec<T
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn max3<T: Number, const D: usize>(
     a: &TVec<T, D>,
     b: &TVec<T, D>,
@@ -60,15 +60,15 @@ pub fn max3<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn max4<T: Number, const D: usize>(
     a: &TVec<T, D>,
     b: &TVec<T, D>,
@@ -82,15 +82,15 @@ pub fn max4<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min2()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn min<T: Number, const D: usize>(x: &TVec<T, D>, y: T) -> TVec<T, D> {
     x.map(|x| crate::min2_scalar(x, y))
 }
@@ -99,15 +99,15 @@ pub fn min<T: Number, const D: usize>(x: &TVec<T, D>, y: T) -> TVec<T, D> {
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min3()`]
+/// * [`min4()`]
 pub fn min2<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<T, D> {
     x.zip_map(y, |a, b| crate::min2_scalar(a, b))
 }
@@ -116,15 +116,15 @@ pub fn min2<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<T
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min4()`]
 pub fn min3<T: Number, const D: usize>(
     a: &TVec<T, D>,
     b: &TVec<T, D>,
@@ -137,15 +137,15 @@ pub fn min3<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
+/// * [`comp_max()`](crate::comp_max)
+/// * [`comp_min()`](crate::comp_min)
+/// * [`max()`]
+/// * [`max2()`]
+/// * [`max3()`]
+/// * [`max4()`]
+/// * [`min()`]
+/// * [`min2()`]
+/// * [`min3()`]
 pub fn min4<T: Number, const D: usize>(
     a: &TVec<T, D>,
     b: &TVec<T, D>,

--- a/nalgebra-glm/src/ext/vector_relational.rs
+++ b/nalgebra-glm/src/ext/vector_relational.rs
@@ -5,9 +5,9 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`equal_eps_vec`](fn.equal_eps_vec.html)
-/// * [`not_equal_eps`](fn.not_equal_eps.html)
-/// * [`not_equal_eps_vec`](fn.not_equal_eps_vec.html)
+/// * [`equal_eps_vec()`]
+/// * [`not_equal_eps()`]
+/// * [`not_equal_eps_vec()`]
 pub fn equal_eps<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -20,9 +20,9 @@ pub fn equal_eps<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`equal_eps`](fn.equal_eps.html)
-/// * [`not_equal_eps`](fn.not_equal_eps.html)
-/// * [`not_equal_eps_vec`](fn.not_equal_eps_vec.html)
+/// * [`equal_eps()`]
+/// * [`not_equal_eps()`]
+/// * [`not_equal_eps_vec()`]
 pub fn equal_eps_vec<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -35,9 +35,9 @@ pub fn equal_eps_vec<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`equal_eps`](fn.equal_eps.html)
-/// * [`equal_eps_vec`](fn.equal_eps_vec.html)
-/// * [`not_equal_eps_vec`](fn.not_equal_eps_vec.html)
+/// * [`equal_eps()`]
+/// * [`equal_eps_vec()`]
+/// * [`not_equal_eps_vec()`]
 pub fn not_equal_eps<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -50,9 +50,9 @@ pub fn not_equal_eps<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`equal_eps`](fn.equal_eps.html)
-/// * [`equal_eps_vec`](fn.equal_eps_vec.html)
-/// * [`not_equal_eps`](fn.not_equal_eps.html)
+/// * [`equal_eps()`]
+/// * [`equal_eps_vec()`]
+/// * [`not_equal_eps()`]
 pub fn not_equal_eps_vec<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,

--- a/nalgebra-glm/src/geometric.rs
+++ b/nalgebra-glm/src/geometric.rs
@@ -12,7 +12,7 @@ pub fn cross<T: Number>(x: &TVec3<T>, y: &TVec3<T>) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`distance2`](fn.distance2.html)
+/// * [`distance2()`](crate::distance2)
 pub fn distance<T: RealNumber, const D: usize>(p0: &TVec<T, D>, p1: &TVec<T, D>) -> T {
     (p1 - p0).norm()
 }
@@ -37,13 +37,13 @@ pub fn faceforward<T: Number, const D: usize>(
 
 /// The magnitude of a vector.
 ///
-/// A synonym for [`magnitude`](fn.magnitude.html).
+/// A synonym for [`magnitude()`].
 ///
 /// # See also:
 ///
-/// * [`length2`](fn.length2.html)
-/// * [`magnitude`](fn.magnitude.html)
-/// * [`magnitude2`](fn.magnitude2.html)
+/// * [`length2()`](crate::length2)
+/// * [`magnitude()`]
+/// * [`magnitude2()`](crate::magnitude2)
 pub fn length<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
     x.norm()
 }
@@ -54,8 +54,8 @@ pub fn length<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
 ///
 /// # See also:
 ///
-/// * [`length`](fn.length.html)
-/// * [`magnitude2`](fn.magnitude2.html)
+/// * [`length()`]
+/// * [`magnitude2()`](crate::magnitude2)
 /// * [`nalgebra::norm`](../nalgebra/fn.norm.html)
 pub fn magnitude<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
     x.norm()

--- a/nalgebra-glm/src/gtc/constants.rs
+++ b/nalgebra-glm/src/gtc/constants.rs
@@ -3,7 +3,7 @@ use na;
 
 /// The Euler constant.
 ///
-/// This is a shorthand alias for [`euler`](fn.euler.html).
+/// This is a shorthand alias for [`euler()`].
 pub fn e<T: RealNumber>() -> T {
     T::e()
 }
@@ -17,18 +17,18 @@ pub fn euler<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn four_over_pi<T: RealNumber>() -> T {
     na::convert::<_, T>(4.0) / T::pi()
 }
@@ -42,18 +42,18 @@ pub fn golden_ratio<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn half_pi<T: RealNumber>() -> T {
     T::frac_pi_2()
 }
@@ -62,8 +62,8 @@ pub fn half_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`ln_ten`](fn.ln_ten.html)
-/// * [`ln_two`](fn.ln_two.html)
+/// * [`ln_ten()`]
+/// * [`ln_two()`]
 pub fn ln_ln_two<T: RealNumber>() -> T {
     T::ln_2().ln()
 }
@@ -72,8 +72,8 @@ pub fn ln_ln_two<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`ln_ln_two`](fn.ln_ln_two.html)
-/// * [`ln_two`](fn.ln_two.html)
+/// * [`ln_ln_two()`]
+/// * [`ln_two()`]
 pub fn ln_ten<T: RealNumber>() -> T {
     T::ln_10()
 }
@@ -82,8 +82,8 @@ pub fn ln_ten<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`ln_ln_two`](fn.ln_ln_two.html)
-/// * [`ln_ten`](fn.ln_ten.html)
+/// * [`ln_ln_two()`]
+/// * [`ln_ten()`]
 pub fn ln_two<T: RealNumber>() -> T {
     T::ln_2()
 }
@@ -95,18 +95,18 @@ pub use na::one;
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn one_over_pi<T: RealNumber>() -> T {
     T::frac_1_pi()
 }
@@ -120,18 +120,18 @@ pub fn one_over_root_two<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn one_over_two_pi<T: RealNumber>() -> T {
     T::frac_1_pi() * na::convert(0.5)
 }
@@ -140,18 +140,18 @@ pub fn one_over_two_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn quarter_pi<T: RealNumber>() -> T {
     T::frac_pi_4()
 }
@@ -160,8 +160,8 @@ pub fn quarter_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`root_three`](fn.root_three.html)
-/// * [`root_two`](fn.root_two.html)
+/// * [`root_three()`]
+/// * [`root_two()`]
 pub fn root_five<T: RealNumber>() -> T {
     na::convert::<_, T>(5.0).sqrt()
 }
@@ -170,18 +170,18 @@ pub fn root_five<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn root_half_pi<T: RealNumber>() -> T {
     (T::pi() / na::convert(2.0)).sqrt()
 }
@@ -195,18 +195,18 @@ pub fn root_ln_four<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn root_pi<T: RealNumber>() -> T {
     T::pi().sqrt()
 }
@@ -215,8 +215,8 @@ pub fn root_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`root_five`](fn.root_five.html)
-/// * [`root_two`](fn.root_two.html)
+/// * [`root_five()`]
+/// * [`root_two()`]
 pub fn root_three<T: RealNumber>() -> T {
     na::convert::<_, T>(3.0).sqrt()
 }
@@ -225,8 +225,8 @@ pub fn root_three<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`root_five`](fn.root_five.html)
-/// * [`root_three`](fn.root_three.html)
+/// * [`root_five()`]
+/// * [`root_three()`]
 pub fn root_two<T: RealNumber>() -> T {
     // TODO: there should be a crate::sqrt_2() on the RealNumber trait.
     na::convert::<_, T>(2.0).sqrt()
@@ -236,18 +236,18 @@ pub fn root_two<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn root_two_pi<T: RealNumber>() -> T {
     T::two_pi().sqrt()
 }
@@ -256,7 +256,7 @@ pub fn root_two_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`two_thirds`](fn.two_thirds.html)
+/// * [`two_thirds()`]
 pub fn third<T: RealNumber>() -> T {
     na::convert(1.0 / 3.0)
 }
@@ -265,18 +265,18 @@ pub fn third<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn three_over_two_pi<T: RealNumber>() -> T {
     na::convert::<_, T>(3.0) / T::two_pi()
 }
@@ -285,17 +285,18 @@ pub fn three_over_two_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_root_pi()`]
+/// * [`two_pi()`]
 pub fn two_over_pi<T: RealNumber>() -> T {
     T::frac_2_pi()
 }
@@ -304,18 +305,18 @@ pub fn two_over_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_pi`](fn.two_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_pi()`]
 pub fn two_over_root_pi<T: RealNumber>() -> T {
     T::frac_2_sqrt_pi()
 }
@@ -324,18 +325,18 @@ pub fn two_over_root_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`four_over_pi`](fn.four_over_pi.html)
-/// * [`half_pi`](fn.half_pi.html)
-/// * [`one_over_pi`](fn.one_over_pi.html)
-/// * [`one_over_two_pi`](fn.one_over_two_pi.html)
-/// * [`pi`](fn.pi.html)
-/// * [`quarter_pi`](fn.quarter_pi.html)
-/// * [`root_half_pi`](fn.root_half_pi.html)
-/// * [`root_pi`](fn.root_pi.html)
-/// * [`root_two_pi`](fn.root_two_pi.html)
-/// * [`three_over_two_pi`](fn.three_over_two_pi.html)
-/// * [`two_over_pi`](fn.two_over_pi.html)
-/// * [`two_over_root_pi`](fn.two_over_root_pi.html)
+/// * [`four_over_pi()`]
+/// * [`half_pi()`]
+/// * [`one_over_pi()`]
+/// * [`one_over_two_pi()`]
+/// * [`pi()`](crate::pi)
+/// * [`quarter_pi()`]
+/// * [`root_half_pi()`]
+/// * [`root_pi()`]
+/// * [`root_two_pi()`]
+/// * [`three_over_two_pi()`]
+/// * [`two_over_pi()`]
+/// * [`two_over_root_pi()`]
 pub fn two_pi<T: RealNumber>() -> T {
     T::two_pi()
 }
@@ -344,7 +345,7 @@ pub fn two_pi<T: RealNumber>() -> T {
 ///
 /// # See also:
 ///
-/// * [`third`](fn.third.html)
+/// * [`third()`]
 pub fn two_thirds<T: RealNumber>() -> T {
     na::convert(2.0 / 3.0)
 }

--- a/nalgebra-glm/src/gtc/matrix_access.rs
+++ b/nalgebra-glm/src/gtc/matrix_access.rs
@@ -6,9 +6,9 @@ use crate::aliases::{TMat, TVec};
 ///
 /// # See also:
 ///
-/// * [`row`](fn.row.html)
-/// * [`set_column`](fn.set_column.html)
-/// * [`set_row`](fn.set_row.html)
+/// * [`row()`]
+/// * [`set_column()`]
+/// * [`set_row()`]
 pub fn column<T: Scalar, const R: usize, const C: usize>(
     m: &TMat<T, R, C>,
     index: usize,
@@ -20,9 +20,9 @@ pub fn column<T: Scalar, const R: usize, const C: usize>(
 ///
 /// # See also:
 ///
-/// * [`column`](fn.column.html)
-/// * [`row`](fn.row.html)
-/// * [`set_row`](fn.set_row.html)
+/// * [`column()`]
+/// * [`row()`]
+/// * [`set_row()`]
 pub fn set_column<T: Scalar, const R: usize, const C: usize>(
     m: &TMat<T, R, C>,
     index: usize,
@@ -37,9 +37,9 @@ pub fn set_column<T: Scalar, const R: usize, const C: usize>(
 ///
 /// # See also:
 ///
-/// * [`column`](fn.column.html)
-/// * [`set_column`](fn.set_column.html)
-/// * [`set_row`](fn.set_row.html)
+/// * [`column()`]
+/// * [`set_column()`]
+/// * [`set_row()`]
 pub fn row<T: Scalar, const R: usize, const C: usize>(
     m: &TMat<T, R, C>,
     index: usize,
@@ -51,9 +51,9 @@ pub fn row<T: Scalar, const R: usize, const C: usize>(
 ///
 /// # See also:
 ///
-/// * [`column`](fn.column.html)
-/// * [`row`](fn.row.html)
-/// * [`set_column`](fn.set_column.html)
+/// * [`column()`]
+/// * [`row()`]
+/// * [`set_column()`]
 pub fn set_row<T: Scalar, const R: usize, const C: usize>(
     m: &TMat<T, R, C>,
     index: usize,

--- a/nalgebra-glm/src/gtc/type_ptr.rs
+++ b/nalgebra-glm/src/gtc/type_ptr.rs
@@ -128,9 +128,9 @@ pub fn make_quat<T: RealNumber>(ptr: &[T]) -> Qua<T> {
 ///
 /// # See also:
 ///
-/// * [`make_vec2`](fn.make_vec2.html)
-/// * [`make_vec3`](fn.make_vec3.html)
-/// * [`make_vec4`](fn.make_vec4.html)
+/// * [`make_vec2()`]
+/// * [`make_vec3()`]
+/// * [`make_vec4()`]
 pub fn make_vec1<T: Scalar>(v: &TVec1<T>) -> TVec1<T> {
     v.clone()
 }
@@ -139,12 +139,11 @@ pub fn make_vec1<T: Scalar>(v: &TVec1<T>) -> TVec1<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec1`](fn.vec1_to_vec1.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec4_to_vec1`](fn.vec4_to_vec1.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
+/// * [`vec3_to_vec1()`]
+/// * [`vec4_to_vec1()`]
+/// * [`vec1_to_vec2()`]
+/// * [`vec1_to_vec3()`]
+/// * [`vec1_to_vec4()`]
 pub fn vec2_to_vec1<T: Scalar>(v: &TVec2<T>) -> TVec1<T> {
     TVec1::new(v.x.clone())
 }
@@ -153,12 +152,11 @@ pub fn vec2_to_vec1<T: Scalar>(v: &TVec2<T>) -> TVec1<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec1`](fn.vec1_to_vec1.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec4_to_vec1`](fn.vec4_to_vec1.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
+/// * [`vec2_to_vec1()`]
+/// * [`vec4_to_vec1()`]
+/// * [`vec1_to_vec2()`]
+/// * [`vec1_to_vec3()`]
+/// * [`vec1_to_vec4()`]
 pub fn vec3_to_vec1<T: Scalar>(v: &TVec3<T>) -> TVec1<T> {
     TVec1::new(v.x.clone())
 }
@@ -167,12 +165,11 @@ pub fn vec3_to_vec1<T: Scalar>(v: &TVec3<T>) -> TVec1<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec1`](fn.vec1_to_vec1.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
+/// * [`vec2_to_vec1()`]
+/// * [`vec3_to_vec1()`]
+/// * [`vec1_to_vec2()`]
+/// * [`vec1_to_vec3()`]
+/// * [`vec1_to_vec4()`]
 pub fn vec4_to_vec1<T: Scalar>(v: &TVec4<T>) -> TVec1<T> {
     TVec1::new(v.x.clone())
 }
@@ -183,12 +180,12 @@ pub fn vec4_to_vec1<T: Scalar>(v: &TVec4<T>) -> TVec1<T> {
 ///
 /// # See also:
 ///
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec4_to_vec2`](fn.vec4_to_vec2.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec2_to_vec2`](fn.vec2_to_vec2.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
+/// * [`vec3_to_vec2()`]
+/// * [`vec4_to_vec2()`]
+/// * [`vec2_to_vec1()`]
+/// * [`vec2_to_vec2()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec2_to_vec4()`]
 pub fn vec1_to_vec2<T: Number>(v: &TVec1<T>) -> TVec2<T> {
     TVec2::new(v.x.clone(), T::zero())
 }
@@ -197,13 +194,13 @@ pub fn vec1_to_vec2<T: Number>(v: &TVec1<T>) -> TVec2<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec4_to_vec2`](fn.vec4_to_vec2.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec2_to_vec2`](fn.vec2_to_vec2.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
+/// * [`vec1_to_vec2()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec4_to_vec2()`]
+/// * [`vec2_to_vec1()`]
+/// * [`vec2_to_vec2()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec2_to_vec4()`]
 pub fn vec2_to_vec2<T: Scalar>(v: &TVec2<T>) -> TVec2<T> {
     v.clone()
 }
@@ -212,12 +209,12 @@ pub fn vec2_to_vec2<T: Scalar>(v: &TVec2<T>) -> TVec2<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec4_to_vec2`](fn.vec4_to_vec2.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec2_to_vec2`](fn.vec2_to_vec2.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
+/// * [`vec1_to_vec2()`]
+/// * [`vec4_to_vec2()`]
+/// * [`vec2_to_vec1()`]
+/// * [`vec2_to_vec2()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec2_to_vec4()`]
 pub fn vec3_to_vec2<T: Scalar>(v: &TVec3<T>) -> TVec2<T> {
     TVec2::new(v.x.clone(), v.y.clone())
 }
@@ -226,12 +223,12 @@ pub fn vec3_to_vec2<T: Scalar>(v: &TVec3<T>) -> TVec2<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec3_to_vec2`](fn.vec4_to_vec2.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec2_to_vec2`](fn.vec2_to_vec2.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
+/// * [`vec1_to_vec2()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec2_to_vec1()`]
+/// * [`vec2_to_vec2()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec2_to_vec4()`]
 pub fn vec4_to_vec2<T: Scalar>(v: &TVec4<T>) -> TVec2<T> {
     TVec2::new(v.x.clone(), v.y.clone())
 }
@@ -240,9 +237,9 @@ pub fn vec4_to_vec2<T: Scalar>(v: &TVec4<T>) -> TVec2<T> {
 ///
 /// # See also:
 ///
-/// * [`make_vec1`](fn.make_vec1.html)
-/// * [`make_vec3`](fn.make_vec3.html)
-/// * [`make_vec4`](fn.make_vec4.html)
+/// * [`make_vec1()`]
+/// * [`make_vec3()`]
+/// * [`make_vec4()`]
 pub fn make_vec2<T: Scalar>(ptr: &[T]) -> TVec2<T> {
     TVec2::from_column_slice(ptr)
 }
@@ -253,11 +250,11 @@ pub fn make_vec2<T: Scalar>(ptr: &[T]) -> TVec2<T> {
 ///
 /// # See also:
 ///
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec3_to_vec3`](fn.vec3_to_vec3.html)
-/// * [`vec4_to_vec3`](fn.vec4_to_vec3.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
+/// * [`vec2_to_vec3()`]
+/// * [`vec3_to_vec3()`]
+/// * [`vec4_to_vec3()`]
+/// * [`vec1_to_vec2()`]
+/// * [`vec1_to_vec4()`]
 pub fn vec1_to_vec3<T: Number>(v: &TVec1<T>) -> TVec3<T> {
     TVec3::new(v.x.clone(), T::zero(), T::zero())
 }
@@ -268,12 +265,12 @@ pub fn vec1_to_vec3<T: Number>(v: &TVec1<T>) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec3_to_vec3`](fn.vec3_to_vec3.html)
-/// * [`vec4_to_vec3`](fn.vec4_to_vec3.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
+/// * [`vec1_to_vec3()`]
+/// * [`vec3_to_vec3()`]
+/// * [`vec4_to_vec3()`]
+/// * [`vec3_to_vec1()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec3_to_vec4()`]
 pub fn vec2_to_vec3<T: Number>(v: &TVec2<T>) -> TVec3<T> {
     TVec3::new(v.x.clone(), v.y.clone(), T::zero())
 }
@@ -282,12 +279,12 @@ pub fn vec2_to_vec3<T: Number>(v: &TVec2<T>) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec4_to_vec3`](fn.vec4_to_vec3.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
+/// * [`vec1_to_vec3()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec4_to_vec3()`]
+/// * [`vec3_to_vec1()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec3_to_vec4()`]
 pub fn vec3_to_vec3<T: Scalar>(v: &TVec3<T>) -> TVec3<T> {
     v.clone()
 }
@@ -296,12 +293,12 @@ pub fn vec3_to_vec3<T: Scalar>(v: &TVec3<T>) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
-/// * [`vec3_to_vec3`](fn.vec3_to_vec3.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
+/// * [`vec1_to_vec3()`]
+/// * [`vec2_to_vec3()`]
+/// * [`vec3_to_vec3()`]
+/// * [`vec3_to_vec1()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec3_to_vec4()`]
 pub fn vec4_to_vec3<T: Scalar>(v: &TVec4<T>) -> TVec3<T> {
     TVec3::new(v.x.clone(), v.y.clone(), v.z.clone())
 }
@@ -310,9 +307,9 @@ pub fn vec4_to_vec3<T: Scalar>(v: &TVec4<T>) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`make_vec1`](fn.make_vec1.html)
-/// * [`make_vec2`](fn.make_vec2.html)
-/// * [`make_vec4`](fn.make_vec4.html)
+/// * [`make_vec1()`]
+/// * [`make_vec2()`]
+/// * [`make_vec4()`]
 pub fn make_vec3<T: Scalar>(ptr: &[T]) -> TVec3<T> {
     TVec3::from_column_slice(ptr)
 }
@@ -323,12 +320,12 @@ pub fn make_vec3<T: Scalar>(ptr: &[T]) -> TVec3<T> {
 ///
 /// # See also:
 ///
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
-/// * [`vec4_to_vec4`](fn.vec4_to_vec4.html)
-/// * [`vec1_to_vec2`](fn.vec1_to_vec2.html)
-/// * [`vec1_to_vec3`](fn.vec1_to_vec3.html)
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
+/// * [`vec2_to_vec4()`]
+/// * [`vec3_to_vec4()`]
+/// * [`vec4_to_vec4()`]
+/// * [`vec1_to_vec2()`]
+/// * [`vec1_to_vec3()`]
+/// * [`vec1_to_vec4()`]
 pub fn vec1_to_vec4<T: Number>(v: &TVec1<T>) -> TVec4<T> {
     TVec4::new(v.x, T::zero(), T::zero(), T::zero())
 }
@@ -339,12 +336,12 @@ pub fn vec1_to_vec4<T: Number>(v: &TVec1<T>) -> TVec4<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
-/// * [`vec4_to_vec4`](fn.vec4_to_vec4.html)
-/// * [`vec2_to_vec1`](fn.vec2_to_vec1.html)
-/// * [`vec2_to_vec2`](fn.vec2_to_vec2.html)
-/// * [`vec2_to_vec3`](fn.vec2_to_vec3.html)
+/// * [`vec1_to_vec4()`]
+/// * [`vec3_to_vec4()`]
+/// * [`vec4_to_vec4()`]
+/// * [`vec2_to_vec1()`]
+/// * [`vec2_to_vec2()`]
+/// * [`vec2_to_vec3()`]
 pub fn vec2_to_vec4<T: Number>(v: &TVec2<T>) -> TVec4<T> {
     TVec4::new(v.x, v.y, T::zero(), T::zero())
 }
@@ -355,12 +352,12 @@ pub fn vec2_to_vec4<T: Number>(v: &TVec2<T>) -> TVec4<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
-/// * [`vec4_to_vec4`](fn.vec4_to_vec4.html)
-/// * [`vec3_to_vec1`](fn.vec3_to_vec1.html)
-/// * [`vec3_to_vec2`](fn.vec3_to_vec2.html)
-/// * [`vec3_to_vec3`](fn.vec3_to_vec3.html)
+/// * [`vec1_to_vec4()`]
+/// * [`vec2_to_vec4()`]
+/// * [`vec4_to_vec4()`]
+/// * [`vec3_to_vec1()`]
+/// * [`vec3_to_vec2()`]
+/// * [`vec3_to_vec3()`]
 pub fn vec3_to_vec4<T: Number>(v: &TVec3<T>) -> TVec4<T> {
     TVec4::new(v.x, v.y, v.z, T::zero())
 }
@@ -369,12 +366,12 @@ pub fn vec3_to_vec4<T: Number>(v: &TVec3<T>) -> TVec4<T> {
 ///
 /// # See also:
 ///
-/// * [`vec1_to_vec4`](fn.vec1_to_vec4.html)
-/// * [`vec2_to_vec4`](fn.vec2_to_vec4.html)
-/// * [`vec3_to_vec4`](fn.vec3_to_vec4.html)
-/// * [`vec4_to_vec1`](fn.vec4_to_vec1.html)
-/// * [`vec4_to_vec2`](fn.vec4_to_vec2.html)
-/// * [`vec4_to_vec3`](fn.vec4_to_vec3.html)
+/// * [`vec1_to_vec4()`]
+/// * [`vec2_to_vec4()`]
+/// * [`vec3_to_vec4()`]
+/// * [`vec4_to_vec1()`]
+/// * [`vec4_to_vec2()`]
+/// * [`vec4_to_vec3()`]
 pub fn vec4_to_vec4<T: Scalar>(v: &TVec4<T>) -> TVec4<T> {
     v.clone()
 }
@@ -383,9 +380,9 @@ pub fn vec4_to_vec4<T: Scalar>(v: &TVec4<T>) -> TVec4<T> {
 ///
 /// # See also:
 ///
-/// * [`make_vec1`](fn.make_vec1.html)
-/// * [`make_vec2`](fn.make_vec2.html)
-/// * [`make_vec3`](fn.make_vec3.html)
+/// * [`make_vec1()`]
+/// * [`make_vec2()`]
+/// * [`make_vec3()`]
 pub fn make_vec4<T: Scalar>(ptr: &[T]) -> TVec4<T> {
     TVec4::from_column_slice(ptr)
 }

--- a/nalgebra-glm/src/gtx/component_wise.rs
+++ b/nalgebra-glm/src/gtx/component_wise.rs
@@ -16,9 +16,9 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`comp_mul`](fn.comp_mul.html)
+/// * [`comp_max()`]
+/// * [`comp_min()`]
+/// * [`comp_mul()`]
 pub fn comp_add<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) -> T {
     m.iter().fold(T::zero(), |x, y| x + *y)
 }
@@ -38,13 +38,13 @@ pub fn comp_add<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) ->
 ///
 /// # See also:
 ///
-/// * [`comp_add`](fn.comp_add.html)
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
-/// * [`max`](fn.max.html)
-/// * [`max2`](fn.max2.html)
-/// * [`max3`](fn.max3.html)
-/// * [`max4`](fn.max4.html)
+/// * [`comp_add()`]
+/// * [`comp_max()`]
+/// * [`comp_min()`]
+/// * [`max()`](crate::max)
+/// * [`max2()`](crate::max2)
+/// * [`max3()`](crate::max3)
+/// * [`max4()`](crate::max4)
 pub fn comp_max<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) -> T {
     m.iter()
         .fold(T::min_value(), |x, y| crate::max2_scalar(x, *y))
@@ -65,13 +65,13 @@ pub fn comp_max<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) ->
 ///
 /// # See also:
 ///
-/// * [`comp_add`](fn.comp_add.html)
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_mul`](fn.comp_mul.html)
-/// * [`min`](fn.min.html)
-/// * [`min2`](fn.min2.html)
-/// * [`min3`](fn.min3.html)
-/// * [`min4`](fn.min4.html)
+/// * [`comp_add()`]
+/// * [`comp_max()`]
+/// * [`comp_mul()`]
+/// * [`min()`](crate::min)
+/// * [`min2()`](crate::min2)
+/// * [`min3()`](crate::min3)
+/// * [`min4()`](crate::min4)
 pub fn comp_min<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) -> T {
     m.iter()
         .fold(T::max_value(), |x, y| crate::min2_scalar(x, *y))
@@ -92,9 +92,9 @@ pub fn comp_min<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) ->
 ///
 /// # See also:
 ///
-/// * [`comp_add`](fn.comp_add.html)
-/// * [`comp_max`](fn.comp_max.html)
-/// * [`comp_min`](fn.comp_min.html)
+/// * [`comp_add()`]
+/// * [`comp_max()`]
+/// * [`comp_min()`]
 pub fn comp_mul<T: Number, const R: usize, const C: usize>(m: &TMat<T, R, C>) -> T {
     m.iter().fold(T::one(), |x, y| x * *y)
 }

--- a/nalgebra-glm/src/gtx/handed_coordinate_space.rs
+++ b/nalgebra-glm/src/gtx/handed_coordinate_space.rs
@@ -5,7 +5,7 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`right_handed`](fn.right_handed.html)
+/// * [`right_handed()`]
 pub fn left_handed<T: Number>(a: &TVec3<T>, b: &TVec3<T>, c: &TVec3<T>) -> bool {
     a.cross(b).dot(c) < T::zero()
 }
@@ -14,7 +14,7 @@ pub fn left_handed<T: Number>(a: &TVec3<T>, b: &TVec3<T>, c: &TVec3<T>) -> bool 
 ///
 /// # See also:
 ///
-/// * [`left_handed`](fn.left_handed.html)
+/// * [`left_handed()`]
 pub fn right_handed<T: Number>(a: &TVec3<T>, b: &TVec3<T>, c: &TVec3<T>) -> bool {
     a.cross(b).dot(c) > T::zero()
 }

--- a/nalgebra-glm/src/gtx/matrix_cross_product.rs
+++ b/nalgebra-glm/src/gtx/matrix_cross_product.rs
@@ -5,7 +5,7 @@ use crate::RealNumber;
 ///
 /// # See also:
 ///
-/// * [`matrix_cross`](fn.matrix_cross.html)
+/// * [`matrix_cross()`]
 pub fn matrix_cross3<T: RealNumber>(x: &TVec3<T>) -> TMat3<T> {
     x.cross_matrix()
 }
@@ -14,7 +14,7 @@ pub fn matrix_cross3<T: RealNumber>(x: &TVec3<T>) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`matrix_cross3`](fn.matrix_cross3.html)
+/// * [`matrix_cross3()`]
 pub fn matrix_cross<T: RealNumber>(x: &TVec3<T>) -> TMat4<T> {
     crate::mat3_to_mat4(&x.cross_matrix())
 }

--- a/nalgebra-glm/src/gtx/matrix_operation.rs
+++ b/nalgebra-glm/src/gtx/matrix_operation.rs
@@ -7,14 +7,14 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal2x2<T: Number>(v: &TVec2<T>) -> TMat2<T> {
     TMat2::from_diagonal(v)
 }
@@ -23,14 +23,14 @@ pub fn diagonal2x2<T: Number>(v: &TVec2<T>) -> TMat2<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal2x3<T: Number>(v: &TVec2<T>) -> TMat2x3<T> {
     TMat2x3::from_partial_diagonal(v.as_slice())
 }
@@ -39,14 +39,14 @@ pub fn diagonal2x3<T: Number>(v: &TVec2<T>) -> TMat2x3<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal2x4<T: Number>(v: &TVec2<T>) -> TMat2x4<T> {
     TMat2x4::from_partial_diagonal(v.as_slice())
 }
@@ -55,14 +55,14 @@ pub fn diagonal2x4<T: Number>(v: &TVec2<T>) -> TMat2x4<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal3x2<T: Number>(v: &TVec2<T>) -> TMat3x2<T> {
     TMat3x2::from_partial_diagonal(v.as_slice())
 }
@@ -71,14 +71,14 @@ pub fn diagonal3x2<T: Number>(v: &TVec2<T>) -> TMat3x2<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal3x3<T: Number>(v: &TVec3<T>) -> TMat3<T> {
     TMat3::from_diagonal(v)
 }
@@ -87,14 +87,14 @@ pub fn diagonal3x3<T: Number>(v: &TVec3<T>) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal3x4<T: Number>(v: &TVec3<T>) -> TMat3x4<T> {
     TMat3x4::from_partial_diagonal(v.as_slice())
 }
@@ -103,14 +103,14 @@ pub fn diagonal3x4<T: Number>(v: &TVec3<T>) -> TMat3x4<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x3()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal4x2<T: Number>(v: &TVec2<T>) -> TMat4x2<T> {
     TMat4x2::from_partial_diagonal(v.as_slice())
 }
@@ -119,14 +119,14 @@ pub fn diagonal4x2<T: Number>(v: &TVec2<T>) -> TMat4x2<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x4`](fn.diagonal4x4.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x4()`]
 pub fn diagonal4x3<T: Number>(v: &TVec3<T>) -> TMat4x3<T> {
     TMat4x3::from_partial_diagonal(v.as_slice())
 }
@@ -135,14 +135,14 @@ pub fn diagonal4x3<T: Number>(v: &TVec3<T>) -> TMat4x3<T> {
 ///
 /// # See also:
 ///
-/// * [`diagonal2x2`](fn.diagonal2x2.html)
-/// * [`diagonal2x3`](fn.diagonal2x3.html)
-/// * [`diagonal2x4`](fn.diagonal2x4.html)
-/// * [`diagonal3x2`](fn.diagonal3x2.html)
-/// * [`diagonal3x3`](fn.diagonal3x3.html)
-/// * [`diagonal3x4`](fn.diagonal3x4.html)
-/// * [`diagonal4x2`](fn.diagonal4x2.html)
-/// * [`diagonal4x3`](fn.diagonal4x3.html)
+/// * [`diagonal2x2()`]
+/// * [`diagonal2x3()`]
+/// * [`diagonal2x4()`]
+/// * [`diagonal3x2()`]
+/// * [`diagonal3x3()`]
+/// * [`diagonal3x4()`]
+/// * [`diagonal4x2()`]
+/// * [`diagonal4x3()`]
 pub fn diagonal4x4<T: Number>(v: &TVec4<T>) -> TMat4<T> {
     TMat4::from_diagonal(v)
 }

--- a/nalgebra-glm/src/gtx/norm.rs
+++ b/nalgebra-glm/src/gtx/norm.rs
@@ -5,7 +5,7 @@ use crate::RealNumber;
 ///
 /// # See also:
 ///
-/// * [`distance`](fn.distance.html)
+/// * [`distance()`](crate::distance)
 pub fn distance2<T: RealNumber, const D: usize>(p0: &TVec<T, D>, p1: &TVec<T, D>) -> T {
     (p1 - p0).norm_squared()
 }
@@ -14,9 +14,9 @@ pub fn distance2<T: RealNumber, const D: usize>(p0: &TVec<T, D>, p1: &TVec<T, D>
 ///
 /// # See also:
 ///
-/// * [`l1_norm`](fn.l1_norm.html)
-/// * [`l2_distance`](fn.l2_distance.html)
-/// * [`l2_norm`](fn.l2_norm.html)
+/// * [`l1_norm()`]
+/// * [`l2_distance()`]
+/// * [`l2_norm()`]
 pub fn l1_distance<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> T {
     l1_norm(&(y - x))
 }
@@ -28,27 +28,27 @@ pub fn l1_distance<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>
 ///
 /// # See also:
 ///
-/// * [`l1_distance`](fn.l1_distance.html)
-/// * [`l2_distance`](fn.l2_distance.html)
-/// * [`l2_norm`](fn.l2_norm.html)
+/// * [`l1_distance()`]
+/// * [`l2_distance()`]
+/// * [`l2_norm()`]
 pub fn l1_norm<T: RealNumber, const D: usize>(v: &TVec<T, D>) -> T {
     crate::comp_add(&v.abs())
 }
 
 /// The l2-norm of `x - y`.
 ///
-/// This is the same value as returned by [`length2`](fn.length2.html) and
-/// [`magnitude2`](fn.magnitude2.html).
+/// This is the same value as returned by [`length2()`] and
+/// [`magnitude2()`].
 ///
 /// # See also:
 ///
-/// * [`l1_distance`](fn.l1_distance.html)
-/// * [`l1_norm`](fn.l1_norm.html)
-/// * [`l2_norm`](fn.l2_norm.html)
-/// * [`length`](fn.length.html)
-/// * [`length2`](fn.length2.html)
-/// * [`magnitude`](fn.magnitude.html)
-/// * [`magnitude2`](fn.magnitude2.html)
+/// * [`l1_distance()`]
+/// * [`l1_norm()`]
+/// * [`l2_norm()`]
+/// * [`length()`](crate::length)
+/// * [`length2()`]
+/// * [`magnitude()`](crate::magnitude)
+/// * [`magnitude2()`]
 pub fn l2_distance<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> T {
     l2_norm(&(y - x))
 }
@@ -57,33 +57,33 @@ pub fn l2_distance<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>
 ///
 /// This is also known as the Euclidean norm.
 ///
-/// This is the same value as returned by [`length`](fn.length.html) and
-/// [`magnitude`](fn.magnitude.html).
+/// This is the same value as returned by [`length()`](crate::length) and
+/// [`magnitude()`](crate::magnitude).
 ///
 /// # See also:
 ///
-/// * [`l1_distance`](fn.l1_distance.html)
-/// * [`l1_norm`](fn.l1_norm.html)
-/// * [`l2_distance`](fn.l2_distance.html)
-/// * [`length`](fn.length.html)
-/// * [`length2`](fn.length2.html)
-/// * [`magnitude`](fn.magnitude.html)
-/// * [`magnitude2`](fn.magnitude2.html)
+/// * [`l1_distance()`]
+/// * [`l1_norm()`]
+/// * [`l2_distance()`]
+/// * [`length()`](crate::length)
+/// * [`length2()`]
+/// * [`magnitude()`](crate::magnitude)
+/// * [`magnitude2()`]
 pub fn l2_norm<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
     x.norm()
 }
 
 /// The squared magnitude of `x`.
 ///
-/// A synonym for [`magnitude2`](fn.magnitude2.html).
+/// A synonym for [`magnitude2()`].
 ///
 /// # See also:
 ///
-/// * [`distance`](fn.distance.html)
-/// * [`distance2`](fn.distance2.html)
-/// * [`length`](fn.length.html)
-/// * [`magnitude`](fn.magnitude.html)
-/// * [`magnitude2`](fn.magnitude2.html)
+/// * [`distance()`](crate::distance)
+/// * [`distance2()`]
+/// * [`length()`](crate::length)
+/// * [`magnitude()`](crate::magnitude)
+/// * [`magnitude2()`]
 pub fn length2<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
     x.norm_squared()
 }
@@ -94,10 +94,10 @@ pub fn length2<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
 ///
 /// # See also:
 ///
-/// * [`distance`](fn.distance.html)
-/// * [`distance2`](fn.distance2.html)
-/// * [`length2`](fn.length2.html)
-/// * [`magnitude`](fn.magnitude.html)
+/// * [`distance()`](crate::distance)
+/// * [`distance2()`]
+/// * [`length2()`]
+/// * [`magnitude()`](crate::magnitude)
 /// * [`nalgebra::norm_squared`](../nalgebra/fn.norm_squared.html)
 pub fn magnitude2<T: RealNumber, const D: usize>(x: &TVec<T, D>) -> T {
     x.norm_squared()

--- a/nalgebra-glm/src/gtx/normalize_dot.rs
+++ b/nalgebra-glm/src/gtx/normalize_dot.rs
@@ -4,11 +4,11 @@ use crate::aliases::TVec;
 
 /// The dot product of the normalized version of `x` and `y`.
 ///
-/// This is currently the same as [`normalize_dot`](fn.normalize_dot.html).
+/// This is currently the same as [`normalize_dot()`]
 ///
 /// # See also:
 ///
-/// * [`normalize_dot`](fn.normalize_dot.html`)
+/// * [`normalize_dot()`]
 pub fn fast_normalize_dot<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> T {
     // XXX: improve those.
     x.normalize().dot(&y.normalize())
@@ -18,7 +18,7 @@ pub fn fast_normalize_dot<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVe
 ///
 /// # See also:
 ///
-/// * [`fast_normalize_dot`](fn.fast_normalize_dot.html`)
+/// * [`fast_normalize_dot()`]
 pub fn normalize_dot<T: RealNumber, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> T {
     // XXX: improve those.
     x.normalize().dot(&y.normalize())

--- a/nalgebra-glm/src/gtx/transform.rs
+++ b/nalgebra-glm/src/gtx/transform.rs
@@ -7,11 +7,11 @@ use crate::traits::{Number, RealNumber};
 ///
 /// # See also:
 ///
-/// * [`scaling`](fn.scaling.html)
-/// * [`translation`](fn.translation.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`scaling()`]
+/// * [`translation()`]
+/// * [`rotation2d()`]
+/// * [`scaling2d()`]
+/// * [`translation2d()`]
 pub fn rotation<T: RealNumber>(angle: T, v: &TVec3<T>) -> TMat4<T> {
     Rotation3::from_axis_angle(&Unit::new_normalize(*v), angle).to_homogeneous()
 }
@@ -20,11 +20,11 @@ pub fn rotation<T: RealNumber>(angle: T, v: &TVec3<T>) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotation`](fn.rotation.html)
-/// * [`translation`](fn.translation.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotation()`]
+/// * [`translation()`]
+/// * [`rotation2d()`]
+/// * [`scaling2d()`]
+/// * [`translation2d()`]
 pub fn scaling<T: Number>(v: &TVec3<T>) -> TMat4<T> {
     TMat4::new_nonuniform_scaling(v)
 }
@@ -33,11 +33,11 @@ pub fn scaling<T: Number>(v: &TVec3<T>) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotation`](fn.rotation.html)
-/// * [`scaling`](fn.scaling.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotation()`]
+/// * [`scaling()`]
+/// * [`rotation2d()`]
+/// * [`scaling2d()`]
+/// * [`translation2d()`]
 pub fn translation<T: Number>(v: &TVec3<T>) -> TMat4<T> {
     TMat4::new_translation(v)
 }
@@ -46,11 +46,11 @@ pub fn translation<T: Number>(v: &TVec3<T>) -> TMat4<T> {
 ///
 /// # See also:
 ///
-/// * [`rotation`](fn.rotation.html)
-/// * [`scaling`](fn.scaling.html)
-/// * [`translation`](fn.translation.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotation()`]
+/// * [`scaling()`]
+/// * [`translation()`]
+/// * [`scaling2d()`]
+/// * [`translation2d()`]
 pub fn rotation2d<T: RealNumber>(angle: T) -> TMat3<T> {
     Rotation2::new(angle).to_homogeneous()
 }
@@ -59,11 +59,11 @@ pub fn rotation2d<T: RealNumber>(angle: T) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`rotation`](fn.rotation.html)
-/// * [`scaling`](fn.scaling.html)
-/// * [`translation`](fn.translation.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotation()`]
+/// * [`scaling()`]
+/// * [`translation()`]
+/// * [`rotation2d()`]
+/// * [`translation2d()`]
 pub fn scaling2d<T: Number>(v: &TVec2<T>) -> TMat3<T> {
     TMat3::new_nonuniform_scaling(v)
 }
@@ -72,11 +72,11 @@ pub fn scaling2d<T: Number>(v: &TVec2<T>) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`rotation`](fn.rotation.html)
-/// * [`scaling`](fn.scaling.html)
-/// * [`translation`](fn.translation.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
+/// * [`rotation()`]
+/// * [`scaling()`]
+/// * [`translation()`]
+/// * [`rotation2d()`]
+/// * [`scaling2d()`]
 pub fn translation2d<T: Number>(v: &TVec2<T>) -> TMat3<T> {
     TMat3::new_translation(v)
 }

--- a/nalgebra-glm/src/gtx/transform2d.rs
+++ b/nalgebra-glm/src/gtx/transform2d.rs
@@ -7,11 +7,11 @@ use crate::traits::{Number, RealNumber};
 ///
 /// # See also:
 ///
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scale2d`](fn.scale2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translate2d`](fn.translate2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotation2d()`](crate::rotation2d)
+/// * [`scale2d()`]
+/// * [`scaling2d()`](crate::scaling2d)
+/// * [`translate2d()`]
+/// * [`translation2d()`](crate::translation2d)
 pub fn rotate2d<T: RealNumber>(m: &TMat3<T>, angle: T) -> TMat3<T> {
     m * UnitComplex::new(angle).to_homogeneous()
 }
@@ -20,11 +20,11 @@ pub fn rotate2d<T: RealNumber>(m: &TMat3<T>, angle: T) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate2d`](fn.rotate2d.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translate2d`](fn.translate2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotate2d()`]
+/// * [`rotation2d()`](crate::rotation2d)
+/// * [`scaling2d()`](crate::scaling2d)
+/// * [`translate2d()`]
+/// * [`translation2d()`](crate::translation2d)
 pub fn scale2d<T: Number>(m: &TMat3<T>, v: &TVec2<T>) -> TMat3<T> {
     m.prepend_nonuniform_scaling(v)
 }
@@ -33,11 +33,11 @@ pub fn scale2d<T: Number>(m: &TMat3<T>, v: &TVec2<T>) -> TMat3<T> {
 ///
 /// # See also:
 ///
-/// * [`rotate2d`](fn.rotate2d.html)
-/// * [`rotation2d`](fn.rotation2d.html)
-/// * [`scale2d`](fn.scale2d.html)
-/// * [`scaling2d`](fn.scaling2d.html)
-/// * [`translation2d`](fn.translation2d.html)
+/// * [`rotate2d()`]
+/// * [`rotation2d()`](crate::rotation2d)
+/// * [`scale2d()`]
+/// * [`scaling2d()`](crate::scaling2d)
+/// * [`translation2d()`](crate::translation2d)
 pub fn translate2d<T: Number>(m: &TMat3<T>, v: &TVec2<T>) -> TMat3<T> {
     m.prepend_translation(v)
 }

--- a/nalgebra-glm/src/gtx/vector_query.rs
+++ b/nalgebra-glm/src/gtx/vector_query.rs
@@ -7,7 +7,7 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`are_collinear2d`](fn.are_collinear2d.html)
+/// * [`are_collinear2d()`]
 pub fn are_collinear<T: Number>(v0: &TVec3<T>, v1: &TVec3<T>, epsilon: T) -> bool {
     is_null(&v0.cross(v1), epsilon)
 }
@@ -16,7 +16,7 @@ pub fn are_collinear<T: Number>(v0: &TVec3<T>, v1: &TVec3<T>, epsilon: T) -> boo
 ///
 /// # See also:
 ///
-/// * [`are_collinear`](fn.are_collinear.html)
+/// * [`are_collinear()`]
 pub fn are_collinear2d<T: Number>(v0: &TVec2<T>, v1: &TVec2<T>, epsilon: T) -> bool {
     abs_diff_eq!(v0.perp(v1), T::zero(), epsilon = epsilon)
 }

--- a/nalgebra-glm/src/lib.rs
+++ b/nalgebra-glm/src/lib.rs
@@ -38,7 +38,7 @@
    * All function names use `snake_case`, which is the Rust convention.
    * All type names use `CamelCase`, which is the Rust convention.
    * All function arguments, except for scalars, are all passed by-reference.
-   * The most generic vector and matrix types are [`TMat`](type.TMat.html) and [`TVec`](type.TVec.html) instead of `mat` and `vec`.
+   * The most generic vector and matrix types are [`TMat`] and [`TVec`] instead of `mat` and `vec`.
    * Some feature are not yet implemented and should be added in the future. In particular, no packing
    functions are available.
    * A few features are not implemented and will never be. This includes functions related to color
@@ -47,17 +47,17 @@
 
    In addition, because Rust does not allows function overloading, all functions must be given a unique name.
    Here are a few rules chosen arbitrarily for **nalgebra-glm**:
-   * Functions operating in 2d will usually end with the `2d` suffix, e.g., [`glm::rotate2d`](fn.rotate2d.html) is for 2D while [`glm::rotate`](fn.rotate.html) is for 3D.
-   * Functions operating on vectors will often end with the `_vec` suffix, possibly followed by the dimension of vector, e.g., [`glm::rotate_vec2`](fn.rotate_vec2.html).
-   * Every function related to quaternions start with the `quat_` prefix, e.g., [`glm::quat_dot(q1, q2)`](fn.quat_dot.html).
+   * Functions operating in 2d will usually end with the `2d` suffix, e.g., [`glm::rotate2d()`](crate::rotate2d) is for 2D while [`glm::rotate()`](crate::rotate) is for 3D.
+   * Functions operating on vectors will often end with the `_vec` suffix, possibly followed by the dimension of vector, e.g., [`glm::rotate_vec2()`](crate::rotate_vec2).
+   * Every function related to quaternions start with the `quat_` prefix, e.g., [`glm::quat_dot(q1, q2)`](crate::quat_dot).
    * All the conversion functions have unique names as described [below](#conversions).
    ### Vector and matrix construction
    Vectors, matrices, and quaternions can be constructed using several approaches:
-   * Using functions with the same name as their type in lower-case. For example [`glm::vec3(x, y, z)`](fn.vec3.html) will create a 3D vector.
+   * Using functions with the same name as their type in lower-case. For example [`glm::vec3(x, y, z)`](crate::vec3) will create a 3D vector.
    * Using the `::new` constructor. For example [`Vec3::new(x, y, z)`](../nalgebra/base/type.OMatrix.html#method.new-27) will create a 3D vector.
-   * Using the functions prefixed by `make_` to build a vector a matrix from a slice. For example [`glm::make_vec3(&[x, y, z])`](fn.make_vec3.html) will create a 3D vector.
+   * Using the functions prefixed by `make_` to build a vector a matrix from a slice. For example [`glm::make_vec3(&[x, y, z])`](crate::make_vec3) will create a 3D vector.
    Keep in mind that constructing a matrix using this type of functions require its components to be arranged in column-major order on the slice.
-   * Using a geometric construction function. For example [`glm::rotation(angle, axis)`](fn.rotation.html) will build a 4x4 homogeneous rotation matrix from an angle (in radians) and an axis.
+   * Using a geometric construction function. For example [`glm::rotation(angle, axis)`](crate::rotation) will build a 4x4 homogeneous rotation matrix from an angle (in radians) and an axis.
    * Using swizzling and conversions as described in the next sections.
    ### Swizzling
    Vector swizzling is a native feature of **nalgebra** itself. Therefore, you can use it with all
@@ -75,9 +75,9 @@
    It is often useful to convert one algebraic type to another. There are two main approaches for converting
    between types in `nalgebra-glm`:
    * Using function with the form `type1_to_type2` in order to convert an instance of `type1` into an instance of `type2`.
-   For example [`glm::mat3_to_mat4(m)`](fn.mat3_to_mat4.html) will convert the 3x3 matrix `m` to a 4x4 matrix by appending one column on the right
+   For example [`glm::mat3_to_mat4(m)`](crate::mat3_to_mat4) will convert the 3x3 matrix `m` to a 4x4 matrix by appending one column on the right
    and one row on the left. Those now row and columns are filled with 0 except for the diagonal element which is set to 1.
-   * Using one of the [`convert`](fn.convert.html), [`try_convert`](fn.try_convert.html), or [`convert_unchecked`](fn.convert_unchecked.html) functions.
+   * Using one of the [`convert`](crate::convert), [`try_convert`](crate::try_convert), or [`convert_unchecked`](crate::convert_unchecked) functions.
    These functions are directly re-exported from nalgebra and are extremely versatile:
        1. The `convert` function can convert any type (especially geometric types from nalgebra like `Isometry3`) into another algebraic type which is equivalent but more general. For example,
    `let sim: Similarity3<_> = na::convert(isometry)` will convert an `Isometry3` into a `Similarity3`.

--- a/nalgebra-glm/src/vector_relational.rs
+++ b/nalgebra-glm/src/vector_relational.rs
@@ -16,8 +16,8 @@ use crate::traits::Number;
 ///
 /// # See also:
 ///
-/// * [`any`](fn.any.html)
-/// * [`not`](fn.not.html)
+/// * [`any()`]
+/// * [`not()`]
 pub fn all<const D: usize>(v: &TVec<bool, D>) -> bool {
     v.iter().all(|x| *x)
 }
@@ -40,8 +40,8 @@ pub fn all<const D: usize>(v: &TVec<bool, D>) -> bool {
 ///
 /// # See also:
 ///
-/// * [`all`](fn.all.html)
-/// * [`not`](fn.not.html)
+/// * [`all()`]
+/// * [`not()`]
 pub fn any<const D: usize>(v: &TVec<bool, D>) -> bool {
     v.iter().any(|x| *x)
 }
@@ -59,12 +59,12 @@ pub fn any<const D: usize>(v: &TVec<bool, D>) -> bool {
 ///
 /// # See also:
 ///
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not`](fn.not.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`greater_than()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than()`]
+/// * [`less_than_equal()`]
+/// * [`not()`]
+/// * [`not_equal()`]
 pub fn equal<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<bool, D> {
     x.zip_map(y, |x, y| x == y)
 }
@@ -82,12 +82,12 @@ pub fn equal<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<
 ///
 /// # See also:
 ///
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not`](fn.not.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`equal()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than()`]
+/// * [`less_than_equal()`]
+/// * [`not()`]
+/// * [`not_equal()`]
 pub fn greater_than<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<bool, D> {
     x.zip_map(y, |x, y| x > y)
 }
@@ -105,12 +105,12 @@ pub fn greater_than<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -
 ///
 /// # See also:
 ///
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not`](fn.not.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`equal()`]
+/// * [`greater_than()`]
+/// * [`less_than()`]
+/// * [`less_than_equal()`]
+/// * [`not()`]
+/// * [`not_equal()`]
 pub fn greater_than_equal<T: Number, const D: usize>(
     x: &TVec<T, D>,
     y: &TVec<T, D>,
@@ -131,12 +131,12 @@ pub fn greater_than_equal<T: Number, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not`](fn.not.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`equal()`]
+/// * [`greater_than()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than_equal()`]
+/// * [`not()`]
+/// * [`not_equal()`]
 pub fn less_than<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<bool, D> {
     x.zip_map(y, |x, y| x < y)
 }
@@ -154,12 +154,12 @@ pub fn less_than<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> T
 ///
 /// # See also:
 ///
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`not`](fn.not.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`equal()`]
+/// * [`greater_than()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than()`]
+/// * [`not()`]
+/// * [`not_equal()`]
 pub fn less_than_equal<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<bool, D> {
     x.zip_map(y, |x, y| x <= y)
 }
@@ -176,14 +176,14 @@ pub fn less_than_equal<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>
 ///
 /// # See also:
 ///
-/// * [`all`](fn.all.html)
-/// * [`any`](fn.any.html)
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not_equal`](fn.not_equal.html)
+/// * [`all()`]
+/// * [`any()`]
+/// * [`equal()`]
+/// * [`greater_than()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than()`]
+/// * [`less_than_equal()`]
+/// * [`not_equal()`]
 pub fn not<const D: usize>(v: &TVec<bool, D>) -> TVec<bool, D> {
     v.map(|x| !x)
 }
@@ -201,12 +201,12 @@ pub fn not<const D: usize>(v: &TVec<bool, D>) -> TVec<bool, D> {
 ///
 /// # See also:
 ///
-/// * [`equal`](fn.equal.html)
-/// * [`greater_than`](fn.greater_than.html)
-/// * [`greater_than_equal`](fn.greater_than_equal.html)
-/// * [`less_than`](fn.less_than.html)
-/// * [`less_than_equal`](fn.less_than_equal.html)
-/// * [`not`](fn.not.html)
+/// * [`equal()`]
+/// * [`greater_than()`]
+/// * [`greater_than_equal()`]
+/// * [`less_than()`]
+/// * [`less_than_equal()`]
+/// * [`not()`]
 pub fn not_equal<T: Number, const D: usize>(x: &TVec<T, D>, y: &TVec<T, D>) -> TVec<bool, D> {
     x.zip_map(y, |x, y| x != y)
 }

--- a/nalgebra-sparse/src/csc.rs
+++ b/nalgebra-sparse/src/csc.rs
@@ -158,7 +158,7 @@ impl<T> CscMatrix<T> {
     /// an error is returned to indicate the failure.
     ///
     /// An error is returned if the data given does not conform to the CSC storage format.
-    /// See the documentation for [CscMatrix](struct.CscMatrix.html) for more information.
+    /// See the documentation for [`CscMatrix`] for more information.
     pub fn try_from_csc_data(
         num_rows: usize,
         num_cols: usize,
@@ -184,7 +184,7 @@ impl<T> CscMatrix<T> {
     ///
     /// An error is returned if the data given does not conform to the CSC storage format
     /// with the exception of having unsorted row indices and values.
-    /// See the documentation for [CscMatrix](struct.CscMatrix.html) for more information.
+    /// See the documentation for [`CscMatrix`] for more information.
     pub fn try_from_unsorted_csc_data(
         num_rows: usize,
         num_cols: usize,
@@ -748,7 +748,7 @@ impl<'a, T> CscColMut<'a, T> {
     }
 }
 
-/// Column iterator for [CscMatrix](struct.CscMatrix.html).
+/// Column iterator for [`CscMatrix`].
 pub struct CscColIter<'a, T> {
     lane_iter: CsLaneIter<'a, T>,
 }
@@ -761,7 +761,7 @@ impl<'a, T> Iterator for CscColIter<'a, T> {
     }
 }
 
-/// Mutable column iterator for [CscMatrix](struct.CscMatrix.html).
+/// Mutable column iterator for [`CscMatrix`].
 pub struct CscColIterMut<'a, T> {
     lane_iter: CsLaneIterMut<'a, T>,
 }

--- a/nalgebra-sparse/src/csr.rs
+++ b/nalgebra-sparse/src/csr.rs
@@ -159,7 +159,7 @@ impl<T> CsrMatrix<T> {
     /// an error is returned to indicate the failure.
     ///
     /// An error is returned if the data given does not conform to the CSR storage format.
-    /// See the documentation for [CsrMatrix](struct.CsrMatrix.html) for more information.
+    /// See the documentation for [`CsrMatrix`] for more information.
     pub fn try_from_csr_data(
         num_rows: usize,
         num_cols: usize,
@@ -185,7 +185,7 @@ impl<T> CsrMatrix<T> {
     ///
     /// An error is returned if the data given does not conform to the CSR storage format
     /// with the exception of having unsorted column indices and values.
-    /// See the documentation for [CsrMatrix](struct.CsrMatrix.html) for more information.
+    /// See the documentation for [`CsrMatrix`] for more information.
     pub fn try_from_unsorted_csr_data(
         num_rows: usize,
         num_cols: usize,
@@ -753,7 +753,7 @@ impl<'a, T> CsrRowMut<'a, T> {
     }
 }
 
-/// Row iterator for [CsrMatrix](struct.CsrMatrix.html).
+/// Row iterator for [`CsrMatrix`].
 pub struct CsrRowIter<'a, T> {
     lane_iter: CsLaneIter<'a, T>,
 }
@@ -766,7 +766,7 @@ impl<'a, T> Iterator for CsrRowIter<'a, T> {
     }
 }
 
-/// Mutable row iterator for [CsrMatrix](struct.CsrMatrix.html).
+/// Mutable row iterator for [`CsrMatrix`].
 pub struct CsrRowIterMut<'a, T> {
     lane_iter: CsLaneIterMut<'a, T>,
 }

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -199,7 +199,7 @@ impl SparseFormatError {
     }
 }
 
-/// The type of format error described by a [SparseFormatError](struct.SparseFormatError.html).
+/// The type of format error described by a [`SparseFormatError`].
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SparseFormatErrorKind {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,8 @@ pub use simba::simd::{SimdBool, SimdComplexField, SimdPartialOrd, SimdRealField,
 ///
 /// # See also:
 ///
-/// * [`origin`](../nalgebra/fn.origin.html)
-/// * [`zero`](fn.zero.html)
+/// * [`origin()`](crate::OPoint::origin)
+/// * [`zero()`]
 #[inline]
 pub fn one<T: One>() -> T {
     T::one()
@@ -184,8 +184,8 @@ pub fn one<T: One>() -> T {
 ///
 /// # See also:
 ///
-/// * [`one`](fn.one.html)
-/// * [`origin`](../nalgebra/fn.origin.html)
+/// * [`one()`]
+/// * [`origin()`](crate::OPoint::origin)
 #[inline]
 pub fn zero<T: Zero>() -> T {
     T::zero()
@@ -262,7 +262,7 @@ pub fn min<T: Ord>(a: T, b: T) -> T {
 
 /// The absolute value of `a`.
 ///
-/// Deprecated: Use [`Matrix::abs`] or [`ComplexField::abs`] instead.
+/// Deprecated: Use [`Matrix::abs()`] or [`ComplexField::abs()`] instead.
 #[deprecated(note = "use the inherent method `Matrix::abs` or `ComplexField::abs` instead")]
 #[inline]
 pub fn abs<T: Signed>(a: &T) -> T {
@@ -400,8 +400,8 @@ pub fn partial_sort2<'a, T: PartialOrd>(a: &'a T, b: &'a T) -> Option<(&'a T, &'
 ///
 /// # See also:
 ///
-/// * [distance](fn.distance.html)
-/// * [`distance_squared`](fn.distance_squared.html)
+/// * [`distance()`]
+/// * [`distance_squared()`]
 #[inline]
 pub fn center<T: SimdComplexField, const D: usize>(
     p1: &Point<T, D>,
@@ -414,8 +414,8 @@ pub fn center<T: SimdComplexField, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [center](fn.center.html)
-/// * [`distance_squared`](fn.distance_squared.html)
+/// * [`center()`]
+/// * [`distance_squared()`]
 #[inline]
 pub fn distance<T: SimdComplexField, const D: usize>(
     p1: &Point<T, D>,
@@ -428,8 +428,8 @@ pub fn distance<T: SimdComplexField, const D: usize>(
 ///
 /// # See also:
 ///
-/// * [center](fn.center.html)
-/// * [distance](fn.distance.html)
+/// * [`center()`]
+/// * [`distance()`]
 #[inline]
 pub fn distance_squared<T: SimdComplexField, const D: usize>(
     p1: &Point<T, D>,
@@ -443,15 +443,15 @@ pub fn distance_squared<T: SimdComplexField, const D: usize>(
  */
 /// Converts an object from one type to an equivalent or more general one.
 ///
-/// See also [`try_convert`](fn.try_convert.html) for conversion to more specific types.
+/// See also [`try_convert()`] for conversion to more specific types.
 ///
 /// # See also:
 ///
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert`](fn.try_convert.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert_ref()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`is_convertible()`]
+/// * [`try_convert()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn convert<From, To: SupersetOf<From>>(t: From) -> To {
     To::from_subset(&t)
@@ -459,46 +459,46 @@ pub fn convert<From, To: SupersetOf<From>>(t: From) -> To {
 
 /// Attempts to convert an object to a more specific one.
 ///
-/// See also [`convert`](fn.convert.html) for conversion to more general types.
+/// See also [`convert()`] for conversion to more general types.
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert()`]
+/// * [`convert_ref()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`is_convertible()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn try_convert<From: SupersetOf<To>, To>(t: From) -> Option<To> {
     t.to_subset()
 }
 
-/// Indicates if [`try_convert`](fn.try_convert.html) will succeed without
+/// Indicates if [`try_convert()`] will succeed without
 /// actually performing the conversion.
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`try_convert`](fn.try_convert.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert()`]
+/// * [`convert_ref()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`try_convert()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn is_convertible<From: SupersetOf<To>, To>(t: &From) -> bool {
     t.is_in_subset()
 }
 
-/// Use with care! Same as [`try_convert`](fn.try_convert.html) but
+/// Use with care! Same as [`try_convert()`] but
 /// without any property checks.
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert`](fn.try_convert.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert()`]
+/// * [`convert_ref()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`is_convertible()`]
+/// * [`try_convert()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn convert_unchecked<From: SupersetOf<To>, To>(t: From) -> To {
     t.to_subset_unchecked()
@@ -508,11 +508,11 @@ pub fn convert_unchecked<From: SupersetOf<To>, To>(t: From) -> To {
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert`](fn.try_convert.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`is_convertible()`]
+/// * [`try_convert()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn convert_ref<From, To: SupersetOf<From>>(t: &From) -> To {
     To::from_subset(t)
@@ -522,26 +522,26 @@ pub fn convert_ref<From, To: SupersetOf<From>>(t: &From) -> To {
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`convert_ref_unchecked`](fn.convert_ref_unchecked.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert`](fn.try_convert.html)
+/// * [`convert()`]
+/// * [`convert_ref()`]
+/// * [`convert_ref_unchecked()`]
+/// * [`is_convertible()`]
+/// * [`try_convert()`]
 #[inline]
 pub fn try_convert_ref<From: SupersetOf<To>, To>(t: &From) -> Option<To> {
     t.to_subset()
 }
 
-/// Use with care! Same as [`try_convert`](fn.try_convert.html) but
+/// Use with care! Same as [`try_convert()`] but
 /// without any property checks.
 ///
 /// # See also:
 ///
-/// * [convert](fn.convert.html)
-/// * [`convert_ref`](fn.convert_ref.html)
-/// * [`is_convertible`](../nalgebra/fn.is_convertible.html)
-/// * [`try_convert`](fn.try_convert.html)
-/// * [`try_convert_ref`](fn.try_convert_ref.html)
+/// * [`convert()`]
+/// * [`convert_ref()`]
+/// * [`is_convertible()`]
+/// * [`try_convert()`]
+/// * [`try_convert_ref()`]
 #[inline]
 pub fn convert_ref_unchecked<From: SupersetOf<To>, To>(t: &From) -> To {
     t.to_subset_unchecked()

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -16,17 +16,17 @@
 //! provides tools for generating matrices and vectors, and not any of the geometry types.
 //! There are essentially two ways of using this functionality:
 //!
-//! - Using the [matrix](fn.matrix.html) function to generate matrices with constraints
+//! - Using the [`matrix()`] function to generate matrices with constraints
 //!   on dimensions and elements.
-//! - Relying on the `Arbitrary` implementation of `OMatrix`.
+//! - Relying on the [`Arbitrary`] implementation of [`OMatrix`].
 //!
 //! The first variant is almost always preferred in practice. Read on to discover why.
 //!
 //! ### Using free function strategies
 //!
 //! In `proptest`, it is usually preferable to have free functions that generate *strategies*.
-//! Currently, the [matrix](fn.matrix.html) function fills this role. The analogous function for
-//! column vectors is [vector](fn.vector.html). Let's take a quick look at how it may be used:
+//! Currently, the [`matrix()`] function fills this role. The analogous function for
+//! column vectors is [`vector()`]. Let's take a quick look at how it may be used:
 //! ```
 //! use nalgebra::proptest::matrix;
 //! use proptest::prelude::*;
@@ -50,7 +50,7 @@
 //! For example, let's consider a toy example where we need to generate pairs of matrices
 //! with exactly 3 rows fixed at compile-time and the same number of columns, but we want the
 //! number of columns to vary. One way to do this is to use `proptest` combinators in combination
-//! with [matrix](fn.matrix.html) as follows:
+//! with [`matrix()`] as follows:
 //!
 //! ```
 //! use nalgebra::{Dyn, OMatrix, Const};
@@ -316,7 +316,7 @@ where
 /// with length in the provided range.
 ///
 /// This is a convenience function for calling
-/// [`matrix(value_strategy, length, U1)`](fn.matrix.html) and should
+/// [`matrix(value_strategy, length, U1)`](crate::matrix) and should
 /// be used when you only want to generate column vectors, as it's simpler and makes the intent
 /// clear.
 pub fn vector<D, ScalarStrategy>(


### PR DESCRIPTION
This fixes almost all HTML links to be intradoc links that Rust can verify during `cargo doc`. This will help prevent future broken links.