### PR TITLE
Inverting a 4x4 matrix with `try_inverse_mut` doesn't leave `self` unchanged if the inversion fails.

### DIFF
--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -180,99 +180,98 @@ where
 
     if det.is_zero() {
         return false;
-    } else {
-        out[(0, 0)] = cofactor00;
-
-        out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
-            - m[1].clone() * m[7].clone() * m[14].clone()
-            - m[5].clone() * m[2].clone() * m[15].clone()
-            + m[5].clone() * m[3].clone() * m[14].clone()
-            + m[13].clone() * m[2].clone() * m[7].clone()
-            - m[13].clone() * m[3].clone() * m[6].clone();
-
-        out[(3, 0)] = -m[1].clone() * m[6].clone() * m[11].clone()
-            + m[1].clone() * m[7].clone() * m[10].clone()
-            + m[5].clone() * m[2].clone() * m[11].clone()
-            - m[5].clone() * m[3].clone() * m[10].clone()
-            - m[9].clone() * m[2].clone() * m[7].clone()
-            + m[9].clone() * m[3].clone() * m[6].clone();
-
-        out[(0, 1)] = cofactor01;
-
-        out[(1, 1)] = m[0].clone() * m[10].clone() * m[15].clone()
-            - m[0].clone() * m[11].clone() * m[14].clone()
-            - m[8].clone() * m[2].clone() * m[15].clone()
-            + m[8].clone() * m[3].clone() * m[14].clone()
-            + m[12].clone() * m[2].clone() * m[11].clone()
-            - m[12].clone() * m[3].clone() * m[10].clone();
-
-        out[(2, 1)] = -m[0].clone() * m[6].clone() * m[15].clone()
-            + m[0].clone() * m[7].clone() * m[14].clone()
-            + m[4].clone() * m[2].clone() * m[15].clone()
-            - m[4].clone() * m[3].clone() * m[14].clone()
-            - m[12].clone() * m[2].clone() * m[7].clone()
-            + m[12].clone() * m[3].clone() * m[6].clone();
-
-        out[(3, 1)] = m[0].clone() * m[6].clone() * m[11].clone()
-            - m[0].clone() * m[7].clone() * m[10].clone()
-            - m[4].clone() * m[2].clone() * m[11].clone()
-            + m[4].clone() * m[3].clone() * m[10].clone()
-            + m[8].clone() * m[2].clone() * m[7].clone()
-            - m[8].clone() * m[3].clone() * m[6].clone();
-
-        out[(0, 2)] = cofactor02;
-
-        out[(1, 2)] = -m[0].clone() * m[9].clone() * m[15].clone()
-            + m[0].clone() * m[11].clone() * m[13].clone()
-            + m[8].clone() * m[1].clone() * m[15].clone()
-            - m[8].clone() * m[3].clone() * m[13].clone()
-            - m[12].clone() * m[1].clone() * m[11].clone()
-            + m[12].clone() * m[3].clone() * m[9].clone();
-
-        out[(2, 2)] = m[0].clone() * m[5].clone() * m[15].clone()
-            - m[0].clone() * m[7].clone() * m[13].clone()
-            - m[4].clone() * m[1].clone() * m[15].clone()
-            + m[4].clone() * m[3].clone() * m[13].clone()
-            + m[12].clone() * m[1].clone() * m[7].clone()
-            - m[12].clone() * m[3].clone() * m[5].clone();
-
-        out[(0, 3)] = cofactor03;
-
-        out[(3, 2)] = -m[0].clone() * m[5].clone() * m[11].clone()
-            + m[0].clone() * m[7].clone() * m[9].clone()
-            + m[4].clone() * m[1].clone() * m[11].clone()
-            - m[4].clone() * m[3].clone() * m[9].clone()
-            - m[8].clone() * m[1].clone() * m[7].clone()
-            + m[8].clone() * m[3].clone() * m[5].clone();
-
-        out[(1, 3)] = m[0].clone() * m[9].clone() * m[14].clone()
-            - m[0].clone() * m[10].clone() * m[13].clone()
-            - m[8].clone() * m[1].clone() * m[14].clone()
-            + m[8].clone() * m[2].clone() * m[13].clone()
-            + m[12].clone() * m[1].clone() * m[10].clone()
-            - m[12].clone() * m[2].clone() * m[9].clone();
-
-        out[(2, 3)] = -m[0].clone() * m[5].clone() * m[14].clone()
-            + m[0].clone() * m[6].clone() * m[13].clone()
-            + m[4].clone() * m[1].clone() * m[14].clone()
-            - m[4].clone() * m[2].clone() * m[13].clone()
-            - m[12].clone() * m[1].clone() * m[6].clone()
-            + m[12].clone() * m[2].clone() * m[5].clone();
-
-        out[(3, 3)] = m[0].clone() * m[5].clone() * m[10].clone()
-            - m[0].clone() * m[6].clone() * m[9].clone()
-            - m[4].clone() * m[1].clone() * m[10].clone()
-            + m[4].clone() * m[2].clone() * m[9].clone()
-            + m[8].clone() * m[1].clone() * m[6].clone()
-            - m[8].clone() * m[2].clone() * m[5].clone();
-
-        let inv_det = T::one() / det;
-
-        for j in 0..4 {
-            for i in 0..4 {
-                out[(i, j)] *= inv_det.clone();
-            }
-        }
-        true
     }
+    out[(0, 0)] = cofactor00;
+
+    out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
+        - m[1].clone() * m[7].clone() * m[14].clone()
+        - m[5].clone() * m[2].clone() * m[15].clone()
+        + m[5].clone() * m[3].clone() * m[14].clone()
+        + m[13].clone() * m[2].clone() * m[7].clone()
+        - m[13].clone() * m[3].clone() * m[6].clone();
+
+    out[(3, 0)] = -m[1].clone() * m[6].clone() * m[11].clone()
+        + m[1].clone() * m[7].clone() * m[10].clone()
+        + m[5].clone() * m[2].clone() * m[11].clone()
+        - m[5].clone() * m[3].clone() * m[10].clone()
+        - m[9].clone() * m[2].clone() * m[7].clone()
+        + m[9].clone() * m[3].clone() * m[6].clone();
+
+    out[(0, 1)] = cofactor01;
+
+    out[(1, 1)] = m[0].clone() * m[10].clone() * m[15].clone()
+        - m[0].clone() * m[11].clone() * m[14].clone()
+        - m[8].clone() * m[2].clone() * m[15].clone()
+        + m[8].clone() * m[3].clone() * m[14].clone()
+        + m[12].clone() * m[2].clone() * m[11].clone()
+        - m[12].clone() * m[3].clone() * m[10].clone();
+
+    out[(2, 1)] = -m[0].clone() * m[6].clone() * m[15].clone()
+        + m[0].clone() * m[7].clone() * m[14].clone()
+        + m[4].clone() * m[2].clone() * m[15].clone()
+        - m[4].clone() * m[3].clone() * m[14].clone()
+        - m[12].clone() * m[2].clone() * m[7].clone()
+        + m[12].clone() * m[3].clone() * m[6].clone();
+
+    out[(3, 1)] = m[0].clone() * m[6].clone() * m[11].clone()
+        - m[0].clone() * m[7].clone() * m[10].clone()
+        - m[4].clone() * m[2].clone() * m[11].clone()
+        + m[4].clone() * m[3].clone() * m[10].clone()
+        + m[8].clone() * m[2].clone() * m[7].clone()
+        - m[8].clone() * m[3].clone() * m[6].clone();
+
+    out[(0, 2)] = cofactor02;
+
+    out[(1, 2)] = -m[0].clone() * m[9].clone() * m[15].clone()
+        + m[0].clone() * m[11].clone() * m[13].clone()
+        + m[8].clone() * m[1].clone() * m[15].clone()
+        - m[8].clone() * m[3].clone() * m[13].clone()
+        - m[12].clone() * m[1].clone() * m[11].clone()
+        + m[12].clone() * m[3].clone() * m[9].clone();
+
+    out[(2, 2)] = m[0].clone() * m[5].clone() * m[15].clone()
+        - m[0].clone() * m[7].clone() * m[13].clone()
+        - m[4].clone() * m[1].clone() * m[15].clone()
+        + m[4].clone() * m[3].clone() * m[13].clone()
+        + m[12].clone() * m[1].clone() * m[7].clone()
+        - m[12].clone() * m[3].clone() * m[5].clone();
+
+    out[(0, 3)] = cofactor03;
+
+    out[(3, 2)] = -m[0].clone() * m[5].clone() * m[11].clone()
+        + m[0].clone() * m[7].clone() * m[9].clone()
+        + m[4].clone() * m[1].clone() * m[11].clone()
+        - m[4].clone() * m[3].clone() * m[9].clone()
+        - m[8].clone() * m[1].clone() * m[7].clone()
+        + m[8].clone() * m[3].clone() * m[5].clone();
+
+    out[(1, 3)] = m[0].clone() * m[9].clone() * m[14].clone()
+        - m[0].clone() * m[10].clone() * m[13].clone()
+        - m[8].clone() * m[1].clone() * m[14].clone()
+        + m[8].clone() * m[2].clone() * m[13].clone()
+        + m[12].clone() * m[1].clone() * m[10].clone()
+        - m[12].clone() * m[2].clone() * m[9].clone();
+
+    out[(2, 3)] = -m[0].clone() * m[5].clone() * m[14].clone()
+        + m[0].clone() * m[6].clone() * m[13].clone()
+        + m[4].clone() * m[1].clone() * m[14].clone()
+        - m[4].clone() * m[2].clone() * m[13].clone()
+        - m[12].clone() * m[1].clone() * m[6].clone()
+        + m[12].clone() * m[2].clone() * m[5].clone();
+
+    out[(3, 3)] = m[0].clone() * m[5].clone() * m[10].clone()
+        - m[0].clone() * m[6].clone() * m[9].clone()
+        - m[4].clone() * m[1].clone() * m[10].clone()
+        + m[4].clone() * m[2].clone() * m[9].clone()
+        + m[8].clone() * m[1].clone() * m[6].clone()
+        - m[8].clone() * m[2].clone() * m[5].clone();
+
+    let inv_det = T::one() / det;
+
+    for j in 0..4 {
+        for i in 0..4 {
+            out[(i, j)] *= inv_det.clone();
+        }
+    }
+    true
 }

--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -145,124 +145,149 @@ where
 {
     let m = m.as_slice();
 
-    out[(0, 0)] = m[5].clone() * m[10].clone() * m[15].clone()
-        - m[5].clone() * m[11].clone() * m[14].clone()
-        - m[9].clone() * m[6].clone() * m[15].clone()
-        + m[9].clone() * m[7].clone() * m[14].clone()
-        + m[13].clone() * m[6].clone() * m[11].clone()
-        - m[13].clone() * m[7].clone() * m[10].clone();
+    let det = m[0].clone()
+        * (m[5].clone() * m[10].clone() * m[15].clone()
+            + m[6].clone() * m[11].clone() * m[13].clone()
+            + m[7].clone() * m[9].clone() * m[14].clone()
+            - m[7].clone() * m[10].clone() * m[13].clone()
+            - m[6].clone() * m[9].clone() * m[15].clone()
+            - m[5].clone() * m[11].clone() * m[14].clone())
+        - m[1].clone()
+            * (m[4].clone() * m[10].clone() * m[15].clone()
+                + m[6].clone() * m[11].clone() * m[12].clone()
+                + m[7].clone() * m[8].clone() * m[14].clone()
+                - m[7].clone() * m[10].clone() * m[12].clone()
+                - m[6].clone() * m[8].clone() * m[15].clone()
+                - m[4].clone() * m[11].clone() * m[14].clone())
+        + m[2].clone()
+            * (m[4].clone() * m[9].clone() * m[15].clone()
+                + m[5].clone() * m[11].clone() * m[12].clone()
+                + m[7].clone() * m[8].clone() * m[13].clone()
+                - m[7].clone() * m[9].clone() * m[12].clone()
+                - m[5].clone() * m[8].clone() * m[15].clone()
+                - m[4].clone() * m[11].clone() * m[13].clone())
+        - m[3].clone()
+            * (m[4].clone() * m[9].clone() * m[14].clone()
+                + m[5].clone() * m[10].clone() * m[12].clone()
+                + m[6].clone() * m[8].clone() * m[13].clone()
+                - m[6].clone() * m[9].clone() * m[12].clone()
+                - m[5].clone() * m[8].clone() * m[14].clone()
+                - m[4].clone() * m[10].clone() * m[13].clone());
+    if det.is_zero() {
+        false
+    } else {
+        out[(0, 0)] = m[5].clone() * m[10].clone() * m[15].clone()
+            - m[5].clone() * m[11].clone() * m[14].clone()
+            - m[9].clone() * m[6].clone() * m[15].clone()
+            + m[9].clone() * m[7].clone() * m[14].clone()
+            + m[13].clone() * m[6].clone() * m[11].clone()
+            - m[13].clone() * m[7].clone() * m[10].clone();
 
-    out[(1, 0)] = -m[1].clone() * m[10].clone() * m[15].clone()
-        + m[1].clone() * m[11].clone() * m[14].clone()
-        + m[9].clone() * m[2].clone() * m[15].clone()
-        - m[9].clone() * m[3].clone() * m[14].clone()
-        - m[13].clone() * m[2].clone() * m[11].clone()
-        + m[13].clone() * m[3].clone() * m[10].clone();
+        out[(1, 0)] = -m[1].clone() * m[10].clone() * m[15].clone()
+            + m[1].clone() * m[11].clone() * m[14].clone()
+            + m[9].clone() * m[2].clone() * m[15].clone()
+            - m[9].clone() * m[3].clone() * m[14].clone()
+            - m[13].clone() * m[2].clone() * m[11].clone()
+            + m[13].clone() * m[3].clone() * m[10].clone();
 
-    out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
-        - m[1].clone() * m[7].clone() * m[14].clone()
-        - m[5].clone() * m[2].clone() * m[15].clone()
-        + m[5].clone() * m[3].clone() * m[14].clone()
-        + m[13].clone() * m[2].clone() * m[7].clone()
-        - m[13].clone() * m[3].clone() * m[6].clone();
+        out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
+            - m[1].clone() * m[7].clone() * m[14].clone()
+            - m[5].clone() * m[2].clone() * m[15].clone()
+            + m[5].clone() * m[3].clone() * m[14].clone()
+            + m[13].clone() * m[2].clone() * m[7].clone()
+            - m[13].clone() * m[3].clone() * m[6].clone();
 
-    out[(3, 0)] = -m[1].clone() * m[6].clone() * m[11].clone()
-        + m[1].clone() * m[7].clone() * m[10].clone()
-        + m[5].clone() * m[2].clone() * m[11].clone()
-        - m[5].clone() * m[3].clone() * m[10].clone()
-        - m[9].clone() * m[2].clone() * m[7].clone()
-        + m[9].clone() * m[3].clone() * m[6].clone();
+        out[(3, 0)] = -m[1].clone() * m[6].clone() * m[11].clone()
+            + m[1].clone() * m[7].clone() * m[10].clone()
+            + m[5].clone() * m[2].clone() * m[11].clone()
+            - m[5].clone() * m[3].clone() * m[10].clone()
+            - m[9].clone() * m[2].clone() * m[7].clone()
+            + m[9].clone() * m[3].clone() * m[6].clone();
 
-    out[(0, 1)] = -m[4].clone() * m[10].clone() * m[15].clone()
-        + m[4].clone() * m[11].clone() * m[14].clone()
-        + m[8].clone() * m[6].clone() * m[15].clone()
-        - m[8].clone() * m[7].clone() * m[14].clone()
-        - m[12].clone() * m[6].clone() * m[11].clone()
-        + m[12].clone() * m[7].clone() * m[10].clone();
+        out[(0, 1)] = -m[4].clone() * m[10].clone() * m[15].clone()
+            + m[4].clone() * m[11].clone() * m[14].clone()
+            + m[8].clone() * m[6].clone() * m[15].clone()
+            - m[8].clone() * m[7].clone() * m[14].clone()
+            - m[12].clone() * m[6].clone() * m[11].clone()
+            + m[12].clone() * m[7].clone() * m[10].clone();
 
-    out[(1, 1)] = m[0].clone() * m[10].clone() * m[15].clone()
-        - m[0].clone() * m[11].clone() * m[14].clone()
-        - m[8].clone() * m[2].clone() * m[15].clone()
-        + m[8].clone() * m[3].clone() * m[14].clone()
-        + m[12].clone() * m[2].clone() * m[11].clone()
-        - m[12].clone() * m[3].clone() * m[10].clone();
+        out[(1, 1)] = m[0].clone() * m[10].clone() * m[15].clone()
+            - m[0].clone() * m[11].clone() * m[14].clone()
+            - m[8].clone() * m[2].clone() * m[15].clone()
+            + m[8].clone() * m[3].clone() * m[14].clone()
+            + m[12].clone() * m[2].clone() * m[11].clone()
+            - m[12].clone() * m[3].clone() * m[10].clone();
 
-    out[(2, 1)] = -m[0].clone() * m[6].clone() * m[15].clone()
-        + m[0].clone() * m[7].clone() * m[14].clone()
-        + m[4].clone() * m[2].clone() * m[15].clone()
-        - m[4].clone() * m[3].clone() * m[14].clone()
-        - m[12].clone() * m[2].clone() * m[7].clone()
-        + m[12].clone() * m[3].clone() * m[6].clone();
+        out[(2, 1)] = -m[0].clone() * m[6].clone() * m[15].clone()
+            + m[0].clone() * m[7].clone() * m[14].clone()
+            + m[4].clone() * m[2].clone() * m[15].clone()
+            - m[4].clone() * m[3].clone() * m[14].clone()
+            - m[12].clone() * m[2].clone() * m[7].clone()
+            + m[12].clone() * m[3].clone() * m[6].clone();
 
-    out[(3, 1)] = m[0].clone() * m[6].clone() * m[11].clone()
-        - m[0].clone() * m[7].clone() * m[10].clone()
-        - m[4].clone() * m[2].clone() * m[11].clone()
-        + m[4].clone() * m[3].clone() * m[10].clone()
-        + m[8].clone() * m[2].clone() * m[7].clone()
-        - m[8].clone() * m[3].clone() * m[6].clone();
+        out[(3, 1)] = m[0].clone() * m[6].clone() * m[11].clone()
+            - m[0].clone() * m[7].clone() * m[10].clone()
+            - m[4].clone() * m[2].clone() * m[11].clone()
+            + m[4].clone() * m[3].clone() * m[10].clone()
+            + m[8].clone() * m[2].clone() * m[7].clone()
+            - m[8].clone() * m[3].clone() * m[6].clone();
 
-    out[(0, 2)] = m[4].clone() * m[9].clone() * m[15].clone()
-        - m[4].clone() * m[11].clone() * m[13].clone()
-        - m[8].clone() * m[5].clone() * m[15].clone()
-        + m[8].clone() * m[7].clone() * m[13].clone()
-        + m[12].clone() * m[5].clone() * m[11].clone()
-        - m[12].clone() * m[7].clone() * m[9].clone();
+        out[(0, 2)] = m[4].clone() * m[9].clone() * m[15].clone()
+            - m[4].clone() * m[11].clone() * m[13].clone()
+            - m[8].clone() * m[5].clone() * m[15].clone()
+            + m[8].clone() * m[7].clone() * m[13].clone()
+            + m[12].clone() * m[5].clone() * m[11].clone()
+            - m[12].clone() * m[7].clone() * m[9].clone();
 
-    out[(1, 2)] = -m[0].clone() * m[9].clone() * m[15].clone()
-        + m[0].clone() * m[11].clone() * m[13].clone()
-        + m[8].clone() * m[1].clone() * m[15].clone()
-        - m[8].clone() * m[3].clone() * m[13].clone()
-        - m[12].clone() * m[1].clone() * m[11].clone()
-        + m[12].clone() * m[3].clone() * m[9].clone();
+        out[(1, 2)] = -m[0].clone() * m[9].clone() * m[15].clone()
+            + m[0].clone() * m[11].clone() * m[13].clone()
+            + m[8].clone() * m[1].clone() * m[15].clone()
+            - m[8].clone() * m[3].clone() * m[13].clone()
+            - m[12].clone() * m[1].clone() * m[11].clone()
+            + m[12].clone() * m[3].clone() * m[9].clone();
 
-    out[(2, 2)] = m[0].clone() * m[5].clone() * m[15].clone()
-        - m[0].clone() * m[7].clone() * m[13].clone()
-        - m[4].clone() * m[1].clone() * m[15].clone()
-        + m[4].clone() * m[3].clone() * m[13].clone()
-        + m[12].clone() * m[1].clone() * m[7].clone()
-        - m[12].clone() * m[3].clone() * m[5].clone();
+        out[(2, 2)] = m[0].clone() * m[5].clone() * m[15].clone()
+            - m[0].clone() * m[7].clone() * m[13].clone()
+            - m[4].clone() * m[1].clone() * m[15].clone()
+            + m[4].clone() * m[3].clone() * m[13].clone()
+            + m[12].clone() * m[1].clone() * m[7].clone()
+            - m[12].clone() * m[3].clone() * m[5].clone();
 
-    out[(0, 3)] = -m[4].clone() * m[9].clone() * m[14].clone()
-        + m[4].clone() * m[10].clone() * m[13].clone()
-        + m[8].clone() * m[5].clone() * m[14].clone()
-        - m[8].clone() * m[6].clone() * m[13].clone()
-        - m[12].clone() * m[5].clone() * m[10].clone()
-        + m[12].clone() * m[6].clone() * m[9].clone();
+        out[(0, 3)] = -m[4].clone() * m[9].clone() * m[14].clone()
+            + m[4].clone() * m[10].clone() * m[13].clone()
+            + m[8].clone() * m[5].clone() * m[14].clone()
+            - m[8].clone() * m[6].clone() * m[13].clone()
+            - m[12].clone() * m[5].clone() * m[10].clone()
+            + m[12].clone() * m[6].clone() * m[9].clone();
 
-    out[(3, 2)] = -m[0].clone() * m[5].clone() * m[11].clone()
-        + m[0].clone() * m[7].clone() * m[9].clone()
-        + m[4].clone() * m[1].clone() * m[11].clone()
-        - m[4].clone() * m[3].clone() * m[9].clone()
-        - m[8].clone() * m[1].clone() * m[7].clone()
-        + m[8].clone() * m[3].clone() * m[5].clone();
+        out[(3, 2)] = -m[0].clone() * m[5].clone() * m[11].clone()
+            + m[0].clone() * m[7].clone() * m[9].clone()
+            + m[4].clone() * m[1].clone() * m[11].clone()
+            - m[4].clone() * m[3].clone() * m[9].clone()
+            - m[8].clone() * m[1].clone() * m[7].clone()
+            + m[8].clone() * m[3].clone() * m[5].clone();
 
-    out[(1, 3)] = m[0].clone() * m[9].clone() * m[14].clone()
-        - m[0].clone() * m[10].clone() * m[13].clone()
-        - m[8].clone() * m[1].clone() * m[14].clone()
-        + m[8].clone() * m[2].clone() * m[13].clone()
-        + m[12].clone() * m[1].clone() * m[10].clone()
-        - m[12].clone() * m[2].clone() * m[9].clone();
+        out[(1, 3)] = m[0].clone() * m[9].clone() * m[14].clone()
+            - m[0].clone() * m[10].clone() * m[13].clone()
+            - m[8].clone() * m[1].clone() * m[14].clone()
+            + m[8].clone() * m[2].clone() * m[13].clone()
+            + m[12].clone() * m[1].clone() * m[10].clone()
+            - m[12].clone() * m[2].clone() * m[9].clone();
 
-    out[(2, 3)] = -m[0].clone() * m[5].clone() * m[14].clone()
-        + m[0].clone() * m[6].clone() * m[13].clone()
-        + m[4].clone() * m[1].clone() * m[14].clone()
-        - m[4].clone() * m[2].clone() * m[13].clone()
-        - m[12].clone() * m[1].clone() * m[6].clone()
-        + m[12].clone() * m[2].clone() * m[5].clone();
+        out[(2, 3)] = -m[0].clone() * m[5].clone() * m[14].clone()
+            + m[0].clone() * m[6].clone() * m[13].clone()
+            + m[4].clone() * m[1].clone() * m[14].clone()
+            - m[4].clone() * m[2].clone() * m[13].clone()
+            - m[12].clone() * m[1].clone() * m[6].clone()
+            + m[12].clone() * m[2].clone() * m[5].clone();
 
-    out[(3, 3)] = m[0].clone() * m[5].clone() * m[10].clone()
-        - m[0].clone() * m[6].clone() * m[9].clone()
-        - m[4].clone() * m[1].clone() * m[10].clone()
-        + m[4].clone() * m[2].clone() * m[9].clone()
-        + m[8].clone() * m[1].clone() * m[6].clone()
-        - m[8].clone() * m[2].clone() * m[5].clone();
+        out[(3, 3)] = m[0].clone() * m[5].clone() * m[10].clone()
+            - m[0].clone() * m[6].clone() * m[9].clone()
+            - m[4].clone() * m[1].clone() * m[10].clone()
+            + m[4].clone() * m[2].clone() * m[9].clone()
+            + m[8].clone() * m[1].clone() * m[6].clone()
+            - m[8].clone() * m[2].clone() * m[5].clone();
 
-    let det = m[0].clone() * out[(0, 0)].clone()
-        + m[1].clone() * out[(0, 1)].clone()
-        + m[2].clone() * out[(0, 2)].clone()
-        + m[3].clone() * out[(0, 3)].clone();
-
-    if !det.is_zero() {
         let inv_det = T::one() / det;
 
         for j in 0..4 {
@@ -271,7 +296,5 @@ where
             }
         }
         true
-    } else {
-        false
     }
 }

--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -183,6 +183,13 @@ where
     }
     out[(0, 0)] = cofactor00;
 
+    out[(1, 0)] = -m[1].clone() * m[10].clone() * m[15].clone()
+        + m[1].clone() * m[11].clone() * m[14].clone()
+        + m[9].clone() * m[2].clone() * m[15].clone()
+        - m[9].clone() * m[3].clone() * m[14].clone()
+        - m[13].clone() * m[2].clone() * m[11].clone()
+        + m[13].clone() * m[3].clone() * m[10].clone();
+
     out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
         - m[1].clone() * m[7].clone() * m[14].clone()
         - m[5].clone() * m[2].clone() * m[15].clone()

--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -145,50 +145,43 @@ where
 {
     let m = m.as_slice();
 
-    let det = m[0].clone()
-        * (m[5].clone() * m[10].clone() * m[15].clone()
-            + m[6].clone() * m[11].clone() * m[13].clone()
-            + m[7].clone() * m[9].clone() * m[14].clone()
-            - m[7].clone() * m[10].clone() * m[13].clone()
-            - m[6].clone() * m[9].clone() * m[15].clone()
-            - m[5].clone() * m[11].clone() * m[14].clone())
-        - m[1].clone()
-            * (m[4].clone() * m[10].clone() * m[15].clone()
-                + m[6].clone() * m[11].clone() * m[12].clone()
-                + m[7].clone() * m[8].clone() * m[14].clone()
-                - m[7].clone() * m[10].clone() * m[12].clone()
-                - m[6].clone() * m[8].clone() * m[15].clone()
-                - m[4].clone() * m[11].clone() * m[14].clone())
-        + m[2].clone()
-            * (m[4].clone() * m[9].clone() * m[15].clone()
-                + m[5].clone() * m[11].clone() * m[12].clone()
-                + m[7].clone() * m[8].clone() * m[13].clone()
-                - m[7].clone() * m[9].clone() * m[12].clone()
-                - m[5].clone() * m[8].clone() * m[15].clone()
-                - m[4].clone() * m[11].clone() * m[13].clone())
-        - m[3].clone()
-            * (m[4].clone() * m[9].clone() * m[14].clone()
-                + m[5].clone() * m[10].clone() * m[12].clone()
-                + m[6].clone() * m[8].clone() * m[13].clone()
-                - m[6].clone() * m[9].clone() * m[12].clone()
-                - m[5].clone() * m[8].clone() * m[14].clone()
-                - m[4].clone() * m[10].clone() * m[13].clone());
-    if det.is_zero() {
-        false
-    } else {
-        out[(0, 0)] = m[5].clone() * m[10].clone() * m[15].clone()
-            - m[5].clone() * m[11].clone() * m[14].clone()
-            - m[9].clone() * m[6].clone() * m[15].clone()
-            + m[9].clone() * m[7].clone() * m[14].clone()
-            + m[13].clone() * m[6].clone() * m[11].clone()
-            - m[13].clone() * m[7].clone() * m[10].clone();
+    let cofactor00 = m[5].clone() * m[10].clone() * m[15].clone()
+        - m[5].clone() * m[11].clone() * m[14].clone()
+        - m[9].clone() * m[6].clone() * m[15].clone()
+        + m[9].clone() * m[7].clone() * m[14].clone()
+        + m[13].clone() * m[6].clone() * m[11].clone()
+        - m[13].clone() * m[7].clone() * m[10].clone();
 
-        out[(1, 0)] = -m[1].clone() * m[10].clone() * m[15].clone()
-            + m[1].clone() * m[11].clone() * m[14].clone()
-            + m[9].clone() * m[2].clone() * m[15].clone()
-            - m[9].clone() * m[3].clone() * m[14].clone()
-            - m[13].clone() * m[2].clone() * m[11].clone()
-            + m[13].clone() * m[3].clone() * m[10].clone();
+    let cofactor01 = -m[4].clone() * m[10].clone() * m[15].clone()
+        + m[4].clone() * m[11].clone() * m[14].clone()
+        + m[8].clone() * m[6].clone() * m[15].clone()
+        - m[8].clone() * m[7].clone() * m[14].clone()
+        - m[12].clone() * m[6].clone() * m[11].clone()
+        + m[12].clone() * m[7].clone() * m[10].clone();
+
+    let cofactor02 = m[4].clone() * m[9].clone() * m[15].clone()
+        - m[4].clone() * m[11].clone() * m[13].clone()
+        - m[8].clone() * m[5].clone() * m[15].clone()
+        + m[8].clone() * m[7].clone() * m[13].clone()
+        + m[12].clone() * m[5].clone() * m[11].clone()
+        - m[12].clone() * m[7].clone() * m[9].clone();
+
+    let cofactor03 = -m[4].clone() * m[9].clone() * m[14].clone()
+        + m[4].clone() * m[10].clone() * m[13].clone()
+        + m[8].clone() * m[5].clone() * m[14].clone()
+        - m[8].clone() * m[6].clone() * m[13].clone()
+        - m[12].clone() * m[5].clone() * m[10].clone()
+        + m[12].clone() * m[6].clone() * m[9].clone();
+
+    let det = m[0].clone() * cofactor00.clone()
+        + m[1].clone() * cofactor01.clone()
+        + m[2].clone() * cofactor02.clone()
+        + m[3].clone() * cofactor03.clone();
+
+    if det.is_zero() {
+        return false;
+    } else {
+        out[(0, 0)] = cofactor00;
 
         out[(2, 0)] = m[1].clone() * m[6].clone() * m[15].clone()
             - m[1].clone() * m[7].clone() * m[14].clone()
@@ -204,12 +197,7 @@ where
             - m[9].clone() * m[2].clone() * m[7].clone()
             + m[9].clone() * m[3].clone() * m[6].clone();
 
-        out[(0, 1)] = -m[4].clone() * m[10].clone() * m[15].clone()
-            + m[4].clone() * m[11].clone() * m[14].clone()
-            + m[8].clone() * m[6].clone() * m[15].clone()
-            - m[8].clone() * m[7].clone() * m[14].clone()
-            - m[12].clone() * m[6].clone() * m[11].clone()
-            + m[12].clone() * m[7].clone() * m[10].clone();
+        out[(0, 1)] = cofactor01;
 
         out[(1, 1)] = m[0].clone() * m[10].clone() * m[15].clone()
             - m[0].clone() * m[11].clone() * m[14].clone()
@@ -232,12 +220,7 @@ where
             + m[8].clone() * m[2].clone() * m[7].clone()
             - m[8].clone() * m[3].clone() * m[6].clone();
 
-        out[(0, 2)] = m[4].clone() * m[9].clone() * m[15].clone()
-            - m[4].clone() * m[11].clone() * m[13].clone()
-            - m[8].clone() * m[5].clone() * m[15].clone()
-            + m[8].clone() * m[7].clone() * m[13].clone()
-            + m[12].clone() * m[5].clone() * m[11].clone()
-            - m[12].clone() * m[7].clone() * m[9].clone();
+        out[(0, 2)] = cofactor02;
 
         out[(1, 2)] = -m[0].clone() * m[9].clone() * m[15].clone()
             + m[0].clone() * m[11].clone() * m[13].clone()
@@ -253,12 +236,7 @@ where
             + m[12].clone() * m[1].clone() * m[7].clone()
             - m[12].clone() * m[3].clone() * m[5].clone();
 
-        out[(0, 3)] = -m[4].clone() * m[9].clone() * m[14].clone()
-            + m[4].clone() * m[10].clone() * m[13].clone()
-            + m[8].clone() * m[5].clone() * m[14].clone()
-            - m[8].clone() * m[6].clone() * m[13].clone()
-            - m[12].clone() * m[5].clone() * m[10].clone()
-            + m[12].clone() * m[6].clone() * m[9].clone();
+        out[(0, 3)] = cofactor03;
 
         out[(3, 2)] = -m[0].clone() * m[5].clone() * m[11].clone()
             + m[0].clone() * m[7].clone() * m[9].clone()

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1264,7 +1264,7 @@ fn column_iterator_double_ended_mut() {
 }
 
 #[test]
-fn test_inversion_failure_leaves_matrix_unchanged() {
+fn test_inversion_failure_leaves_matrix4_unchanged() {
     let mut mat = na::Matrix4::new(
         1.0, 2.0, 3.0, 4.0,
         2.0, 4.0, 6.0, 8.0,
@@ -1272,9 +1272,8 @@ fn test_inversion_failure_leaves_matrix_unchanged() {
         4.0, 8.0, 12.0, 16.0
     );
     let expected = mat.clone();
-    if !mat.try_inverse_mut() {
-        assert_eq!(mat, expected);
-    }
+    assert!(!mat.try_inverse_mut());
+    assert_eq!(mat, expected);
 }
 
 #[test]

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -931,7 +931,7 @@ mod inversion_tests {
     use super::*;
     use crate::proptest::*;
     use na::Matrix1;
-    use proptest::{prop_assert, proptest};
+    use proptest::{prop_assert, proptest, prop_assert_eq};
 
     proptest! {
         #[test]
@@ -968,6 +968,14 @@ mod inversion_tests {
                 prop_assert!(relative_eq!(im * m, id, epsilon = 1.0e-7));
                 prop_assert!(relative_eq!(m * im, id, epsilon = 1.0e-7));
             }
+        }
+
+        #[test]
+        fn test_inversion_failure_leaves_matrix_unchanged(m in matrix4()) {
+                let original_matrix = m.clone();
+                if m.try_inverse().is_none() {
+                    prop_assert_eq!(m, original_matrix);
+                }
         }
 
         #[test]

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1266,10 +1266,7 @@ fn column_iterator_double_ended_mut() {
 #[test]
 fn test_inversion_failure_leaves_matrix4_unchanged() {
     let mut mat = na::Matrix4::new(
-        1.0, 2.0, 3.0, 4.0,
-        2.0, 4.0, 6.0, 8.0,
-        3.0, 6.0, 9.0, 12.0,
-        4.0, 8.0, 12.0, 16.0
+        1.0, 2.0, 3.0, 4.0, 2.0, 4.0, 6.0, 8.0, 3.0, 6.0, 9.0, 12.0, 4.0, 8.0, 12.0, 16.0,
     );
     let expected = mat.clone();
     assert!(!mat.try_inverse_mut());

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -931,7 +931,7 @@ mod inversion_tests {
     use super::*;
     use crate::proptest::*;
     use na::Matrix1;
-    use proptest::{prop_assert, proptest, prop_assert_eq};
+    use proptest::{prop_assert, proptest};
 
     proptest! {
         #[test]
@@ -968,14 +968,6 @@ mod inversion_tests {
                 prop_assert!(relative_eq!(im * m, id, epsilon = 1.0e-7));
                 prop_assert!(relative_eq!(m * im, id, epsilon = 1.0e-7));
             }
-        }
-
-        #[test]
-        fn test_inversion_failure_leaves_matrix_unchanged(m in matrix4()) {
-                let original_matrix = m.clone();
-                if m.try_inverse().is_none() {
-                    prop_assert_eq!(m, original_matrix);
-                }
         }
 
         #[test]
@@ -1269,6 +1261,20 @@ fn column_iterator_double_ended_mut() {
     assert_eq!(col_iter_mut.next(), Some(cloned.column_mut(2)));
     assert_eq!(col_iter_mut.next_back(), None);
     assert_eq!(col_iter_mut.next(), None);
+}
+
+#[test]
+fn test_inversion_failure_leaves_matrix_unchanged() {
+    let mut mat = na::Matrix4::new(
+        1.0, 2.0, 3.0, 4.0,
+        2.0, 4.0, 6.0, 8.0,
+        3.0, 6.0, 9.0, 12.0,
+        4.0, 8.0, 12.0, 16.0
+    );
+    let expected = mat.clone();
+    if !mat.try_inverse_mut() {
+        assert_eq!(mat, expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1380 


Modified the `do_inverse4` function to calculate the determinant of 4x4 matrix before proceeding with the computation of the adjugate matrix to ensure that `out` is not modified if the determinant is zero.