### PR TITLE
Fix false row-major comment in doc

### DIFF
--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -59,7 +59,7 @@ pub unsafe trait RawStorage<T, R: Dim, C: Dim = U1>: Sized {
 
     /// The spacing between consecutive row elements and consecutive column elements.
     ///
-    /// For example this returns `(1, 5)` for a row-major matrix with 5 columns.
+    /// For example this returns `(1, 5)` for a column-major matrix with 5 columns.
     fn strides(&self) -> (Self::RStride, Self::CStride);
 
     /// Compute the index corresponding to the irow-th row and icol-th column of this matrix. The


### PR DESCRIPTION
As already discussed in https://github.com/dimforge/nalgebra.org/pull/86, there is a false statement in the documentation of the RawStorage trait.

In the documentation of RawStorage::stride it was falsely claimed that the storage of the matrix happens in a row-major fashion. In fact it is column-major.