### PR TITLE
Fix bug in SVD related to values near zero

### DIFF
--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -228,8 +228,9 @@ where
 
         for i in (0..dim - shift).rev() {
             let axis = self.uv.view_range(i + shift.., i);
+
             // Sometimes, the axis might have a zero magnitude.
-            if axis.magnitude().is_zero() {
+            if axis.norm_squared().is_zero() {
                 continue;
             }
             let refl = Reflection::new(Unit::new_unchecked(axis), T::zero());
@@ -267,8 +268,9 @@ where
             let axis = self.uv.view_range(i, i + shift..);
             let mut axis_packed = axis_packed.rows_range_mut(i + shift..);
             axis_packed.tr_copy_from(&axis);
+
             // Sometimes, the axis might have a zero magnitude.
-            if axis_packed.magnitude().is_zero() {
+            if axis_packed.norm_squared().is_zero() {
                 continue;
             }
             let refl = Reflection::new(Unit::new_unchecked(axis_packed), T::zero());

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -8,6 +8,7 @@ use simba::scalar::ComplexField;
 
 use crate::geometry::Reflection;
 use crate::linalg::householder;
+use crate::num::Zero;
 use std::mem::MaybeUninit;
 
 /// The bidiagonalization of a general matrix.
@@ -227,7 +228,10 @@ where
 
         for i in (0..dim - shift).rev() {
             let axis = self.uv.view_range(i + shift.., i);
-            // TODO: sometimes, the axis might have a zero magnitude.
+            // Sometimes, the axis might have a zero magnitude.
+            if axis.magnitude().is_zero() {
+                continue;
+            }
             let refl = Reflection::new(Unit::new_unchecked(axis), T::zero());
 
             let mut res_rows = res.view_range_mut(i + shift.., i..);
@@ -263,7 +267,10 @@ where
             let axis = self.uv.view_range(i, i + shift..);
             let mut axis_packed = axis_packed.rows_range_mut(i + shift..);
             axis_packed.tr_copy_from(&axis);
-            // TODO: sometimes, the axis might have a zero magnitude.
+            // Sometimes, the axis might have a zero magnitude.
+            if axis_packed.magnitude().is_zero() {
+                continue;
+            }
             let refl = Reflection::new(Unit::new_unchecked(axis_packed), T::zero());
 
             let mut res_rows = res.view_range_mut(i.., i + shift..);

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,7 +17,7 @@ pub struct GivensRotation<T: ComplexField> {
 
 // Matrix = UnitComplex * Matrix
 impl<T: ComplexField> GivensRotation<T> {
-    /// The Givents rotation that does nothing.
+    /// The Givens rotation that does nothing.
     pub fn identity() -> Self {
         Self {
             c: T::RealField::one(),
@@ -88,13 +88,13 @@ impl<T: ComplexField> GivensRotation<T> {
         }
     }
 
-    /// The cos part of this roration.
+    /// The cos part of this rotation.
     #[must_use]
     pub fn c(&self) -> T::RealField {
         self.c.clone()
     }
 
-    /// The sin part of this roration.
+    /// The sin part of this rotation.
     #[must_use]
     pub fn s(&self) -> T {
         self.s.clone()

--- a/tests/linalg/svd.rs
+++ b/tests/linalg/svd.rs
@@ -499,3 +499,17 @@ fn svd_regression_issue_1072() {
         epsilon = 1e-9
     );
 }
+
+#[test]
+// Exercises bug reported in issue #1313 of nalgebra (https://github.com/dimforge/nalgebra/issues/1313)
+fn svd_regression_issue_1313() {
+    let s = 6.123234e-16_f32;
+    let m = nalgebra::dmatrix![
+        10.0,   0.0, 0.0,  0.0, -10.0, 0.0, 0.0, 0.0;
+           s,  10.0, 0.0, 10.0,     s, 0.0, 0.0, 0.0;
+        20.0, -20.0, 0.0, 20.0,  20.0, 0.0, 0.0, 0.0;
+    ];
+    let svd = m.clone().svd(true, true);
+    let m2 = svd.recompose().unwrap();
+    assert_relative_eq!(&m, &m2, epsilon = 1e-5);
+}


### PR DESCRIPTION
This resolves issue #1313.

The problem was in the bidiagonalization where U and V is computed. There is a corner case where U D V doesn't agree how the sign should be handled when the reflection axis has zero magnitude.

This solution fixes the correctness but I would like some input on how to make the test for zero magnitude more efficient.