### PR TITLE
Always check iterator size when allocating

### DIFF
--- a/src/base/allocator.rs
+++ b/src/base/allocator.rs
@@ -36,11 +36,26 @@ pub trait Allocator<T, R: Dim, C: Dim = U1>: Any + Sized {
     unsafe fn assume_init(uninit: Self::BufferUninit) -> Self::Buffer;
 
     /// Allocates a buffer initialized with the content of the given iterator.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the iterator yields too few or too many
+    /// elements.
     fn allocate_from_iterator<I: IntoIterator<Item = T>>(
         nrows: R,
         ncols: C,
         iter: I,
     ) -> Self::Buffer;
+
+    /// Allocates a buffer from a `Vec<T>`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `Vec` contains too few or too many
+    /// elements.
+    fn allocate_from_vec(nrows: R, ncols: C, vec: Vec<T>) -> Self::Buffer {
+        Self::allocate_from_iterator(nrows, ncols, vec)
+    }
 
     #[inline]
     /// Allocates a buffer initialized with the content of the given row-major order iterator.

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -331,7 +331,7 @@ where
     #[inline]
     #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn from_vec_generic(nrows: R, ncols: C, data: Vec<T>) -> Self {
-        Self::from_iterator_generic(nrows, ncols, data)
+        Self::from_data(DefaultAllocator::allocate_from_vec(nrows, ncols, data))
     }
 }
 

--- a/tests/core/matrix_view.rs
+++ b/tests/core/matrix_view.rs
@@ -208,19 +208,19 @@ fn new_from_slice() {
                  5.0, 6.0,  7.0,  8.0,
                  9.0, 10.0, 11.0, 12.0 ];
 
-    let expected2   = Matrix2::from_column_slice(&data);
-    let expected3   = Matrix3::from_column_slice(&data);
-    let expected2x3 = Matrix2x3::from_column_slice(&data);
-    let expected3x2 = Matrix3x2::from_column_slice(&data);
+    let expected2   = Matrix2::from_column_slice(&data[0..4]);
+    let expected3   = Matrix3::from_column_slice(&data[0..9]);
+    let expected2x3 = Matrix2x3::from_column_slice(&data[0..6]);
+    let expected3x2 = Matrix3x2::from_column_slice(&data[0..6]);
 
     {
-        let m2   = MatrixView2::from_slice(&data);
-        let m3   = MatrixView3::from_slice(&data);
-        let m2x3 = MatrixView2x3::from_slice(&data);
-        let m3x2 = MatrixView3x2::from_slice(&data);
-        let m2xX = MatrixView2xX::from_slice(&data, 3);
-        let mXx3 = MatrixViewXx3::from_slice(&data, 2);
-        let mXxX = DMatrixView::from_slice(&data, 2, 3);
+        let m2   = MatrixView2::from_slice(&data[0..4]);
+        let m3   = MatrixView3::from_slice(&data[0..9]);
+        let m2x3 = MatrixView2x3::from_slice(&data[0..6]);
+        let m3x2 = MatrixView3x2::from_slice(&data[0..6]);
+        let m2xX = MatrixView2xX::from_slice(&data[0..6], 3);
+        let mXx3 = MatrixViewXx3::from_slice(&data[0..6], 2);
+        let mXxX = DMatrixView::from_slice(&data[0..6], 2, 3);
 
         assert!(m2.eq(&expected2));
         assert!(m3.eq(&expected3));


### PR DESCRIPTION
Fixes #1391.

Allocation now checks whether the supplied iterator has the correct size. Because checking this size messes with the zero-cost conversion of a `Vec` to a `Matrix`, I have also added a method `allocate_from_vec` to the `Allocator` trait with a default implementation. I am not sure if this will be useful in general. Alternatively this could also just be a private method of `DefaultAllocator` instead.