### PR TITLE
Use std::hint::black_box consistently.

### DIFF
--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -142,7 +142,7 @@ fn iter(bench: &mut criterion::Criterion) {
     bench.bench_function("iter", move |bh| {
         bh.iter(|| {
             for value in a.iter() {
-                criterion::black_box(value);
+                std::hint::black_box(value);
             }
         })
     });
@@ -154,7 +154,7 @@ fn iter_rev(bench: &mut criterion::Criterion) {
     bench.bench_function("iter_rev", move |bh| {
         bh.iter(|| {
             for value in a.iter().rev() {
-                criterion::black_box(value);
+                std::hint::black_box(value);
             }
         })
     });

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bench_black_box)]
 #![allow(unused_macros)]
 
 extern crate nalgebra as na;


### PR DESCRIPTION
This also removes the `#![feature(bench_black_box)]`. This was stabilized in Rust 1.66 and anyone building benchmarks will be on that or later (as they previously would have been on nightly).

This also allows building `cargo build --all-targets` on stable Rust as it no longer dies when hitting the feature addition in the benchmarks.