### PR TITLE
proof of concept for mul_tr

### DIFF
--- a/src/base/alias_view.rs
+++ b/src/base/alias_view.rs
@@ -379,6 +379,14 @@ pub type MatrixViewXx6<'a, T, RStride = U1, CStride = Dyn> =
 pub type VectorView<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, U1, ViewStorage<'a, T, D, U1, RStride, CStride>>;
 
+/// An immutable row vector view with dimensions known at compile-time.
+///
+///
+///
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+pub type RowVectorView<'a, T, D, RStride = D, CStride = U1> =
+    Matrix<T, U1, D, ViewStorage<'a, T, U1, D, RStride, CStride>>;
+
 /// An immutable column vector view with dimensions known at compile-time.
 ///
 /// See [`SVectorViewMut`] for a mutable version of this type.
@@ -806,7 +814,6 @@ pub type MatrixViewMutXx5<'a, T, RStride = U1, CStride = Dyn> =
 /// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
 pub type MatrixViewMutXx6<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U6, ViewStorageMut<'a, T, Dyn, U6, RStride, CStride>>;
-
 /// A mutable column vector view with dimensions known at compile-time.
 ///
 /// See [`VectorView`] for an immutable version of this type.

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,7 +546,7 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW,CVIEW)`
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW, CVIEW)`
         /// consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
@@ -556,7 +556,7 @@ macro_rules! matrix_view_impl (
         }
 
         /// Return a view of this matrix starting at its component `(irow, icol)` and with
-        /// `(RVIEW,CVIEW)` consecutive components.
+        /// `(RVIEW, CVIEW)` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
             -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, S::RStride, S::CStride> {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,8 +546,8 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
-        /// CView::dim())` consecutive components.
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RVIEW,CVIEW)`
+        /// consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
         pub fn $fixed_slice<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
@@ -555,8 +555,8 @@ macro_rules! matrix_view_impl (
             $me.$fixed_view(irow, icol)
         }
 
-        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
-        /// CView::dim())` consecutive components.
+        /// Return a view of this matrix starting at its component `(irow, icol)` and with
+        /// `(RVIEW,CVIEW)` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)
             -> $MatrixView<'_, T, Const<RVIEW>, Const<CVIEW>, S::RStride, S::CStride> {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -546,7 +546,7 @@ macro_rules! matrix_view_impl (
             $me.$generic_view_with_steps(start, shape, steps)
         }
 
-        /// Slices this matrix starting at its component `(irow, icol)` and with `(R::dim(),
+        /// Slices this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
         /// CView::dim())` consecutive components.
         #[inline]
         #[deprecated = slice_deprecation_note!($fixed_view)]
@@ -555,7 +555,7 @@ macro_rules! matrix_view_impl (
             $me.$fixed_view(irow, icol)
         }
 
-        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(R::dim(),
+        /// Return a view of this matrix starting at its component `(irow, icol)` and with `(RView::dim(),
         /// CView::dim())` consecutive components.
         #[inline]
         pub fn $fixed_view<const RVIEW: usize, const CVIEW: usize>($me: $Me, irow: usize, icol: usize)

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -679,6 +679,20 @@ where
         // SAFETY: this is OK because the result is now initialized.
         unsafe { res.assume_init() }
     }
+    
+    #[inline]
+    #[must_use]
+    pub fn mul_tr<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<T, R2, C2, SB>) -> OMatrix<T, C1, C2>
+    where
+        SB: Storage<T, R2, C2>,
+        DefaultAllocator: Allocator<T, R1, R2>,
+        ShapeConstraint: SameNumberOfColumns<C1, C2>,
+    {
+        let mut res = Matrix::uninit(self.shape_generic().0, rhs.shape_generic().0);
+        self.yy_mul_to_uninit(Uninit, rhs, &mut res, |a, b| a.dot(b)); //note: this was changed
+        // SAFETY: this is OK because the result is now initialized.
+        unsafe { res.assume_init() }
+    }
 
     /// Equivalent to `self.adjoint() * rhs`.
     #[inline]
@@ -740,6 +754,54 @@ where
                 let dot = dot(&self.column(i), &rhs.column(j));
                 let elt = unsafe { out.get_unchecked_mut((i, j)) };
                 Status::init(elt, dot);
+            }
+        }
+    }
+
+     #[inline(always)]
+    fn yy_mul_to_uninit<Status, R2: Dim, C2: Dim, SB, R3: Dim, C3: Dim, SC>(
+        &self,
+        _status: Status,
+        rhs: &Matrix<T, R2, C2, SB>,
+        out: &mut Matrix<Status::Value, R3, C3, SC>,
+        dot: impl Fn(
+            &VectorView<'_, T, R1, SA::RStride, SA::CStride>,
+            &VectorView<'_, T, R2, SB::RStride, SB::CStride>,
+        ) -> T,
+    ) where
+        Status: InitStatus<T>,
+        SB: RawStorage<T, R2, C2>,
+        SC: RawStorageMut<Status::Value, R3, C3>,
+        ShapeConstraint: SameNumberOfColumns<C1, C2> + DimEq<R1, R3> + DimEq<R2, C3>,
+    {
+        let (nrows1, ncols1) = self.shape();
+        let (nrows2, ncols2) = rhs.shape();
+        let (nrows3, ncols3) = out.shape();
+
+        assert!(
+            ncols1 == ncols2,
+            "Matrix multiplication dimensions mismatch {:?} and {:?}: left rows != right rows.",
+            self.shape(),
+            rhs.shape()
+        );
+        assert!(
+            nrows1 == nrows3,
+            "Matrix multiplication output dimensions mismatch {:?} and {:?}: left cols != right rows.",
+            self.shape(),
+            out.shape()
+        );
+        assert!(
+            nrows2 == ncols3,
+            "Matrix multiplication output dimensions mismatch {:?} and {:?}: left cols != right cols",
+            rhs.shape(),
+            out.shape()
+        );
+
+        for i in 0..nrows1 {
+            for j in 0..nrows2 {
+                let dot = dot(&self.row(i), &rhs.row(j)); 
+                let elt = unsafe { out.get_unchecked_mut((i, j)) };
+                Status::init(elt, dot)
             }
         }
     }

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -682,7 +682,8 @@ where
     
     #[inline]
     #[must_use]
-    pub fn mul_tr<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<T, R2, C2, SB>) -> OMatrix<T, C1, C2>
+    /// Equivalent to `self * rhs.transpose()`.
+    pub fn mul_tr<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<T, R2, C2, SB>) -> OMatrix<T, R1, R2>
     where
         SB: Storage<T, R2, C2>,
         DefaultAllocator: Allocator<T, R1, R2>,

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -920,13 +920,13 @@ mod transposition_tests {
         }
 
         #[test]
-        fn tr_mul_is_transpose_lhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
+        fn tr_mul_is_transpose_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
             prop_assert!(relative_eq!(m.transpose() * v, m.tr_mul(&v), epsilon = 1.0e-7))
         }
-        #[test]
-        fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
-            prop_assert!(relative_eq!(m*v.transpose(), m.mul_tr(&v), epsilon = 1.0e-7))
-        }
+        //#[test]
+        //fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
+        //    prop_assert!(relative_eq!(m * v.transpose(), m.mul_tr(&v), epsilon = 1.0e-7))
+        //}
     }
 }
 

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -923,10 +923,11 @@ mod transposition_tests {
         fn tr_mul_is_transpose_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
             prop_assert!(relative_eq!(m.transpose() * v, m.tr_mul(&v), epsilon = 1.0e-7))
         }
-        //#[test]
-        //fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
-        //    prop_assert!(relative_eq!(m * v.transpose(), m.mul_tr(&v), epsilon = 1.0e-7))
-        //}
+
+        #[test] //this one gives an error
+        fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<6>, Const::<4>), v in vector4()) {
+            prop_assert!(relative_eq!(m * v, m.mul_tr(&v.transpose()), epsilon = 1.0e-7))
+        }
     }
 }
 

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -920,8 +920,12 @@ mod transposition_tests {
         }
 
         #[test]
-        fn tr_mul_is_transpose_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
+        fn tr_mul_is_transpose_lhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
             prop_assert!(relative_eq!(m.transpose() * v, m.tr_mul(&v), epsilon = 1.0e-7))
+        }
+        #[test]
+        fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<4>, Const::<6>), v in vector4()) {
+            prop_assert!(relative_eq!(m*v.transpose(), m.mul_tr(&v), epsilon = 1.0e-7))
         }
     }
 }

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -924,7 +924,7 @@ mod transposition_tests {
             prop_assert!(relative_eq!(m.transpose() * v, m.tr_mul(&v), epsilon = 1.0e-7))
         }
 
-        #[test] //this one gives an error
+        #[test]
         fn mul_tr_is_transpose_rhs_then_mul(m in matrix(PROPTEST_F64, Const::<6>, Const::<4>), v in vector4()) {
             prop_assert!(relative_eq!(m * v, m.mul_tr(&v.transpose()), epsilon = 1.0e-7))
         }


### PR DESCRIPTION
I saw issue #1254. Attempted to implement it following the implementation for tr_mul. I'm not quire sure why the original hidden function was called xx_mul_to_unit (specifically the `xx` part), but I made a corresponding function yy_mul_to_uninit. 

Opening this pull request mainly to gather feedback, and if all is good I should be able to write other variations of the functions in ops.rs such as mul_ad, mul_tr_to, etc.

I also also wanted to add a test similar to `tr_mul_is_transpose_then_mul` was for tr_mul, except for the new mul_tr function. I'm not used to writing tests, and especially not the proptest library. I was able to write a test, but I had to resort to physically transposing a column vector for the test. 

Not really a programmer by trade, new to github. Feedback welcomed.