### PR TITLE
Added a simple LU decomposition

### DIFF
--- a/nalgebra-sparse/src/factorization/lu.rs
+++ b/nalgebra-sparse/src/factorization/lu.rs
@@ -1,0 +1,137 @@
+use nalgebra::{DMatrix, RealField};
+use std::error::Error;
+use std::ops::{Div, SubAssign};
+
+/// LU decomposition of a square matrix.
+#[derive(Debug)]
+pub struct LuDecomposition<T> {
+    l: DMatrix<T>,
+    u: DMatrix<T>,
+}
+
+impl<T: RealField> LuDecomposition<T>
+where
+    T: Div<T, Output = T> + SubAssign + Copy,
+{
+    /// Computes the LU decomposition of a given square matrix.
+    pub fn decompose(matrix: &DMatrix<T>) -> Result<Self, Box<dyn Error>> {
+        if matrix.nrows() != matrix.ncols() {
+            return Err("Matrix is not square".into());
+        }
+
+        let n = matrix.nrows();
+        let mut l = DMatrix::zeros(n, n);
+        let mut u = matrix.clone();
+
+        // LU decomposition algorithm
+        for i in 0..n {
+            for j in 0..=i {
+                let sum: T = (0..j)
+                    .map(|k| l[(i, k)] * u[(k, j)])
+                    .fold(T::zero(), |acc, x| acc + x);
+                l[(i, j)] = u[(i, j)] - sum;
+            }
+
+            for j in (i + 1)..n {
+                let sum: T = (0..i)
+                    .map(|k| l[(i, k)] * u[(k, j)])
+                    .fold(T::zero(), |acc, x| acc + x);
+                if l[(i, i)].is_zero() {
+                    return Err("Matrix is singular and cannot be decomposed".into());
+                }
+                u[(i, j)] = (u[(i, j)] - sum) / l[(i, i)];
+            }
+        }
+
+        Ok(LuDecomposition { l, u })
+    }
+
+    /// Returns a reference to the lower triangular matrix `l`.
+    pub fn l(&self) -> &DMatrix<T> {
+        &self.l
+    }
+
+    /// Returns a reference to the upper triangular matrix `u`.
+    pub fn u(&self) -> &DMatrix<T> {
+        &self.u
+    }
+
+    /// Prints the L and U matrices.
+    pub fn print_matrices(&self) {
+        println!("L matrix:\n{}", self.l);
+        println!("U matrix:\n{}", self.u);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use itertools::assert_equal;
+    use nalgebra::DMatrix;
+
+    #[test]
+    fn test_lu_decomposition() {
+        let matrix =
+            DMatrix::from_row_slice(3, 3, &[2.0, 3.0, 1.0, 4.0, 1.0, -1.0, -1.0, 3.0, 2.0]);
+        let lu = LuDecomposition::decompose(&matrix).unwrap();
+
+        // Print L and U matrices
+        let l = lu.l();
+        let u = lu.u();
+        assert_equal(
+            l.iter(),
+            DMatrix::from_row_slice(
+                3,
+                3,
+                &[
+                    2.0,
+                    0.0,
+                    0.0,
+                    4.0,
+                    -5.0,
+                    0.0,
+                    -1.0,
+                    4.5,
+                    -0.19999999999999973,
+                ],
+            )
+            .iter(),
+        );
+        assert_equal(
+            u.iter(),
+            DMatrix::from_row_slice(3, 3, &[2.0, 1.5, 0.5, 4.0, 1.0, 0.6, -1.0, 3.0, 2.0]).iter(),
+        );
+    }
+
+    #[test]
+    fn test_lu_decomposition_singular() {
+        let matrix = DMatrix::from_row_slice(3, 3, &[1.0, 2.0, 3.0, 2.0, 4.0, 6.0, 3.0, 6.0, 9.0]);
+        let lu = LuDecomposition::decompose(&matrix);
+        assert!(lu.is_err());
+    }
+
+    #[test]
+    fn test_lu_decomposition_non_square() {
+        let matrix = DMatrix::from_row_slice(3, 2, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let lu = LuDecomposition::decompose(&matrix);
+        assert!(lu.is_err());
+    }
+
+    #[test]
+    fn test_lu_decomposition_identity() {
+        let matrix = DMatrix::from_row_slice(3, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
+        let lu = LuDecomposition::decompose(&matrix).unwrap();
+
+        // Print L and U matrices
+        let l = lu.l();
+        let u = lu.u();
+        assert_equal(
+            l.iter(),
+            DMatrix::from_row_slice(3, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]).iter(),
+        );
+        assert_equal(
+            u.iter(),
+            DMatrix::from_row_slice(3, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]).iter(),
+        );
+    }
+}

--- a/nalgebra-sparse/src/factorization/mod.rs
+++ b/nalgebra-sparse/src/factorization/mod.rs
@@ -2,5 +2,7 @@
 //!
 //! Currently, the only factorization provided here is the [`CscCholesky`] factorization.
 mod cholesky;
+mod lu;
 
 pub use cholesky::*;
+pub use lu::*;


### PR DESCRIPTION
# Add LU Decomposition for Square Matrices Using nalgebra

## Overview

This pull request introduces an implementation of LU Decomposition for square matrices using the nalgebra library in Rust. LU Decomposition is crucial in numerical linear algebra for solving linear equations, inverting matrices, and computing determinants.

## Features

- **LU Decomposition Struct:** Stores the lower (`L`) and upper (`U`) triangular matrices.
- **Generic Implementation:** Works with any type `T` that implements `RealField` from nalgebra.
- **Error Handling:** Handles non-square matrices and singular matrices.
- **Matrix Printing:** Method to print `L` and `U` matrices for verification.
- **Comprehensive Testing:** Includes tests for various scenarios including singular and non-square matrices.

## Usage

The `LuDecomposition::decompose` method performs the decomposition, returning `L` and `U` matrices within `LuDecomposition` struct.

### Example

```rust
let matrix = DMatrix::from_row_slice(3, 3, &[2.0, 3.0, 1.0, 4.0, 1.0, -1.0, -1.0, 3.0, 2.0]);
let lu = LuDecomposition::decompose(&matrix).unwrap();
lu.print_matrices();
