### PR TITLE
Implement Default trait for sparse matrix types

### DIFF
--- a/nalgebra-sparse/src/cs.rs
+++ b/nalgebra-sparse/src/cs.rs
@@ -226,6 +226,15 @@ impl<T> CsMatrix<T> {
     }
 }
 
+impl<T> Default for CsMatrix<T> {
+    fn default() -> Self {
+        Self {
+            sparsity_pattern: Default::default(),
+            values: vec![],
+        }
+    }
+}
+
 impl<T: Scalar + One> CsMatrix<T> {
     #[inline]
     pub fn identity(n: usize) -> Self {

--- a/nalgebra-sparse/src/csc.rs
+++ b/nalgebra-sparse/src/csc.rs
@@ -574,6 +574,14 @@ impl<T> CscMatrix<T> {
     }
 }
 
+impl<T> Default for CscMatrix<T> {
+    fn default() -> Self {
+        Self {
+            cs: Default::default(),
+        }
+    }
+}
+
 /// Convert pattern format errors into more meaningful CSC-specific errors.
 ///
 /// This ensures that the terminology is consistent: we are talking about rows and columns,

--- a/nalgebra-sparse/src/csr.rs
+++ b/nalgebra-sparse/src/csr.rs
@@ -575,6 +575,14 @@ impl<T> CsrMatrix<T> {
     }
 }
 
+impl<T> Default for CsrMatrix<T> {
+    fn default() -> Self {
+        Self {
+            cs: Default::default(),
+        }
+    }
+}
+
 /// Convert pattern format errors into more meaningful CSR-specific errors.
 ///
 /// This ensures that the terminology is consistent: we are talking about rows and columns,

--- a/nalgebra-sparse/src/pattern.rs
+++ b/nalgebra-sparse/src/pattern.rs
@@ -291,6 +291,16 @@ impl SparsityPattern {
     }
 }
 
+impl Default for SparsityPattern {
+    fn default() -> Self {
+        Self {
+            major_offsets: vec![0],
+            minor_indices: vec![],
+            minor_dim: 0,
+        }
+    }
+}
+
 /// Error type for `SparsityPattern` format errors.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/nalgebra-sparse/tests/unit_tests/csc.rs
+++ b/nalgebra-sparse/tests/unit_tests/csc.rs
@@ -13,6 +13,18 @@ use crate::common::csc_strategy;
 use std::collections::HashSet;
 
 #[test]
+fn csc_matrix_default() {
+    let matrix: CscMatrix<f32> = CscMatrix::default();
+
+    assert_eq!(matrix.nrows(), 0);
+    assert_eq!(matrix.ncols(), 0);
+    assert_eq!(matrix.nnz(), 0);
+
+    assert_eq!(matrix.values(), &[]);
+    assert!(matrix.get_entry(0, 0).is_none());
+}
+
+#[test]
 fn csc_matrix_valid_data() {
     // Construct matrix from valid data and check that selected methods return results
     // that agree with expectations.

--- a/nalgebra-sparse/tests/unit_tests/csr.rs
+++ b/nalgebra-sparse/tests/unit_tests/csr.rs
@@ -13,6 +13,18 @@ use crate::common::csr_strategy;
 use std::collections::HashSet;
 
 #[test]
+fn csr_matrix_default() {
+    let matrix: CsrMatrix<f32> = CsrMatrix::default();
+
+    assert_eq!(matrix.nrows(), 0);
+    assert_eq!(matrix.ncols(), 0);
+    assert_eq!(matrix.nnz(), 0);
+
+    assert_eq!(matrix.values(), &[]);
+    assert!(matrix.get_entry(0, 0).is_none());
+}
+
+#[test]
 fn csr_matrix_valid_data() {
     // Construct matrix from valid data and check that selected methods return results
     // that agree with expectations.

--- a/nalgebra-sparse/tests/unit_tests/pattern.rs
+++ b/nalgebra-sparse/tests/unit_tests/pattern.rs
@@ -5,7 +5,7 @@ fn sparsity_pattern_default() {
     // Check that the pattern created with `Default::default()` is equivalent to a zero-sized pattern.
     let pattern = SparsityPattern::default();
     let zero = SparsityPattern::zeros(0, 0);
-    
+
     assert_eq!(pattern.major_dim(), zero.major_dim());
     assert_eq!(pattern.minor_dim(), zero.minor_dim());
     assert_eq!(pattern.major_offsets(), zero.major_offsets());

--- a/nalgebra-sparse/tests/unit_tests/pattern.rs
+++ b/nalgebra-sparse/tests/unit_tests/pattern.rs
@@ -1,6 +1,20 @@
 use nalgebra_sparse::pattern::{SparsityPattern, SparsityPatternFormatError};
 
 #[test]
+fn sparsity_pattern_default() {
+    // Check that the pattern created with `Default::default()` is equivalent to a zero-sized pattern.
+    let pattern = SparsityPattern::default();
+    let zero = SparsityPattern::zeros(0, 0);
+    
+    assert_eq!(pattern.major_dim(), zero.major_dim());
+    assert_eq!(pattern.minor_dim(), zero.minor_dim());
+    assert_eq!(pattern.major_offsets(), zero.major_offsets());
+    assert_eq!(pattern.minor_indices(), zero.minor_indices());
+
+    assert_eq!(pattern.nnz(), 0);
+}
+
+#[test]
 fn sparsity_pattern_valid_data() {
     // Construct pattern from valid data and check that selected methods return results
     // that agree with expectations.

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -34,7 +34,7 @@ pub struct VecStorage<T, R: Dim, C: Dim> {
 impl<T> Default for VecStorage<T, Dyn, Dyn> {
     fn default() -> Self {
         Self {
-            data: vec![],
+            data: Vec::new(),
             nrows: Dyn::from_usize(0),
             ncols: Dyn::from_usize(0),
         }
@@ -44,7 +44,7 @@ impl<T> Default for VecStorage<T, Dyn, Dyn> {
 impl<T, R: DimName> Default for VecStorage<T, R, Dyn> {
     fn default() -> Self {
         Self {
-            data: vec![],
+            data: Vec::new(),
             nrows: R::name(),
             ncols: Dyn::from_usize(0),
         }
@@ -54,7 +54,7 @@ impl<T, R: DimName> Default for VecStorage<T, R, Dyn> {
 impl<T, C: DimName> Default for VecStorage<T, Dyn, C> {
     fn default() -> Self {
         Self {
-            data: vec![],
+            data: Vec::new(),
             nrows: Dyn::from_usize(0),
             ncols: C::name(),
         }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -31,6 +31,46 @@ pub struct VecStorage<T, R: Dim, C: Dim> {
     ncols: C,
 }
 
+impl<T> Default for VecStorage<T, Dyn, Dyn> {
+    fn default() -> Self {
+        Self {
+            data: vec![],
+            nrows: Dyn::from_usize(0),
+            ncols: Dyn::from_usize(0),
+        }
+    }
+}
+
+impl<T, R: DimName> Default for VecStorage<T, R, Dyn> {
+    fn default() -> Self {
+        Self {
+            data: vec![],
+            nrows: R::name(),
+            ncols: Dyn::from_usize(0),
+        }
+    }
+}
+
+impl<T, C: DimName> Default for VecStorage<T, Dyn, C> {
+    fn default() -> Self {
+        Self {
+            data: vec![],
+            nrows: Dyn::from_usize(0),
+            ncols: C::name(),
+        }
+    }
+}
+
+impl<T: Default, R: DimName, C: DimName> Default for VecStorage<T, R, C> {
+    fn default() -> Self {
+        let nrows = R::name();
+        let ncols = C::name();
+        let mut data = Vec::new();
+        data.resize_with(nrows.value() * ncols.value(), Default::default);
+        Self { data, nrows, ncols }
+    }
+}
+
 #[cfg(feature = "serde-serialize")]
 impl<T, R: Dim, C: Dim> Serialize for VecStorage<T, R, C>
 where


### PR DESCRIPTION
This solves https://github.com/dimforge/nalgebra/issues/1204 and implements the `Default` trait for `CsMatrix`, `CscMatrix`, `CsrMatrix`, `SparsityPattern`, and `VecStorage`, applying the changes proposed by @Andlon in https://github.com/dimforge/nalgebra/pull/1206.

I added some unit tests where applicable as well.