### PR TITLE
Add `try_from_triplets_iter`

### DIFF
--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -160,6 +160,25 @@ impl<T> CooMatrix<T> {
         }
     }
 
+    /// Try to construct a COO matrix from the given dimensions and a finite iterator of
+    /// (i, j, v) triplets.
+    ///
+    /// Returns an error if either row or column indices contain indices out of bounds.
+    /// Note that the COO format inherently supports duplicate entries, but they are not
+    /// eagerly summed.
+    ///
+    /// Implementation note:
+    /// Calls try_from_triplets so each value is scanned twice.
+    pub fn try_from_triplets_iter(
+        nrows: usize,
+        ncols: usize,
+        triplets: impl IntoIterator<Item = (usize, usize, T)>,
+    ) -> Result<Self, SparseFormatError> {
+        let (row_indices, (col_indices, values)) =
+            triplets.into_iter().map(|(r, c, v)| (r, (c, v))).unzip();
+        Self::try_from_triplets(nrows, ncols, row_indices, col_indices, values)
+    }
+
     /// An iterator over triplets (i, j, v).
     // TODO: Consider giving the iterator a concrete type instead of impl trait...?
     pub fn triplet_iter(&self) -> impl Iterator<Item = (usize, usize, &T)> {

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -191,6 +191,31 @@ fn coo_try_from_triplets_panics_on_mismatched_vectors() {
         ($result:expr) => {
             assert!(matches!(
                 $result.unwrap_err().kind(),
+                SparseFormatErrorKind::IndexOutOfBounds
+            ))
+        };
+    }
+
+    assert_errs!(CooMatrix::<f32>::try_from_triplets_iter(
+        3,
+        5,
+        vec![(0, 6, 3.0)].into_iter(),
+    ));
+    assert!(CooMatrix::<f32>::try_from_triplets_iter(
+        3,
+        5,
+        vec![(0, 3, 3.0), (1, 2, 2.0), (0, 3, 1.0),].into_iter(),
+    )
+    .is_ok());
+}
+
+#[test]
+fn coo_try_from_triplets_iter() {
+    // Check that try_from_triplets panics when the triplet vectors have different lengths
+    macro_rules! assert_errs {
+        ($result:expr) => {
+            assert!(matches!(
+                $result.unwrap_err().kind(),
                 SparseFormatErrorKind::InvalidStructure
             ))
         };

--- a/nalgebra-sparse/tests/unit_tests/coo.rs
+++ b/nalgebra-sparse/tests/unit_tests/coo.rs
@@ -185,8 +185,8 @@ fn coo_try_from_triplets_reports_out_of_bounds_indices() {
 }
 
 #[test]
-fn coo_try_from_triplets_panics_on_mismatched_vectors() {
-    // Check that try_from_triplets panics when the triplet vectors have different lengths
+fn coo_try_from_triplets_iter() {
+    // Check that try_from_triplets_iter panics when the triplet vectors have different lengths
     macro_rules! assert_errs {
         ($result:expr) => {
             assert!(matches!(
@@ -210,7 +210,7 @@ fn coo_try_from_triplets_panics_on_mismatched_vectors() {
 }
 
 #[test]
-fn coo_try_from_triplets_iter() {
+fn coo_try_from_triplets_panics_on_mismatched_vectors() {
     // Check that try_from_triplets panics when the triplet vectors have different lengths
     macro_rules! assert_errs {
         ($result:expr) => {


### PR DESCRIPTION
Calls `try_from_triplets` for now, and is mentioned in the documentation.

Closes #1286 