### PR TITLE
Fixed a (presumed) typo in documentation in matrix_view.rs

### DIFF
--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,7 +546,7 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW,CVIEW)`
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW, CVIEW)`
         /// consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
@@ -556,7 +556,7 @@ macro_rules! matrix_view_impl (
         }
 
         /// Return a view of this matrix starting at its component `(irow, icol)` and with
-        /// `(RVIEW,CVIEW)` consecutive components.
+        /// `(RVIEW, CVIEW)` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
             -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, S::RStride, S::CStride> {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,8 +546,8 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
-        /// CView::dim())` consecutive components.
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW,CVIEW)`
+        /// consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
         pub fn $fixed_slice<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
@@ -555,8 +555,8 @@ macro_rules! matrix_view_impl (
             $me.$fixed_view(irow, icol)
         }
 
-        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
-        /// CView::dim())` consecutive components.
+        /// Return a view of this matrix starting at its component `(irow, icol)` and with
+        /// `(RVIEW,CVIEW)` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
             -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, S::RStride, S::CStride> {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,7 +546,7 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(R::dim(),
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
         /// CView::dim())` consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
@@ -555,7 +555,7 @@ macro_rules! matrix_view_impl (
             $me.$fixed_view(irow, icol)
         }
 
-        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(R::dim(),
+        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
         /// CView::dim())` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)


### PR DESCRIPTION
Fixed a (presumed) typo in documentation in matrix_view.rs.

Previously it says fixed_view and fixed_slice returns a matrix with `(R::dim(), CView::dim())` consecutive components. I just changed R to RView, because presumably this is a typo.

This is my first time submitting a pull request, and I would be more than happy to take any input.