### PR TITLE
Implement Sparse Left-Looking LU factorization

### DIFF
--- a/nalgebra-sparse/src/cs.rs
+++ b/nalgebra-sparse/src/cs.rs
@@ -4,7 +4,7 @@ use num_traits::One;
 
 use nalgebra::Scalar;
 
-use crate::pattern::SparsityPattern;
+use crate::pattern::{BuilderInsertError, SparsityPattern, SparsityPatternBuilder};
 use crate::utils::{apply_permutation, compute_sort_permutation};
 use crate::{SparseEntry, SparseEntryMut, SparseFormatError, SparseFormatErrorKind};
 
@@ -699,4 +699,57 @@ where
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CsBuilder<T> {
+    sparsity_builder: SparsityPatternBuilder,
+    values: Vec<T>,
+}
+
+impl<T> CsBuilder<T> {
+    /// Constructs a new CsBuilder of the given size.
+    pub fn new(major_dim: usize, minor_dim: usize) -> Self {
+        Self {
+            sparsity_builder: SparsityPatternBuilder::new(major_dim, minor_dim),
+            values: vec![],
+        }
+    }
+    /// Given an existing CsMatrix, allows for modification by converting it into a builder.
+    pub fn from_mat(mat: CsMatrix<T>) -> Self {
+        let CsMatrix {
+            sparsity_pattern,
+            values,
+        } = mat;
+
+        CsBuilder {
+            sparsity_builder: SparsityPatternBuilder::from(sparsity_pattern),
+            values,
+        }
+    }
+    /// Backtracks to a given major index
+    pub fn revert_to_major(&mut self, maj: usize) -> bool {
+        if !self.sparsity_builder.revert_to_major(maj) {
+            return false;
+        }
+
+        self.values.truncate(self.sparsity_builder.num_entries());
+        true
+    }
+    pub fn insert(&mut self, maj: usize, min: usize, val: T) -> Result<(), BuilderInsertError> {
+        self.sparsity_builder.insert(maj, min)?;
+        self.values.push(val);
+        Ok(())
+    }
+    pub fn build(self) -> CsMatrix<T> {
+        let CsBuilder {
+            sparsity_builder,
+            values,
+        } = self;
+        let sparsity_pattern = sparsity_builder.build();
+        CsMatrix {
+            sparsity_pattern,
+            values,
+        }
+    }
 }

--- a/nalgebra-sparse/src/factorization/lu.rs
+++ b/nalgebra-sparse/src/factorization/lu.rs
@@ -1,0 +1,103 @@
+use crate::SparseEntryMut;
+use crate::{CscBuilder, CscMatrix};
+use nalgebra::{DMatrix, RealField};
+
+/// Constructs an LU Factorization using a left-looking approach.
+/// This means it will construct each column, starting from the leftmost one.
+pub struct LeftLookingLUFactorization<T> {
+    /// A single matrix stores both the lower and upper triangular components
+    l_u: CscMatrix<T>,
+}
+
+impl<T: RealField + Copy> LeftLookingLUFactorization<T> {
+    /// Returns the upper triangular part of this matrix.
+    pub fn u(&self) -> CscMatrix<T> {
+        self.l_u.upper_triangle()
+    }
+
+    /// Returns the joint L\U matrix. Here, `L` implicitly has 1 along the diagonal.
+    pub fn lu(&self) -> &CscMatrix<T> {
+        &self.l_u
+    }
+
+    /// Returns the lower triangular part of this matrix.
+    pub fn l(&self) -> CscMatrix<T> {
+        let mut l = self.l_u.lower_triangle();
+        let n = self.l_u.nrows();
+        for i in 0..n {
+            if let SparseEntryMut::NonZero(v) = l.index_entry_mut(i, i) {
+                *v = T::one();
+            } else {
+                unreachable!();
+            }
+        }
+        l
+    }
+
+    /// Computes `x` in `LUx = b`, where `b` is a dense vector.
+    pub fn solve(&self, b: &[T]) -> DMatrix<T> {
+        let mut y = vec![T::zero(); b.len()];
+        // Implementation: Solve two systems: Ly = b, then Ux = y.
+        self.l_u.dense_lower_triangular_solve(b, &mut y, true);
+        let mut out = y.clone();
+        self.l_u.dense_upper_triangular_solve(&y, &mut out);
+
+        DMatrix::from_vec(b.len(), 1, out)
+    }
+
+    /// Construct a new sparse LU factorization
+    /// from a given CSC matrix.
+    pub fn new(a: &CscMatrix<T>) -> Self {
+        assert_eq!(a.nrows(), a.ncols());
+        let n = a.nrows();
+
+        // this initially starts as an identity  matrix.
+        // but the ones are all implicit.
+        let mut csc_builder = CscBuilder::new(n, n);
+
+        let mut val_buf = vec![];
+        let mut pat_buf = vec![];
+
+        for (ci, col) in a.col_iter().enumerate() {
+            let curr_mat = csc_builder.build();
+
+            curr_mat
+                .pattern()
+                .sparse_lower_triangular_solve(col.row_indices(), &mut pat_buf);
+            pat_buf.sort_unstable();
+            val_buf.resize_with(pat_buf.len(), T::zero);
+
+            // Solve the current column, assuming that it is lower triangular
+            curr_mat.sparse_lower_triangular_solve_sorted(
+                col.row_indices(),
+                col.values(),
+                &pat_buf,
+                &mut val_buf,
+                true,
+            );
+
+            // convert builder back to matrix
+            csc_builder = CscBuilder::from_mat(curr_mat);
+            assert!(csc_builder.revert_to_col(ci));
+            let mut ukk = T::zero();
+            for (row, val) in pat_buf.drain(..).zip(val_buf.drain(..)) {
+                use std::cmp::Ordering;
+                let val = match row.cmp(&ci) {
+                    Ordering::Less => val,
+                    Ordering::Equal => {
+                        ukk = val;
+                        val
+                    }
+                    Ordering::Greater => {
+                        assert_ne!(ukk, T::zero());
+                        val / ukk
+                    }
+                };
+                assert_eq!(csc_builder.insert(row, ci, val), Ok(()));
+            }
+        }
+
+        let l_u = csc_builder.build();
+        Self { l_u }
+    }
+}

--- a/nalgebra-sparse/src/factorization/mod.rs
+++ b/nalgebra-sparse/src/factorization/mod.rs
@@ -2,5 +2,7 @@
 //!
 //! Currently, the only factorization provided here is the [`CscCholesky`] factorization.
 mod cholesky;
+mod lu;
 
 pub use cholesky::*;
+pub use lu::*;

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -171,7 +171,7 @@ use std::error::Error;
 use std::fmt;
 
 pub use self::coo::CooMatrix;
-pub use self::csc::CscMatrix;
+pub use self::csc::{CscBuilder, CscMatrix};
 pub use self::csr::CsrMatrix;
 
 /// Errors produced by functions that expect well-formed sparse format data.
@@ -277,6 +277,13 @@ impl<'a, T: Clone + Zero> SparseEntryMut<'a, T> {
         match self {
             SparseEntryMut::NonZero(value) => value.clone(),
             SparseEntryMut::Zero => T::zero(),
+        }
+    }
+    /// If the entry is nonzero, returns `Some(&mut value)`, otherwise returns `None`.
+    pub fn nonzero(self) -> Option<&'a mut T> {
+        match self {
+            SparseEntryMut::NonZero(v) => Some(v),
+            SparseEntryMut::Zero => None,
         }
     }
 }

--- a/nalgebra-sparse/tests/lu_factorization.rs
+++ b/nalgebra-sparse/tests/lu_factorization.rs
@@ -1,0 +1,46 @@
+use nalgebra_sparse::factorization::LeftLookingLUFactorization;
+use nalgebra_sparse::CscBuilder;
+
+#[test]
+fn test_basic_lu_factorization() {
+    let n = 5;
+    let mut a = CscBuilder::new(n, n);
+    for i in 0..n {
+        assert!(a.insert(i, i, 1.).is_ok());
+    }
+    // construct an identity matrix as a basic test
+    let a = a.build();
+
+    let lu_fact = LeftLookingLUFactorization::new(&a);
+
+    assert_eq!(lu_fact.u(), a);
+}
+
+#[test]
+fn test_basic_lu_factorization_with_one_more_entry() {
+    let n = 3;
+    let mut a = CscBuilder::new(n, n);
+    for i in 0..n {
+        assert!(a.insert(i, i, if i == 0 { 0.5 } else { 1. }).is_ok());
+        if i == 0 {
+            assert!(a.insert(1, 0, 1.).is_ok());
+        }
+    }
+    // construct an identity matrix as a basic test
+    let a = a.build();
+
+    let lu_fact = LeftLookingLUFactorization::new(&a);
+
+    let mut ground_truth = CscBuilder::new(n, n);
+    for i in 0..n {
+        assert!(ground_truth
+            .insert(i, i, if i == 0 { 0.5 } else { 1. })
+            .is_ok());
+        if i == 0 {
+            assert!(ground_truth.insert(1, 0, 2.).is_ok());
+        }
+    }
+    let gt = ground_truth.build();
+
+    assert_eq!(lu_fact.lu(), &gt);
+}

--- a/nalgebra-sparse/tests/sparsity.rs
+++ b/nalgebra-sparse/tests/sparsity.rs
@@ -1,0 +1,131 @@
+use nalgebra_sparse::pattern::{SparsityPattern, SparsityPatternBuilder};
+
+#[test]
+fn sparsity_identity() {
+    let n = 100;
+    let speye = SparsityPattern::identity(n);
+    for (i, j) in speye.entries() {
+        assert_eq!(i, j);
+    }
+    assert_eq!(speye.major_dim(), n);
+    assert_eq!(speye.minor_dim(), n);
+}
+
+#[test]
+fn lower_sparse_solve() {
+    // just a smaller number so it's easier to debug
+    let n = 8;
+    let speye = SparsityPattern::identity(n);
+    let mut buf = vec![];
+    speye.sparse_lower_triangular_solve(&[0, 5], &mut buf);
+    assert_eq!(buf, vec![0, 5]);
+
+    // test case from
+    // https://www.youtube.com/watch?v=1dGRTOwBkQs&ab_channel=TimDavis
+    let mut builder = SparsityPatternBuilder::new(14, 14);
+    // building CscMatrix, so it will be col, row
+    #[rustfmt::skip]
+    let indices = vec![
+      (0, 0), (0, 2),
+      (1, 1), (1, 3), (1, 6), (1, 8),
+      (2,2), (2,4), (2,7),
+      (3,3), (3,8),
+      (4,4), (4,7),
+      (5,5), (5,8), (5,9),
+      (6,6), (6,9), (6,10),
+      (7,7), (7,9),
+      (8,8), (8,11), (8,12),
+      (9,9), (9,10), (9, 12), (9, 13),
+      (10,10), (10,11), (10,12),
+      (11,11), (11,12),
+      (12,12), (12,13),
+      (13,13),
+    ];
+    for (maj, min) in indices.iter().copied() {
+        assert!(builder.insert(maj, min).is_ok());
+    }
+    let sp = builder.build();
+    assert_eq!(sp.major_dim(), 14);
+    assert_eq!(sp.minor_dim(), 14);
+    assert_eq!(sp.nnz(), indices.len());
+    for ij in sp.entries() {
+        assert!(indices.contains(&ij));
+    }
+    sp.sparse_lower_triangular_solve(&[3, 5], &mut buf);
+    assert_eq!(buf, vec![3, 8, 11, 12, 13, 5, 9, 10]);
+}
+
+// this test is a flipped version of lower sparse solve
+#[test]
+fn upper_sparse_solve() {
+    // just a smaller number so it's easier to debug
+    let n = 8;
+    let speye = SparsityPattern::identity(n);
+    let mut buf = vec![];
+    speye.sparse_lower_triangular_solve(&[0, 5], &mut buf);
+    assert_eq!(buf, vec![0, 5]);
+
+    // test case from
+    // https://www.youtube.com/watch?v=1dGRTOwBkQs&ab_channel=TimDavis
+    let mut builder = SparsityPatternBuilder::new(14, 14);
+    // building CscMatrix, so it will be col, row
+    #[rustfmt::skip]
+    let mut indices = vec![
+      (0, 0), (0, 2),
+      (1, 1), (1, 3), (1, 6), (1, 8),
+      (2,2), (2,4), (2,7),
+      (3,3), (3,8),
+      (4,4), (4,7),
+      (5,5), (5,8), (5,9),
+      (6,6), (6,9), (6,10),
+      (7,7), (7,9),
+      (8,8), (8,11), (8,12),
+      (9,9), (9,10), (9, 12), (9, 13),
+      (10,10), (10,11), (10,12),
+      (11,11), (11,12),
+      (12,12), (12,13),
+      (13,13),
+    ];
+    indices.sort_by_key(|&(min, maj)| (maj, min));
+    for (min, maj) in indices.iter().copied() {
+        assert!(builder.insert(maj, min).is_ok());
+    }
+    let sp = builder.build();
+    assert_eq!(sp.major_dim(), 14);
+    assert_eq!(sp.minor_dim(), 14);
+    assert_eq!(sp.nnz(), indices.len());
+    sp.sparse_upper_triangular_solve(&[9], &mut buf);
+    assert_eq!(buf, vec![9, 7, 4, 2, 0, 6, 1, 5]);
+}
+
+#[test]
+fn test_builder() {
+    let mut builder = SparsityPatternBuilder::new(2, 2);
+    assert!(builder.insert(0, 0).is_ok());
+    assert!(builder.insert(0, 0).is_err());
+    assert!(builder.insert(0, 1).is_ok());
+    assert!(builder.insert(0, 1).is_err());
+    assert!(builder.insert(1, 0).is_ok());
+    assert!(builder.insert(1, 0).is_err());
+}
+
+#[test]
+fn test_builder_reset() {
+    let mut builder = SparsityPatternBuilder::new(4, 4);
+    for i in 0..3 {
+        assert!(builder.insert(i, i + 1).is_ok());
+    }
+    let out = builder.build();
+    assert_eq!(out.major_dim(), 4);
+    assert_eq!(out.minor_dim(), 4);
+    let mut builder = SparsityPatternBuilder::from(out);
+    for i in (0..=2).rev() {
+        assert!(builder.revert_to_major(i));
+        assert_eq!(builder.current_major(), i);
+    }
+    let out = builder.build();
+
+    let mut builder = SparsityPatternBuilder::from(out);
+    assert!(builder.revert_to_major(1));
+    assert_eq!(builder.current_major(), 1);
+}

--- a/nalgebra-sparse/tests/unit_tests/cholesky.rs
+++ b/nalgebra-sparse/tests/unit_tests/cholesky.rs
@@ -9,7 +9,7 @@ use nalgebra::proptest::matrix;
 use proptest::prelude::*;
 use matrixcompare::{assert_matrix_eq, prop_assert_matrix_eq};
 
-fn positive_definite() -> impl Strategy<Value=CscMatrix<f64>> {
+pub fn positive_definite() -> impl Strategy<Value=CscMatrix<f64>> {
     let csc_f64 = csc(value_strategy::<f64>(),
                       PROPTEST_MATRIX_DIM,
                       PROPTEST_MATRIX_DIM,

--- a/nalgebra-sparse/tests/unit_tests/csr.rs
+++ b/nalgebra-sparse/tests/unit_tests/csr.rs
@@ -519,6 +519,38 @@ fn csr_matrix_get_index_entry() {
 }
 
 #[test]
+fn csr_upper_triangle_solve_ok() {
+    const N: usize = 10;
+    let eye = CsrMatrix::<f32>::identity(N);
+    let b = DMatrix::from_row_slice(N, 1, &[0.5; N]);
+    assert_eq!(eye.solve_upper_triangular(&b), Some(b));
+
+    let mut eye = CsrMatrix::<f32>::identity(N);
+    let v = if let SparseEntryMut::NonZero(v) = eye.index_entry_mut(0, 0) {
+        v
+    } else {
+        unreachable!();
+    };
+    *v = 2.0;
+    let b = DMatrix::from_row_slice(N, 1, &[1.0; N]);
+    let mut x = b.clone();
+    x[0] = 0.5;
+    assert_eq!(eye.solve_upper_triangular(&b), Some(x));
+
+    #[rustfmt::skip]
+    let dense = DMatrix::from_row_slice(3, 3, &[
+        1., 1., 1.,
+        0., 1., 1.,
+        0., 0., 1.,
+    ]);
+    let csr = CsrMatrix::from(&dense);
+
+    let b = DMatrix::from_row_slice(3, 1, &[1.0; 3]);
+    let x = DMatrix::from_row_slice(3, 1, &[-1., 0., 1.]);
+    assert_eq!(csr.solve_upper_triangular(&b), Some(x));
+}
+
+#[test]
 fn csr_matrix_row_iter() {
     #[rustfmt::skip]
     let dense = DMatrix::from_row_slice(3, 4, &[

--- a/nalgebra-sparse/tests/unit_tests/left_looking_lu.proptest-regressions
+++ b/nalgebra-sparse/tests/unit_tests/left_looking_lu.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b8e49f3fa66a3568e1c29a47de5f3d2f67866d59b39329e2a0da1537a9c6d584 # shrinks to matrix = CscMatrix { cs: CsMatrix { sparsity_pattern: SparsityPattern { major_offsets: [0, 4, 8, 11, 16, 21], minor_indices: [0, 1, 3, 4, 0, 1, 3, 4, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4], minor_dim: 5 }, values: [1.0, 0.0, 0.0, 0.0, 0.0, 8.445226477445164, 0.0, 5.072108001361104, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 5.072108001361104, 0.0, 0.0, 4.455405910808415] } }

--- a/nalgebra-sparse/tests/unit_tests/left_looking_lu.rs
+++ b/nalgebra-sparse/tests/unit_tests/left_looking_lu.rs
@@ -1,0 +1,75 @@
+use crate::unit_tests::cholesky::positive_definite;
+
+use nalgebra_sparse::factorization::LeftLookingLUFactorization;
+
+use matrixcompare::{assert_matrix_eq, prop_assert_matrix_eq};
+use proptest::prelude::*;
+
+use crate::common::value_strategy;
+use nalgebra::proptest::matrix;
+use nalgebra_sparse::CscMatrix;
+
+proptest! {
+  // Note that positive definite matrices are guaranteed to be invertible.
+  // That's why they're used here, but it's not necessary for a matrix to be pd to be
+  // invertible.
+  #[test]
+  fn lu_for_positive_def_matrices(
+    matrix in positive_definite()
+  ) {
+    let lu = LeftLookingLUFactorization::new(&matrix);
+
+    let l = lu.l();
+    prop_assert!(l.triplet_iter().all(|(i, j, _)| j <= i));
+    let u = lu.u();
+    prop_assert!(u.triplet_iter().all(|(i, j, _)| j >= i));
+    prop_assert_matrix_eq!(l * u, matrix, comp = abs, tol = 1e-7);
+  }
+
+  #[test]
+  fn lu_solve_correct_for_positive_def_matrices(
+    (matrix, b) in positive_definite()
+      .prop_flat_map(|csc| {
+        let rhs = matrix(value_strategy::<f64>(), csc.nrows(), 1);
+        (Just(csc), rhs)
+      })
+  ) {
+    let lu = LeftLookingLUFactorization::new(&matrix);
+
+    let l = lu.l();
+    prop_assert!(l.triplet_iter().all(|(i, j, _)| j <= i));
+
+    let mut x_l = b.clone_owned();
+    l.dense_lower_triangular_solve(b.as_slice(), x_l.as_mut_slice(), true);
+
+    prop_assert_matrix_eq!(l * x_l, b, comp=abs, tol=1e-12);
+
+    let u = lu.u();
+    prop_assert!(u.triplet_iter().all(|(i, j, _)| j >= i));
+
+    let mut x_u = b.clone_owned();
+    u.dense_upper_triangular_solve(b.as_slice(), x_u.as_mut_slice());
+    prop_assert_matrix_eq!(u * x_u, b, comp = abs, tol = 1e-7);
+
+    let x = lu.solve(b.as_slice());
+    prop_assert_matrix_eq!(&matrix * &x, b, comp=abs, tol=1e-12);
+  }
+}
+
+#[test]
+fn minimized_lu() {
+    let major_offsets = vec![0, 1, 3, 4, 5, 8];
+    let minor_indices = vec![0, 1, 4, 2, 3, 1, 2, 4];
+    let values = vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 1.0];
+    assert_eq!(minor_indices.len(), values.len());
+    let mat = CscMatrix::try_from_unsorted_csc_data(5, 5, major_offsets, minor_indices, values);
+    let mat = mat.unwrap();
+
+    let lu = LeftLookingLUFactorization::new(&mat);
+
+    let l = lu.l();
+    assert!(l.triplet_iter().all(|(i, j, _)| j <= i));
+    let u = lu.u();
+    assert!(u.triplet_iter().all(|(i, j, _)| j >= i));
+    assert_matrix_eq!(l * u, mat, comp = abs, tol = 1e-7);
+}

--- a/nalgebra-sparse/tests/unit_tests/mod.rs
+++ b/nalgebra-sparse/tests/unit_tests/mod.rs
@@ -1,4 +1,7 @@
+// factorization tests
 mod cholesky;
+mod left_looking_lu;
+
 mod convert_serial;
 mod coo;
 mod csc;


### PR DESCRIPTION
This allows a sparse matrix to be used for efficient solving with a dense LU decomposition.

It generally follows lectures from Tim Davis
https://www.youtube.com/watch?v=wiL_jIuENkk&ab_channel=TimDavis
(Lectures 1-3), and implements a basic left looking sparse LU factorization.
I primarily focus on CSC matrices, since they are what is focused on in the lecture, identical to what is done in Matlab.

I believe for most use cases this should be efficient and correct, and thus it serves as a useful to building even more customized solvers down the line.

Summary of changes:

1. Sparsity Pattern Builder:  Allowing for building up sparsity patterns, rather than constructing them all in one go. This seemed to be a drawback of the previous design, and I've added a builder to construct Sparsity Patterns. This was necessary when computing the sparsity of the decomposed LU matrix.

2. Sparse lower triangular solving. For most users, the result will probably want `LUx = b`, with `b` a dense vector. While constructing the LU matrix though, it calls a sparse `Ly = s`, with `s` sparse. This allows for building up a sparse LU pattern iteratively. The LU matrix is packed into a single sparse matrix, with the diagonal belonging to U, and `L` has implicit 1s along the diagonal.

3. Dense lower/upper triangular solving. This is what the end user will interact with. I've added it to take slices, but I should probably convert it to DMatrices. Slices feel more natural to me though, since it decouples the requirement of the input being a matrix, as it's just solving a vector anyway.

r? @sebcrozet @Andlon 

Not sure if y'all have time to review.

Motivation:

Currently I'm trying to reimplement a paper that uses libigl within Rust, but there's a significant amount of library functionality that is missing. Specifically, quadratic programming doesn't exist, so this is a step to making it available.

Closes #1197