### PR TITLE
Fix redundant import errors in `nalgebra-glm`

### DIFF
--- a/nalgebra-glm/src/ext/quaternion_common.rs
+++ b/nalgebra-glm/src/ext/quaternion_common.rs
@@ -1,4 +1,4 @@
-use na::{self, Unit};
+use na::Unit;
 
 use crate::aliases::Qua;
 use crate::RealNumber;

--- a/nalgebra-glm/src/traits.rs
+++ b/nalgebra-glm/src/traits.rs
@@ -1,7 +1,6 @@
 use approx::AbsDiffEq;
 use num::{Bounded, Signed};
 
-use core::cmp::PartialOrd;
 use na::Scalar;
 use simba::scalar::{ClosedAdd, ClosedMul, ClosedSub, RealField};
 


### PR DESCRIPTION
More fallout from https://github.com/rust-lang/rust/issues/121708
Should make CI green again