### PR TITLE
Allow creating matrix iter with an owned view

### DIFF
--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -98,6 +98,18 @@ impl<'a, T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> IntoIterator
     }
 }
 
+impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> IntoIterator
+    for Matrix<T, R, C, ViewStorage<'a, T, R, C, RStride, CStride>>
+{
+    type Item = &'a T;
+    type IntoIter = MatrixIter<'a, T, R, C, ViewStorage<'a, T, R, C, RStride, CStride>>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        MatrixIter::new_owned(self.data)
+    }
+}
+
 impl<'a, T: Scalar, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> IntoIterator
     for &'a mut Matrix<T, R, C, S>
 {
@@ -107,6 +119,18 @@ impl<'a, T: Scalar, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> IntoIterator
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
+    }
+}
+
+impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> IntoIterator
+    for Matrix<T, R, C, ViewStorageMut<'a, T, R, C, RStride, CStride>>
+{
+    type Item = &'a mut T;
+    type IntoIter = MatrixIterMut<'a, T, R, C, ViewStorageMut<'a, T, R, C, RStride, CStride>>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        MatrixIterMut::new_owned_mut(self.data)
     }
 }
 


### PR DESCRIPTION
Fixes #747 

First of all - thanks for this crate, it's really fun to use, except for the lack of `IntoIterator` impls on (owned) view storages.

This allows overcoming the borrow checker issues when trying to do something like this:
![image](https://github.com/dimforge/nalgebra/assets/1835307/30417bc0-bba4-4233-815d-d83f1bc92d56)

Using the `IntoIterator` impl from this PR:
![image](https://github.com/dimforge/nalgebra/assets/1835307/b190bd79-0fd3-4d5b-afa4-efad1f4ea6b9)

I implemented this feature by extracting a common subset of `MatrixIter` and `MatrixIterMut` into a `RawIter` struct which erases the lifetime it is created with, and iterates over raw pointers instead of references.
Then, the `MatrixIter(Mut)` structs become simple wrappers over `RawIter`, but with an added lifetime constraint.

It's technically possible to keep the old code (and remove most of the code added in this PR) and impl the new `new_owned` and `new_owned_mut` using a transmute from `MatrixIter<'outer, ...>` to a `MatrixIter<'inner, ...>`, but I'm not even sure that's not possibly UB.

Let me know what you think :)