### PR TITLE
Remove unnecessary code in qr.rs

### DIFF
--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -291,17 +291,4 @@ where
 
         true
     }
-
-    // /// Computes the determinant of the decomposed matrix.
-    // pub fn determinant(&self) -> T {
-    //     let dim = self.qr.nrows();
-    //     assert!(self.qr.is_square(), "QR determinant: unable to compute the determinant of a non-square matrix.");
-
-    //     let mut res = T::one();
-    //     for i in 0 .. dim {
-    //         res *= unsafe { *self.diag.vget_unchecked(i) };
-    //     }
-
-    //     res self.q_determinant()
-    // }
 }


### PR DESCRIPTION
# Changes
Removed unnecessary residual codes in qr.rs.


# Purpose
To make codes easier to read by removing unnecessary residual codes. The residual code is not to be restored from the comment out because the similar check is being performed on [this code](https://github.com/dimforge/nalgebra/blob/f404bcbd6d9b2acd699b0b9ec8ff387d8a9c1742/src/linalg/qr.rs#L278-L293).