### PR TITLE
`split_at` is only used by Rayon code.

### DIFF
--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -313,8 +313,9 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> ColumnIter<'a, T, R, C,
         }
     }
 
+    #[cfg(feature = "rayon")]
     pub(crate) fn split_at(self, index: usize) -> (Self, Self) {
-        // SAFETY: this makes sur the generated ranges are valid.
+        // SAFETY: this makes sure the generated ranges are valid.
         let split_pos = (self.range.start + index).min(self.range.end);
 
         let left_iter = ColumnIter {
@@ -401,8 +402,9 @@ impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> ColumnIterMut<'a, T,
         }
     }
 
+    #[cfg(feature = "rayon")]
     pub(crate) fn split_at(self, index: usize) -> (Self, Self) {
-        // SAFETY: this makes sur the generated ranges are valid.
+        // SAFETY: this makes sure the generated ranges are valid.
         let split_pos = (self.range.start + index).min(self.range.end);
 
         let left_iter = ColumnIterMut {


### PR DESCRIPTION
This fixes an unused code warning. Since the code is `pub(crate)`, it was only available within the crate and only used by Rayon code, so it is no functional change to not compile it except when the right feature is enabled.

Also, fix a minor typo in some non-doc comments.