### PR TITLE
Forward `std` feature to some deps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [features]
 default = [ "std", "macros" ]
-std     = [ "matrixmultiply", "simba/std" ]
+std     = [ "matrixmultiply", "num-traits/std", "num-complex/std", "num-rational/std", "approx/std", "simba/std", "alga?/std" ]
 sparse  = [ ]
 debug   = [ "approx/num-complex", "rand" ]
 alloc   = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [features]
 default = [ "std", "macros" ]
-std     = [ "matrixmultiply", "num-traits/std", "num-complex/std", "num-rational/std", "approx/std", "simba/std", "alga?/std" ]
+std     = [ "matrixmultiply", "num-traits/std", "num-complex/std", "num-rational/std", "approx/std", "simba/std" ]
 sparse  = [ ]
 debug   = [ "approx/num-complex", "rand" ]
 alloc   = [ ]


### PR DESCRIPTION
Fixes #623 (specifically about `Complex::from_polar` at least)

`nalgebra`'s `std` cargo feature now also enables the `std` feature of some dependencies that use `default-features = false` (`num-traits`, `num-rational`, `num-complex`, `approx`, (if enabled) `alga`)

(Note: the  `"alga?/std"` syntax for enabling features of optional dependencies without necessarily enabling the optional dependency itself was only stabilized in Rust 1.60, but `nalgebra` seems to state that it's MSRV policy is ["latest stable"](https://docs.rs/nalgebra/latest/nalgebra/#using-nalgebra) so that would be fine.)