### PR TITLE
Fix type inference error in tests on rustc beta

### DIFF
--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -360,7 +360,7 @@ mod test {
     #[test]
     fn wilkinson_shift_random() {
         for _ in 0..1000 {
-            let m = Matrix2::new_random();
+            let m = Matrix2::<f64>::new_random();
             let m = m * m.transpose();
 
             let expected = expected_shift(m);


### PR DESCRIPTION
On the latest release of rustc on the beta channel, running `cargo test` fails:

```
error[E0283]: type annotations needed for `matrix::Matrix<T, base::dimension::Const<2>, base::dimension::Const<2>, array_storage::ArrayStorage<T, 2, 2>>`
   --> src/linalg/symmetric_eigen.rs:363:17
    |
363 |             let m = Matrix2::new_random();
    |                 ^   --------------------- type must be known at this point
    |
    = note: cannot satisfy `_: base::scalar::Scalar`
note: required by a bound in `construction::<impl matrix::Matrix<T, R, C, <default_allocator::DefaultAllocator as base::allocator::Allocator<T, R, C>>::Buffer>>::new_random`
   --> src/base/construction.rs:647:9
    |
639 |         pub fn new_random($($args: usize),*) -> Self
    |                ---------- required by a bound in this associated function
...
647 | impl<T: Scalar, R: DimName, C: DimName> OMatrix<T, R, C>
    |         ^^^^^^ required by this bound in `construction::<impl Matrix<T, R, C, <DefaultAllocator as Allocator<T, R, C>>::Buffer>>::new_random`
help: consider giving `m` an explicit type, where the type for type parameter `T` is specified
    |
363 |             let m: matrix::Matrix<T, base::dimension::Const<2>, base::dimension::Const<2>, array_storage::ArrayStorage<T, 2, 2>> = Matrix2::new_random();
    |                  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0283]: type annotations needed
   --> src/linalg/symmetric_eigen.rs:364:23
    |
364 |             let m = m * m.transpose();
    |                       ^ cannot infer type for struct `matrix::Matrix<_, base::dimension::Const<2>, base::dimension::Const<2>, array_storage::ArrayStorage<_, 2, 2>>`
    |
note: multiple `impl`s satisfying `matrix::Matrix<_, base::dimension::Const<2>, base::dimension::Const<2>, array_storage::ArrayStorage<_, 2, 2>>: Mul<matrix::Matrix<_, base::dimension::Const<2>, base::dimension::Const<2>, array_storage::ArrayStorage<_, 2, 2>>>` found
   --> src/base/ops.rs:458:9
    |
458 | /         impl<T, R: Dim, C: Dim, S> $Trait<T> for Matrix<T, R, C, S>
459 | |             where T: Scalar + $bound,
460 | |                   S: Storage<T, R, C>,
461 | |                   DefaultAllocator: Allocator<T, R, C> {
    | |______________________________________________________^
...
509 |   componentwise_scalarop_impl!(Mul, mul, ClosedMul; MulAssign, mul_assign);
    |   ------------------------------------------------------------------------ in this macro invocation
...
607 | / impl<T, R1: Dim, C1: Dim, R2: Dim, C2: Dim, SA, SB> Mul<Matrix<T, R2, C2, SB>>
608 | |     for Matrix<T, R1, C1, SA>
609 | | where
610 | |     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
...   |
613 | |     DefaultAllocator: Allocator<T, R1, C2>,
614 | |     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
    | |_____________________________________________________^
    = note: this error originates in the macro `componentwise_scalarop_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0283`.
```

I used `cargo-bisect-rustc` and got pointed to this PR: https://github.com/rust-lang/rust/pull/119989
It seems like the author of the PR knew it might cause some regressions, but they were deemed acceptable.
This means that `nalgebra`'s CI will break on May 2nd, when 1.78 gets promoted to stable.
This small change fixes the regression.