### PR TITLE
Introduce Storage::forget_elements() to fix memory leak in Matrix::generic_resize()

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -130,6 +130,12 @@ where
     {
         self.clone()
     }
+    
+    #[inline]
+    fn forget(self) {
+        // No additional cleanup required.
+        std::mem::forget(self);
+    }
 }
 
 unsafe impl<T, const R: usize, const C: usize> RawStorageMut<T, Const<R>, Const<C>>

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -130,7 +130,7 @@ where
     {
         self.clone()
     }
-    
+
     #[inline]
     fn forget(self) {
         // No additional cleanup required.

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -132,7 +132,7 @@ where
     }
 
     #[inline]
-    fn forget(self) {
+    fn forget_elements(self) {
         // No additional cleanup required.
         std::mem::forget(self);
     }

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -237,7 +237,7 @@ where
 
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
-        // - We forget `buf` so that we don’t drop the other elements.
+        // - We forget `buf` so that we don’t drop the other elements, but ensure the buffer itself is cleaned up.
         buf.forget_elements();
 
         res
@@ -268,7 +268,7 @@ where
 
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
-        // - We forget `buf` so that we don’t drop the other elements.
+        // - We forget `buf` so that we don’t drop the other elements, but ensure the buffer itself is cleaned up.
         buf.forget_elements();
 
         res

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -207,7 +207,7 @@ where
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
         // - We forget `buf` so that we don’t drop the other elements, but ensure the buffer itself is cleaned up.
-        buf.forget();
+        buf.forget_elements();
 
         res
     }
@@ -238,7 +238,7 @@ where
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
         // - We forget `buf` so that we don’t drop the other elements.
-        buf.forget();
+        buf.forget_elements();
 
         res
     }
@@ -269,7 +269,7 @@ where
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
         // - We forget `buf` so that we don’t drop the other elements.
-        buf.forget();
+        buf.forget_elements();
 
         res
     }

--- a/src/base/default_allocator.rs
+++ b/src/base/default_allocator.rs
@@ -15,7 +15,7 @@ use crate::base::array_storage::ArrayStorage;
 use crate::base::dimension::Dim;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::base::dimension::{DimName, Dyn};
-use crate::base::storage::{RawStorage, RawStorageMut};
+use crate::base::storage::{RawStorage, RawStorageMut, Storage};
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::base::vec_storage::VecStorage;
 use crate::base::Scalar;
@@ -206,8 +206,8 @@ where
 
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
-        // - We forget `buf` so that we don’t drop the other elements.
-        std::mem::forget(buf);
+        // - We forget `buf` so that we don’t drop the other elements, but ensure the buffer itself is cleaned up.
+        buf.forget();
 
         res
     }
@@ -238,7 +238,7 @@ where
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
         // - We forget `buf` so that we don’t drop the other elements.
-        std::mem::forget(buf);
+        buf.forget();
 
         res
     }
@@ -269,7 +269,7 @@ where
         // Safety:
         // - We don’t care about dropping elements because the caller is responsible for dropping things.
         // - We forget `buf` so that we don’t drop the other elements.
-        std::mem::forget(buf);
+        buf.forget();
 
         res
     }

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -229,7 +229,7 @@ macro_rules! storage_impl(
                 let it = MatrixIter::new(self).cloned();
                 DefaultAllocator::allocate_from_iterator(nrows, ncols, it)
             }
-    
+
             #[inline]
             fn forget(self) {
                 // No cleanup required.

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -231,7 +231,7 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-            fn forget(self) {
+            fn forget_elements(self) {
                 // No cleanup required.
             }
         }

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -229,6 +229,11 @@ macro_rules! storage_impl(
                 let it = MatrixIter::new(self).cloned();
                 DefaultAllocator::allocate_from_iterator(nrows, ncols, it)
             }
+    
+            #[inline]
+            fn forget(self) {
+                // No cleanup required.
+            }
         }
     )*}
 );

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -150,8 +150,8 @@ pub unsafe trait Storage<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     where
         DefaultAllocator: Allocator<T, R, C>;
 
-    /// Cleans up the storage without calling the destructors on the contained elements.
-    fn forget(self);
+    /// Drops the storage without calling the destructors on the contained elements.
+    fn forget_elements(self);
 }
 
 /// Trait implemented by matrix data storage that can provide a mutable access to its elements.

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -149,6 +149,9 @@ pub unsafe trait Storage<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     fn clone_owned(&self) -> Owned<T, R, C>
     where
         DefaultAllocator: Allocator<T, R, C>;
+
+    /// Cleans up the storage without calling the destructors on the contained elements.
+    fn forget(self);
 }
 
 /// Trait implemented by matrix data storage that can provide a mutable access to its elements.

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -281,7 +281,7 @@ where
     {
         self.clone()
     }
-    
+
     #[inline]
     fn forget(mut self) {
         // Set length to 0 so element destructors are not called.
@@ -338,7 +338,7 @@ where
     {
         self.clone()
     }
-    
+
     #[inline]
     fn forget(mut self) {
         // Set length to 0 so element destructors are not called.

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -283,8 +283,13 @@ where
     }
 
     #[inline]
-    fn forget(mut self) {
-        // Set length to 0 so element destructors are not called.
+    fn forget_elements(mut self) {
+        // SAFETY: setting the length to zero is always sound, as it does not
+        // cause any memory to be deemed initialized. If the previous length was
+        // non-zero, it is equivalent to using mem::forget to leak each element.
+        // Then, when this function returns, self.data is dropped, freeing the
+        // allocated memory, but the elements are not dropped because they are
+        // now considered uninitialized.
         unsafe { self.data.set_len(0) };
     }
 }
@@ -340,8 +345,13 @@ where
     }
 
     #[inline]
-    fn forget(mut self) {
-        // Set length to 0 so element destructors are not called.
+    fn forget_elements(mut self) {
+        // SAFETY: setting the length to zero is always sound, as it does not
+        // cause any memory to be deemed initialized. If the previous length was
+        // non-zero, it is equivalent to using mem::forget to leak each element.
+        // Then, when this function returns, self.data is dropped, freeing the
+        // allocated memory, but the elements are not dropped because they are
+        // now considered uninitialized.
         unsafe { self.data.set_len(0) };
     }
 }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -281,6 +281,12 @@ where
     {
         self.clone()
     }
+    
+    #[inline]
+    fn forget(mut self) {
+        // Set length to 0 so element destructors are not called.
+        unsafe { self.data.set_len(0) };
+    }
 }
 
 unsafe impl<T, R: DimName> RawStorage<T, R, Dyn> for VecStorage<T, R, Dyn> {
@@ -331,6 +337,12 @@ where
         DefaultAllocator: Allocator<T, R, Dyn>,
     {
         self.clone()
+    }
+    
+    #[inline]
+    fn forget(mut self) {
+        // Set length to 0 so element destructors are not called.
+        unsafe { self.data.set_len(0) };
     }
 }
 


### PR DESCRIPTION
Fixes #1378 

Adds a trait method `Storage::forget()` to clean up the storage while forgetting (i.e., not dropping) the contents. Makes use of this method instead of `mem::forget()` in the implementations of `Reallocator` for `DefaultAllocator`.