### PR TITLE
docs: grammar: "Constrains ... to be"

### DIFF
--- a/src/base/constraint.rs
+++ b/src/base/constraint.rs
@@ -6,7 +6,7 @@ use crate::base::dimension::{Dim, DimName, Dyn};
 #[derive(Copy, Clone, Debug)]
 pub struct ShapeConstraint;
 
-/// Constraints `C1` and `R2` to be equivalent.
+/// Constrains `C1` and `R2` to be equivalent.
 pub trait AreMultipliable<R1: Dim, C1: Dim, R2: Dim, C2: Dim>: DimEq<C1, R2> {}
 
 impl<R1: Dim, C1: Dim, R2: Dim, C2: Dim> AreMultipliable<R1, C1, R2, C2> for ShapeConstraint where
@@ -14,7 +14,7 @@ impl<R1: Dim, C1: Dim, R2: Dim, C2: Dim> AreMultipliable<R1, C1, R2, C2> for Sha
 {
 }
 
-/// Constraints `D1` and `D2` to be equivalent.
+/// Constrains `D1` and `D2` to be equivalent.
 pub trait DimEq<D1: Dim, D2: Dim> {
     /// This is either equal to `D1` or `D2`, always choosing the one (if any) which is a type-level
     /// constant.
@@ -35,7 +35,7 @@ impl<D: DimName> DimEq<Dyn, D> for ShapeConstraint {
 
 macro_rules! equality_trait_decl(
     ($($doc: expr, $Trait: ident),* $(,)*) => {$(
-        // XXX: we can't do something like `DimEq<D1> for D2` because we would require a blancket impl…
+        // XXX: we can't do something like `DimEq<D1> for D2` because we would require a blanket impl…
         #[doc = $doc]
         pub trait $Trait<D1: Dim, D2: Dim>: DimEq<D1, D2> + DimEq<D2, D1> {
             /// This is either equal to `D1` or `D2`, always choosing the one (if any) which is a type-level
@@ -58,17 +58,17 @@ macro_rules! equality_trait_decl(
 );
 
 equality_trait_decl!(
-    "Constraints `D1` and `D2` to be equivalent. \
+    "Constrains `D1` and `D2` to be equivalent. \
      They are both assumed to be the number of \
      rows of a matrix.",
     SameNumberOfRows,
-    "Constraints `D1` and `D2` to be equivalent. \
+    "Constrains `D1` and `D2` to be equivalent. \
      They are both assumed to be the number of \
      columns of a matrix.",
     SameNumberOfColumns
 );
 
-/// Constraints D1 and D2 to be equivalent, where they both designate dimensions of algebraic
+/// Constrains D1 and D2 to be equivalent, where they both designate dimensions of algebraic
 /// entities (e.g. square matrices).
 pub trait SameDimension<D1: Dim, D2: Dim>:
     SameNumberOfRows<D1, D2> + SameNumberOfColumns<D1, D2>


### PR DESCRIPTION
(Also pick up a small typo in a non-doc comment in the same area of code.)