### PR TITLE
Support Glam 0.25 type conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add the methods `Matrix1::as_scalar`, `::as_scalar_mut`, `::to_scalar`, `::into_scalar`.
 - Add `Rotation3::euler_angles_ordered`, a generalized euler angles calculation.
 - Add the `glam-0.24` feature to enable conversion from/to types from `glam` v0.24.
+- Add the `glam-0.25` feature to enable conversion from/to types from `glam` v0.25.
 - Add the `lerp` method to points.
 - Implement `Clone` for `MatrixIter`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ convert-glam021 = [ "glam021" ]
 convert-glam022 = [ "glam022" ]
 convert-glam023 = [ "glam023" ]
 convert-glam024 = [ "glam024" ]
+convert-glam025 = [ "glam025" ]
 
 # Serialization
 ## To use serde in a #[no-std] environment, enable the
@@ -103,6 +104,7 @@ glam021        = { package = "glam", version = "0.21", optional = true }
 glam022        = { package = "glam", version = "0.22", optional = true }
 glam023        = { package = "glam", version = "0.23", optional = true }
 glam024        = { package = "glam", version = "0.24", optional = true }
+glam025        = { package = "glam", version = "0.25", optional = true }
 rayon          = { version = "1.6", optional = true }
 
 [dev-dependencies]

--- a/src/third_party/glam/mod.rs
+++ b/src/third_party/glam/mod.rs
@@ -20,3 +20,5 @@ mod v022;
 mod v023;
 #[cfg(feature = "glam024")]
 mod v024;
+#[cfg(feature = "glam025")]
+mod v025;

--- a/src/third_party/glam/v025/mod.rs
+++ b/src/third_party/glam/v025/mod.rs
@@ -1,0 +1,18 @@
+#[path = "../common/glam_isometry.rs"]
+mod glam_isometry;
+#[path = "../common/glam_matrix.rs"]
+mod glam_matrix;
+#[path = "../common/glam_point.rs"]
+mod glam_point;
+#[path = "../common/glam_quaternion.rs"]
+mod glam_quaternion;
+#[path = "../common/glam_rotation.rs"]
+mod glam_rotation;
+#[path = "../common/glam_similarity.rs"]
+mod glam_similarity;
+#[path = "../common/glam_translation.rs"]
+mod glam_translation;
+#[path = "../common/glam_unit_complex.rs"]
+mod glam_unit_complex;
+
+pub(self) use glam025 as glam;


### PR DESCRIPTION
Glam was updated to 0.25 a few weeks ago, so this PR adds type conversion for it through the `glam-0.25` feature. This will be needed for migrating e.g. Bevy physics engines to Bevy 0.13 once it is released.

Let me know if I missed something I need to update!