### PR TITLE
Make OPoint call `T::fmt` to respect formatting modifiers

### DIFF
--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -511,12 +511,26 @@ where
 
         let mut it = self.coords.iter();
 
-        write!(f, "{}", *it.next().unwrap())?;
+        <T as fmt::Display>::fmt(it.next().unwrap(), f)?;
 
         for comp in it {
-            write!(f, ", {}", *comp)?;
+            write!(f, ", ")?;
+            <T as fmt::Display>::fmt(comp, f)?;
         }
 
         write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_fmt_respects_modifiers() {
+        let p = crate::Point3::new(1.23, 3.45, 5.67);
+        assert_eq!(&format!("{p}"), "{1.23, 3.45, 5.67}");
+        assert_eq!(&format!("{p:.1}"), "{1.2, 3.5, 5.7}");
+        assert_eq!(&format!("{p:.0}"), "{1, 3, 6}");
     }
 }

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -521,16 +521,3 @@ where
         write!(f, "}}")
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn display_fmt_respects_modifiers() {
-        let p = crate::Point3::new(1.23, 3.45, 5.67);
-        assert_eq!(&format!("{p}"), "{1.23, 3.45, 5.67}");
-        assert_eq!(&format!("{p:.1}"), "{1.2, 3.5, 5.7}");
-        assert_eq!(&format!("{p:.0}"), "{1, 3, 6}");
-    }
-}

--- a/tests/geometry/point.rs
+++ b/tests/geometry/point.rs
@@ -92,3 +92,11 @@ fn to_homogeneous() {
 
     assert_eq!(a.to_homogeneous(), expected);
 }
+
+#[test]
+fn display_fmt_respects_modifiers() {
+    let p = Point3::new(1.23, 3.45, 5.67);
+    assert_eq!(&format!("{p}"), "{1.23, 3.45, 5.67}");
+    assert_eq!(&format!("{p:.1}"), "{1.2, 3.5, 5.7}");
+    assert_eq!(&format!("{p:.0}"), "{1, 3, 6}");
+}


### PR DESCRIPTION
Invokes `T::fmt` rather than `write!`, which allows points to be formatted with modifiers like so:

```rust
let p = Point3::new(1.23, 3.45, 5.67);
assert_eq!(&format!("{p}"), "{1.23, 3.45, 5.67}");
assert_eq!(&format!("{p:.1}"), "{1.2, 3.5, 5.7}");
assert_eq!(&format!("{p:.0}"), "{1, 3, 6}");
```

I was not sure where to place the simple test code, it is currently adjacent in the file.