### PR TITLE
feat: remove the scalar type T from the Allocator trait

### DIFF
--- a/examples/dimensional_genericity.rs
+++ b/examples/dimensional_genericity.rs
@@ -12,7 +12,7 @@ fn reflect_wrt_hyperplane_with_dimensional_genericity<T: RealField, D: Dim>(
 where
     T: RealField,
     D: Dim,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     let n = plane_normal.as_ref(); // Get the underlying V.
     vector - n * (n.dot(vector) * na::convert(2.0))

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name    = "nalgebra-lapack"
+name = "nalgebra-lapack"
 version = "0.24.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>" ]
+authors = ["Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>"]
 
-description   = "Matrix decompositions using nalgebra matrices and Lapack bindings."
+description = "Matrix decompositions using nalgebra matrices and Lapack bindings."
 documentation = "https://www.nalgebra.org/docs"
 homepage = "https://nalgebra.org"
 repository = "https://github.com/dimforge/nalgebra"
 readme = "../README.md"
-categories = [ "science", "mathematics" ]
-keywords = [ "linear", "algebra", "matrix", "vector", "lapack" ]
+categories = ["science", "mathematics"]
+keywords = ["linear", "algebra", "matrix", "vector", "lapack"]
 license = "MIT"
 edition = "2018"
 
@@ -17,31 +17,31 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-serde-serialize  = [ "serde", "nalgebra/serde-serialize" ]
-proptest-support = [ "nalgebra/proptest-support" ]
-arbitrary        = [ "nalgebra/arbitrary" ]
+serde-serialize = ["serde", "nalgebra/serde-serialize"]
+proptest-support = ["nalgebra/proptest-support"]
+arbitrary = ["nalgebra/arbitrary"]
 
 # For BLAS/LAPACK
-default    = ["netlib"]
-openblas   = ["lapack-src/openblas"]
-netlib     = ["lapack-src/netlib"]
+default = ["netlib"]
+openblas = ["lapack-src/openblas"]
+netlib = ["lapack-src/netlib"]
 accelerate = ["lapack-src/accelerate"]
-intel-mkl  = ["lapack-src/intel-mkl"]
+intel-mkl = ["lapack-src/intel-mkl"]
 
 [dependencies]
-nalgebra      = { version = "0.32", path = ".." }
-num-traits    = "0.2"
-num-complex   = { version = "0.4", default-features = false }
-simba         = "0.8"
-serde         = { version = "1.0", features = [ "derive" ], optional = true }
-lapack        = { version = "0.19", default-features = false }
-lapack-src    = { version = "0.8", default-features = false }
+nalgebra = { version = "0.32", path = ".." }
+num-traits = "0.2"
+num-complex = { version = "0.4", default-features = false }
+simba = "0.8"
+serde = { version = "1.0", features = ["derive"], optional = true }
+lapack = { version = "0.19", default-features = false }
+lapack-src = { version = "0.8", default-features = false }
 # clippy = "*"
 
 [dev-dependencies]
-nalgebra   = { version = "0.32", features = [ "arbitrary", "rand" ], path = ".." }
-proptest   = { version = "1", default-features = false, features = ["std"] }
+nalgebra = { version = "0.32", features = ["arbitrary", "rand"], path = ".." }
+proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = "1"
-approx     = "0.5"
-rand       = "0.8"
+approx = "0.5"
+rand = "0.8"
 

--- a/nalgebra-lapack/src/cholesky.rs
+++ b/nalgebra-lapack/src/cholesky.rs
@@ -15,32 +15,32 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D>,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Cholesky<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     l: OMatrix<T, D, D>,
 }
 
 impl<T: Scalar + Copy, D: Dim> Copy for Cholesky<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     OMatrix<T, D, D>: Copy,
 {
 }
 
 impl<T: CholeskyScalar + Zero, D: Dim> Cholesky<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Computes the cholesky decomposition of the given symmetric-definite-positive square
     /// matrix.
@@ -105,7 +105,7 @@ where
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let mut res = b.clone_owned();
         if self.solve_mut(&mut res) {
@@ -119,7 +119,7 @@ where
     /// the unknown to be determined.
     pub fn solve_mut<R2: Dim, C2: Dim>(&self, b: &mut OMatrix<T, R2, C2>) -> bool
     where
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let dim = self.l.nrows();
 

--- a/nalgebra-lapack/src/eigen.rs
+++ b/nalgebra-lapack/src/eigen.rs
@@ -16,24 +16,20 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(serialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Serialize")
-    )
+         OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(deserialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Deserialize<'de>")
-    )
+         OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Eigen<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     /// The real parts of eigenvalues of the decomposed matrix.
     pub eigenvalues_re: OVector<T, D>,
@@ -47,7 +43,7 @@ where
 
 impl<T: Scalar + Copy, D: Dim> Copy for Eigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
     OVector<T, D>: Copy,
     OMatrix<T, D, D>: Copy,
 {
@@ -55,7 +51,7 @@ where
 
 impl<T: EigenScalar + RealField, D: Dim> Eigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Computes the eigenvalues and eigenvectors of the square matrix `m`.
     ///
@@ -177,7 +173,7 @@ where
         Option<Vec<OVector<T, D>>>,
     )
     where
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let (number_of_elements, _) = self.eigenvalues_re.shape_generic();
         let number_of_elements_value = number_of_elements.value();
@@ -234,7 +230,7 @@ where
         Option<Vec<OVector<Complex<T>, D>>>,
     )
     where
-        DefaultAllocator: Allocator<Complex<T>, D>,
+        DefaultAllocator: Allocator<D>,
     {
         match self.eigenvalues_are_real() {
             true => (None, None, None),

--- a/nalgebra-lapack/src/generalized_eigenvalues.rs
+++ b/nalgebra-lapack/src/generalized_eigenvalues.rs
@@ -30,24 +30,20 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(serialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Serialize")
-    )
+         OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(deserialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Deserialize<'de>,
-         OMatrix<T, D, D>: Deserialize<'de>")
-    )
+         OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct GeneralizedEigen<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     alphar: OVector<T, D>,
     alphai: OVector<T, D>,
@@ -58,7 +54,7 @@ where
 
 impl<T: Scalar + Copy, D: Dim> Copy for GeneralizedEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T, D>: Copy,
 {
@@ -66,7 +62,7 @@ where
 
 impl<T: GeneralizedEigenScalar + RealField + Copy, D: Dim> GeneralizedEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Attempts to compute the generalized eigenvalues, and left and right associated eigenvectors
     /// via the raw returns from LAPACK's dggev and sggev routines
@@ -162,8 +158,7 @@ where
     /// as columns.
     pub fn eigenvectors(&self) -> (OMatrix<Complex<T>, D, D>, OMatrix<Complex<T>, D, D>)
     where
-        DefaultAllocator:
-            Allocator<Complex<T>, D, D> + Allocator<Complex<T>, D> + Allocator<(Complex<T>, T), D>,
+        DefaultAllocator: Allocator<D, D> + Allocator<D>,
     {
         /*
          How the eigenvectors are built up:
@@ -230,7 +225,7 @@ where
     #[must_use]
     pub fn raw_eigenvalues(&self) -> OVector<(Complex<T>, T), D>
     where
-        DefaultAllocator: Allocator<(Complex<T>, T), D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut out = Matrix::from_element_generic(
             self.vsl.shape_generic().0,

--- a/nalgebra-lapack/src/hessenberg.rs
+++ b/nalgebra-lapack/src/hessenberg.rs
@@ -12,22 +12,22 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Serialize,
          OVector<T, DimDiff<D, U1>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Deserialize<'de>,
          OVector<T, DimDiff<D, U1>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Hessenberg<T: Scalar, D: DimSub<U1>>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     h: OMatrix<T, D, D>,
     tau: OVector<T, DimDiff<D, U1>>,
@@ -35,7 +35,7 @@ where
 
 impl<T: Scalar + Copy, D: DimSub<U1>> Copy for Hessenberg<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
     OMatrix<T, D, D>: Copy,
     OVector<T, DimDiff<D, U1>>: Copy,
 {
@@ -43,7 +43,7 @@ where
 
 impl<T: HessenbergScalar + Zero, D: DimSub<U1>> Hessenberg<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     /// Computes the hessenberg decomposition of the matrix `m`.
     pub fn new(mut m: OMatrix<T, D, D>) -> Self {
@@ -97,7 +97,7 @@ where
 
 impl<T: HessenbergReal + Zero, D: DimSub<U1>> Hessenberg<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     /// Computes the matrices `(Q, H)` of this decomposition.
     #[inline]

--- a/nalgebra-lapack/src/lu.rs
+++ b/nalgebra-lapack/src/lu.rs
@@ -20,22 +20,22 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<i32, DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<i32, DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct LU<T: Scalar, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<i32, DimMinimum<R, C>> + Allocator<T, R, C>,
+    DefaultAllocator: Allocator<DimMinimum<R, C>> + Allocator<R, C>,
 {
     lu: OMatrix<T, R, C>,
     p: OVector<i32, DimMinimum<R, C>>,
@@ -43,7 +43,7 @@ where
 
 impl<T: Scalar + Copy, R: DimMin<C>, C: Dim> Copy for LU<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<i32, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     OVector<i32, DimMinimum<R, C>>: Copy,
 {
@@ -53,11 +53,11 @@ impl<T: LUScalar, R: Dim, C: Dim> LU<T, R, C>
 where
     T: Zero + One,
     R: DimMin<C>,
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, R, R>
-        + Allocator<T, R, DimMinimum<R, C>>
-        + Allocator<T, DimMinimum<R, C>, C>
-        + Allocator<i32, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C>
+        + Allocator<R, R>
+        + Allocator<R, DimMinimum<R, C>>
+        + Allocator<DimMinimum<R, C>, C>
+        + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the LU decomposition with partial (row) pivoting of `matrix`.
     pub fn new(mut m: OMatrix<T, R, C>) -> Self {
@@ -136,7 +136,7 @@ where
     #[inline]
     pub fn permute<C2: Dim>(&self, rhs: &mut OMatrix<T, R, C2>)
     where
-        DefaultAllocator: Allocator<T, R, C2>,
+        DefaultAllocator: Allocator<R, C2>,
     {
         let (nrows, ncols) = rhs.shape();
 
@@ -153,7 +153,7 @@ where
 
     fn generic_solve_mut<R2: Dim, C2: Dim>(&self, trans: u8, b: &mut OMatrix<T, R2, C2>) -> bool
     where
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         let dim = self.lu.nrows();
 
@@ -192,7 +192,7 @@ where
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         let mut res = b.clone_owned();
         if self.generic_solve_mut(b'T', &mut res) {
@@ -210,7 +210,7 @@ where
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         let mut res = b.clone_owned();
         if self.generic_solve_mut(b'T', &mut res) {
@@ -228,7 +228,7 @@ where
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         let mut res = b.clone_owned();
         if self.generic_solve_mut(b'T', &mut res) {
@@ -243,7 +243,7 @@ where
     /// Returns `false` if no solution was found (the decomposed matrix is singular).
     pub fn solve_mut<R2: Dim, C2: Dim>(&self, b: &mut OMatrix<T, R2, C2>) -> bool
     where
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         self.generic_solve_mut(b'T', b)
     }
@@ -254,7 +254,7 @@ where
     /// Returns `false` if no solution was found (the decomposed matrix is singular).
     pub fn solve_transpose_mut<R2: Dim, C2: Dim>(&self, b: &mut OMatrix<T, R2, C2>) -> bool
     where
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         self.generic_solve_mut(b'T', b)
     }
@@ -265,7 +265,7 @@ where
     /// Returns `false` if no solution was found (the decomposed matrix is singular).
     pub fn solve_adjoint_mut<R2: Dim, C2: Dim>(&self, b: &mut OMatrix<T, R2, C2>) -> bool
     where
-        DefaultAllocator: Allocator<T, R2, C2> + Allocator<i32, R2>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<R2>,
     {
         self.generic_solve_mut(b'T', b)
     }
@@ -275,7 +275,7 @@ impl<T: LUScalar, D: Dim> LU<T, D, D>
 where
     T: Zero + One,
     D: DimMin<D, Output = D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<i32, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Computes the inverse of the decomposed matrix.
     pub fn inverse(mut self) -> Option<OMatrix<T, D, D>> {

--- a/nalgebra-lapack/src/qr.rs
+++ b/nalgebra-lapack/src/qr.rs
@@ -15,22 +15,22 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          OVector<T, DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct QR<T: Scalar, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     qr: OMatrix<T, R, C>,
     tau: OVector<T, DimMinimum<R, C>>,
@@ -38,7 +38,7 @@ where
 
 impl<T: Scalar + Copy, R: DimMin<C>, C: Dim> Copy for QR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     OVector<T, DimMinimum<R, C>>: Copy,
 {
@@ -46,10 +46,10 @@ where
 
 impl<T: QRScalar + Zero, R: DimMin<C>, C: Dim> QR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, R, DimMinimum<R, C>>
-        + Allocator<T, DimMinimum<R, C>, C>
-        + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C>
+        + Allocator<R, DimMinimum<R, C>>
+        + Allocator<DimMinimum<R, C>, C>
+        + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the QR decomposition of the matrix `m`.
     pub fn new(mut m: OMatrix<T, R, C>) -> Self {
@@ -98,10 +98,10 @@ where
 
 impl<T: QRReal + Zero, R: DimMin<C>, C: Dim> QR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, R, DimMinimum<R, C>>
-        + Allocator<T, DimMinimum<R, C>, C>
-        + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C>
+        + Allocator<R, DimMinimum<R, C>>
+        + Allocator<DimMinimum<R, C>, C>
+        + Allocator<DimMinimum<R, C>>,
 {
     /// Retrieves the matrices `(Q, R)` of this decompositions.
     pub fn unpack(

--- a/nalgebra-lapack/src/qz.rs
+++ b/nalgebra-lapack/src/qz.rs
@@ -22,24 +22,20 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(serialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Serialize")
-    )
+         OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(deserialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Deserialize<'de>,
-         OMatrix<T, D, D>: Deserialize<'de>")
-    )
+         OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct QZ<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     alphar: OVector<T, D>,
     alphai: OVector<T, D>,
@@ -52,7 +48,7 @@ where
 
 impl<T: Scalar + Copy, D: Dim> Copy for QZ<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T, D>: Copy,
 {
@@ -60,7 +56,7 @@ where
 
 impl<T: QZScalar + RealField, D: Dim> QZ<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Attempts to compute the QZ decomposition of input real square matrices `a` and `b`.
     ///
@@ -182,7 +178,7 @@ where
     #[must_use]
     pub fn raw_eigenvalues(&self) -> OVector<(Complex<T>, T), D>
     where
-        DefaultAllocator: Allocator<(Complex<T>, T), D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut out = Matrix::from_element_generic(
             self.vsl.shape_generic().0,

--- a/nalgebra-lapack/src/schur.rs
+++ b/nalgebra-lapack/src/schur.rs
@@ -17,24 +17,20 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(serialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Serialize")
-    )
+         OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(
-        bound(deserialize = "DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> + Allocator<D>,
          OVector<T, D>: Serialize,
-         OMatrix<T, D, D>: Deserialize<'de>")
-    )
+         OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Schur<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     re: OVector<T, D>,
     im: OVector<T, D>,
@@ -44,7 +40,7 @@ where
 
 impl<T: Scalar + Copy, D: Dim> Copy for Schur<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T, D>: Copy,
 {
@@ -52,7 +48,7 @@ where
 
 impl<T: SchurScalar + RealField, D: Dim> Schur<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Computes the eigenvalues and real Schur form of the matrix `m`.
     ///
@@ -150,7 +146,7 @@ where
     #[must_use]
     pub fn complex_eigenvalues(&self) -> OVector<Complex<T>, D>
     where
-        DefaultAllocator: Allocator<Complex<T>, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut out = Matrix::zeros_generic(self.t.shape_generic().0, Const::<1>);
 

--- a/nalgebra-lapack/src/symmetric_eigen.rs
+++ b/nalgebra-lapack/src/symmetric_eigen.rs
@@ -17,22 +17,22 @@ use lapack;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<D>,
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<D>,
          OVector<T, D>: Deserialize<'de>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct SymmetricEigen<T: Scalar, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     /// The eigenvectors of the decomposed matrix.
     pub eigenvectors: OMatrix<T, D, D>,
@@ -43,7 +43,7 @@ where
 
 impl<T: Scalar + Copy, D: Dim> Copy for SymmetricEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T, D>: Copy,
 {
@@ -51,7 +51,7 @@ where
 
 impl<T: SymmetricEigenScalar + RealField, D: Dim> SymmetricEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Computes the eigenvalues and eigenvectors of the symmetric matrix `m`.
     ///

--- a/nalgebra-sparse/src/ops/impl_std_ops.rs
+++ b/nalgebra-sparse/src/ops/impl_std_ops.rs
@@ -302,13 +302,13 @@ macro_rules! impl_spmm_cs_dense {
             R: Dim,
             C: Dim,
             S: RawStorage<T, R, C>,
-            DefaultAllocator: Allocator<T, Dyn, C>,
+            DefaultAllocator: Allocator<Dyn, C>,
             // TODO: Is it possible to simplify these bounds?
             ShapeConstraint:
                 // Bounds so that we can turn OMatrix<T, Dyn, C> into a DMatrixSliceMut
-                  DimEq<U1, <<DefaultAllocator as Allocator<T, Dyn, C>>::Buffer as RawStorage<T, Dyn, C>>::RStride>
+                  DimEq<U1, <<DefaultAllocator as Allocator<Dyn, C>>::Buffer<T> as RawStorage<T, Dyn, C>>::RStride>
                 + DimEq<C, Dyn>
-                + DimEq<Dyn, <<DefaultAllocator as Allocator<T, Dyn, C>>::Buffer as RawStorage<T, Dyn, C>>::CStride>
+                + DimEq<Dyn, <<DefaultAllocator as Allocator<Dyn, C>>::Buffer<T> as RawStorage<T, Dyn, C>>::CStride>
                 // Bounds so that we can turn &Matrix<T, R, C, S> into a DMatrixSlice
                 + DimEq<U1, S::RStride>
                 + DimEq<R, Dyn>

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -113,12 +113,12 @@ unsafe impl<T, const R: usize, const C: usize> RawStorage<T, Const<R>, Const<C>>
 unsafe impl<T: Scalar, const R: usize, const C: usize> Storage<T, Const<R>, Const<C>>
     for ArrayStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<T, Const<R>, Const<C>, Buffer<T> = Self>,
+    DefaultAllocator: Allocator<Const<R>, Const<C>, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, Const<R>, Const<C>>
     where
-        DefaultAllocator: Allocator<T, Const<R>, Const<C>>,
+        DefaultAllocator: Allocator<Const<R>, Const<C>>,
     {
         self
     }
@@ -126,7 +126,7 @@ where
     #[inline]
     fn clone_owned(&self) -> Owned<T, Const<R>, Const<C>>
     where
-        DefaultAllocator: Allocator<T, Const<R>, Const<C>>,
+        DefaultAllocator: Allocator<Const<R>, Const<C>>,
     {
         self.clone()
     }
@@ -250,7 +250,7 @@ where
         V: SeqAccess<'a>,
     {
         let mut out: ArrayStorage<core::mem::MaybeUninit<T>, R, C> =
-            <DefaultAllocator as Allocator<T, _, _>>::allocate_uninit(Const::<R>, Const::<C>);
+            <DefaultAllocator as Allocator<_, _>>::allocate_uninit(Const::<R>, Const::<C>);
         let mut curr = 0;
 
         while let Some(value) = visitor.next_element()? {
@@ -263,7 +263,7 @@ where
 
         if curr == R * C {
             // Safety: all the elements have been initialized.
-            unsafe { Ok(<DefaultAllocator as Allocator<T, Const<R>, Const<C>>>::assume_init(out)) }
+            unsafe { Ok(<DefaultAllocator as Allocator<Const<R>, Const<C>>>::assume_init(out)) }
         } else {
             for i in 0..curr {
                 // Safety:

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -113,7 +113,7 @@ unsafe impl<T, const R: usize, const C: usize> RawStorage<T, Const<R>, Const<C>>
 unsafe impl<T: Scalar, const R: usize, const C: usize> Storage<T, Const<R>, Const<C>>
     for ArrayStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<T, Const<R>, Const<C>, Buffer = Self>,
+    DefaultAllocator: Allocator<T, Const<R>, Const<C>, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, Const<R>, Const<C>>
@@ -250,7 +250,7 @@ where
         V: SeqAccess<'a>,
     {
         let mut out: ArrayStorage<core::mem::MaybeUninit<T>, R, C> =
-            DefaultAllocator::allocate_uninit(Const::<R>, Const::<C>);
+            <DefaultAllocator as Allocator<T, _, _>>::allocate_uninit(Const::<R>, Const::<C>);
         let mut curr = 0;
 
         while let Some(value) = visitor.next_element()? {

--- a/src/base/blas.rs
+++ b/src/base/blas.rs
@@ -1098,7 +1098,7 @@ where
         S3: Storage<T, R3, C3>,
         S4: Storage<T, D4, D4>,
         ShapeConstraint: DimEq<D1, D1> + DimEq<D1, R3> + DimEq<C3, D4>,
-        DefaultAllocator: Allocator<T, D1>,
+        DefaultAllocator: Allocator<D1>,
     {
         // TODO: would it be useful to avoid the zero-initialization of the workspace data?
         let mut work = Matrix::zeros_generic(self.shape_generic().0, Const::<1>);
@@ -1196,7 +1196,7 @@ where
         S2: Storage<T, D2, D2>,
         S3: Storage<T, R3, C3>,
         ShapeConstraint: DimEq<D2, R3> + DimEq<D1, C3> + AreMultipliable<C3, R3, D2, U1>,
-        DefaultAllocator: Allocator<T, D2>,
+        DefaultAllocator: Allocator<D2>,
     {
         // TODO: would it be useful to avoid the zero-initialization of the workspace data?
         let mut work = Vector::zeros_generic(mid.shape_generic().0, Const::<1>);

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -25,7 +25,7 @@ use simba::scalar::{ClosedAdd, ClosedMul, RealField};
 impl<T, D: DimName> OMatrix<T, D, D>
 where
     T: Scalar + Zero + One,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Creates a new homogeneous matrix that applies the same scaling factor on each dimension.
     #[inline]
@@ -216,7 +216,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     pub fn append_scaling(&self, scaling: T) -> OMatrix<T, D, D>
     where
         D: DimNameSub<U1>,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut res = self.clone_owned();
         res.append_scaling_mut(scaling);
@@ -229,7 +229,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     pub fn prepend_scaling(&self, scaling: T) -> OMatrix<T, D, D>
     where
         D: DimNameSub<U1>,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut res = self.clone_owned();
         res.prepend_scaling_mut(scaling);
@@ -246,7 +246,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     where
         D: DimNameSub<U1>,
         SB: Storage<T, DimNameDiff<D, U1>>,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut res = self.clone_owned();
         res.append_nonuniform_scaling_mut(scaling);
@@ -263,7 +263,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     where
         D: DimNameSub<U1>,
         SB: Storage<T, DimNameDiff<D, U1>>,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut res = self.clone_owned();
         res.prepend_nonuniform_scaling_mut(scaling);
@@ -280,7 +280,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     where
         D: DimNameSub<U1>,
         SB: Storage<T, DimNameDiff<D, U1>>,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut res = self.clone_owned();
         res.append_translation_mut(shift);
@@ -297,7 +297,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
     where
         D: DimNameSub<U1>,
         SB: Storage<T, DimNameDiff<D, U1>>,
-        DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimNameDiff<D, U1>>,
+        DefaultAllocator: Allocator<D, D> + Allocator<DimNameDiff<D, U1>>,
     {
         let mut res = self.clone_owned();
         res.prepend_translation_mut(shift);
@@ -379,7 +379,7 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
         D: DimNameSub<U1>,
         S: StorageMut<T, D, D>,
         SB: Storage<T, DimNameDiff<D, U1>>,
-        DefaultAllocator: Allocator<T, DimNameDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
     {
         let scale = self
             .generic_view(
@@ -405,9 +405,9 @@ impl<T: Scalar + Zero + One + ClosedMul + ClosedAdd, D: DimName, S: Storage<T, D
 /// # Transformation of vectors and points
 impl<T: RealField, D: DimNameSub<U1>, S: Storage<T, D, D>> SquareMatrix<T, D, S>
 where
-    DefaultAllocator: Allocator<T, D, D>
-        + Allocator<T, DimNameDiff<D, U1>>
-        + Allocator<T, DimNameDiff<D, U1>, DimNameDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D>
+        + Allocator<DimNameDiff<D, U1>>
+        + Allocator<DimNameDiff<D, U1>, DimNameDiff<D, U1>>,
 {
     /// Transforms the given vector, assuming the matrix `self` uses homogeneous coordinates.
     #[inline]

--- a/src/base/componentwise.rs
+++ b/src/base/componentwise.rs
@@ -32,7 +32,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn abs(&self) -> OMatrix<T, R, C>
     where
         T: Signed,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let mut res = self.clone_owned();
 
@@ -55,7 +55,7 @@ macro_rules! component_binop_impl(
             where T: $Trait,
                   R2: Dim, C2: Dim,
                   SB: Storage<T, R2, C2>,
-                  DefaultAllocator: SameShapeAllocator<T, R1, C1, R2, C2>,
+                  DefaultAllocator: SameShapeAllocator<R1, C1, R2, C2>,
                   ShapeConstraint:  SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2> {
 
             assert_eq!(self.shape(), rhs.shape(), "Componentwise mul/div: mismatched matrix dimensions.");
@@ -257,7 +257,7 @@ impl<T: Scalar, R1: Dim, C1: Dim, SA: Storage<T, R1, C1>> Matrix<T, R1, C1, SA> 
     pub fn inf(&self, other: &Self) -> OMatrix<T, R1, C1>
     where
         T: SimdPartialOrd,
-        DefaultAllocator: Allocator<T, R1, C1>,
+        DefaultAllocator: Allocator<R1, C1>,
     {
         self.zip_map(other, |a, b| a.simd_min(b))
     }
@@ -278,7 +278,7 @@ impl<T: Scalar, R1: Dim, C1: Dim, SA: Storage<T, R1, C1>> Matrix<T, R1, C1, SA> 
     pub fn sup(&self, other: &Self) -> OMatrix<T, R1, C1>
     where
         T: SimdPartialOrd,
-        DefaultAllocator: Allocator<T, R1, C1>,
+        DefaultAllocator: Allocator<R1, C1>,
     {
         self.zip_map(other, |a, b| a.simd_max(b))
     }
@@ -299,7 +299,7 @@ impl<T: Scalar, R1: Dim, C1: Dim, SA: Storage<T, R1, C1>> Matrix<T, R1, C1, SA> 
     pub fn inf_sup(&self, other: &Self) -> (OMatrix<T, R1, C1>, OMatrix<T, R1, C1>)
     where
         T: SimdPartialOrd,
-        DefaultAllocator: Allocator<T, R1, C1>,
+        DefaultAllocator: Allocator<R1, C1>,
     {
         // TODO: can this be optimized?
         (self.inf(other), self.sup(other))
@@ -321,7 +321,7 @@ impl<T: Scalar, R1: Dim, C1: Dim, SA: Storage<T, R1, C1>> Matrix<T, R1, C1, SA> 
     pub fn add_scalar(&self, rhs: T) -> OMatrix<T, R1, C1>
     where
         T: ClosedAdd,
-        DefaultAllocator: Allocator<T, R1, C1>,
+        DefaultAllocator: Allocator<R1, C1>,
     {
         let mut res = self.clone_owned();
         res.add_scalar_mut(rhs);

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -29,7 +29,7 @@ use std::mem::MaybeUninit;
 
 impl<T: Scalar, R: Dim, C: Dim> UninitMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     /// Builds a matrix with uninitialized elements of type `MaybeUninit<T>`.
     #[inline(always)]
@@ -50,7 +50,7 @@ where
 /// These functions should only be used when working on dimension-generic code.
 impl<T: Scalar, R: Dim, C: Dim> OMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     /// Creates a matrix with all its elements set to `elem`.
     #[inline]
@@ -338,7 +338,7 @@ where
 impl<T, D: Dim> OMatrix<T, D, D>
 where
     T: Scalar,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Creates a square matrix with its diagonal set to `diag` and all other entries set to 0.
     ///
@@ -646,7 +646,7 @@ macro_rules! impl_constructors(
 /// # Constructors of statically-sized vectors or statically-sized matrices
 impl<T: Scalar, R: DimName, C: DimName> OMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     // TODO: this is not very pretty. We could find a better call syntax.
     impl_constructors!(R, C;                         // Arguments for Matrix<T, ..., S>
@@ -658,7 +658,7 @@ where
 /// # Constructors of matrices with a dynamic number of columns
 impl<T: Scalar, R: DimName> OMatrix<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dyn>,
+    DefaultAllocator: Allocator<R, Dyn>,
 {
     impl_constructors!(R, Dyn;
                    => R: DimName;
@@ -669,7 +669,7 @@ where
 /// # Constructors of dynamic vectors and matrices with a dynamic number of rows
 impl<T: Scalar, C: DimName> OMatrix<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dyn, C>,
+    DefaultAllocator: Allocator<Dyn, C>,
 {
     impl_constructors!(Dyn, C;
                    => C: DimName;
@@ -678,9 +678,10 @@ where
 }
 
 /// # Constructors of fully dynamic matrices
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<T: Scalar> OMatrix<T, Dyn, Dyn>
 where
-    DefaultAllocator: Allocator<T, Dyn, Dyn>,
+    DefaultAllocator: Allocator<Dyn, Dyn>,
 {
     impl_constructors!(Dyn, Dyn;
                    ;
@@ -697,7 +698,7 @@ where
 macro_rules! impl_constructors_from_data(
     ($data: ident; $($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr),*; $($args: ident),*) => {
         impl<T: Scalar, $($DimIdent: $DimBound, )*> OMatrix<T $(, $Dims)*>
-        where DefaultAllocator: Allocator<T $(, $Dims)*> {
+        where DefaultAllocator: Allocator<$($Dims),*> {
             /// Creates a matrix with its elements filled with the components provided by a slice
             /// in row-major order.
             ///
@@ -800,6 +801,7 @@ impl_constructors_from_data!(data; Dyn, C;
 Dyn(data.len() / C::dim()), C::name();
 );
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl_constructors_from_data!(data; Dyn, Dyn;
                             ;
                             Dyn(nrows), Dyn(ncols);
@@ -813,7 +815,7 @@ impl_constructors_from_data!(data; Dyn, Dyn;
 impl<T, R: DimName, C: DimName> Zero for OMatrix<T, R, C>
 where
     T: Scalar + Zero + ClosedAdd,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn zero() -> Self {
@@ -829,7 +831,7 @@ where
 impl<T, D: DimName> One for OMatrix<T, D, D>
 where
     T: Scalar + Zero + One + ClosedMul + ClosedAdd,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     #[inline]
     fn one() -> Self {
@@ -840,7 +842,7 @@ where
 impl<T, R: DimName, C: DimName> Bounded for OMatrix<T, R, C>
 where
     T: Scalar + Bounded,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn max_value() -> Self {
@@ -856,7 +858,7 @@ where
 #[cfg(feature = "rand-no-std")]
 impl<T: Scalar, R: Dim, C: Dim> Distribution<OMatrix<T, R, C>> for Standard
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
     Standard: Distribution<T>,
 {
     #[inline]
@@ -874,7 +876,7 @@ where
     R: Dim,
     C: Dim,
     T: Scalar + Arbitrary + Send,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
     Owned<T, R, C>: Clone + Send,
 {
     #[inline]
@@ -892,7 +894,7 @@ where
 #[cfg(feature = "rand")]
 impl<T: crate::RealField, D: DimName> Distribution<Unit<OVector<T, D>>> for Standard
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
     rand_distr::StandardNormal: Distribution<T>,
 {
     /// Generate a uniformly distributed random unit vector.
@@ -1111,7 +1113,7 @@ impl<T, R: DimName> OVector<T, R>
 where
     R: ToTypenum,
     T: Scalar + Zero + One,
-    DefaultAllocator: Allocator<T, R>,
+    DefaultAllocator: Allocator<R>,
 {
     /// The column vector with `val` as its i-th component.
     #[inline]

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -35,8 +35,7 @@ where
     C2: Dim,
     T1: Scalar,
     T2: Scalar + SupersetOf<T1>,
-    DefaultAllocator:
-        Allocator<T2, R2, C2> + Allocator<T1, R1, C1> + SameShapeAllocator<T1, R1, C1, R2, C2>,
+    DefaultAllocator: Allocator<R2, C2> + Allocator<R1, C1> + SameShapeAllocator<R1, C1, R2, C2>,
     ShapeConstraint: SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2>,
 {
     #[inline]
@@ -561,7 +560,7 @@ impl<T: Scalar + PrimitiveSimdValue, R: Dim, C: Dim> From<[OMatrix<T::Element, R
 where
     T: From<[<T as SimdValue>::Element; 2]>,
     T::Element: Scalar + SimdValue,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [OMatrix<T::Element, R, C>; 2]) -> Self {
@@ -578,7 +577,7 @@ impl<T: Scalar + PrimitiveSimdValue, R: Dim, C: Dim> From<[OMatrix<T::Element, R
 where
     T: From<[<T as SimdValue>::Element; 4]>,
     T::Element: Scalar + SimdValue,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [OMatrix<T::Element, R, C>; 4]) -> Self {
@@ -601,7 +600,7 @@ impl<T: Scalar + PrimitiveSimdValue, R: Dim, C: Dim> From<[OMatrix<T::Element, R
 where
     T: From<[<T as SimdValue>::Element; 8]>,
     T::Element: Scalar + SimdValue,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [OMatrix<T::Element, R, C>; 8]) -> Self {
@@ -628,7 +627,7 @@ impl<T: Scalar + PrimitiveSimdValue, R: Dim, C: Dim> From<[OMatrix<T::Element, R
 where
     T: From<[<T as SimdValue>::Element; 16]>,
     T::Element: Scalar + SimdValue,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     fn from(arr: [OMatrix<T::Element, R, C>; 16]) -> Self {
         let (nrows, ncols) = arr[0].shape_generic();

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -21,7 +21,7 @@ impl<T: Scalar + Zero, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     #[must_use]
     pub fn upper_triangle(&self) -> OMatrix<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let mut res = self.clone_owned();
         res.fill_lower_triangle(T::zero(), 1);
@@ -34,7 +34,7 @@ impl<T: Scalar + Zero, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     #[must_use]
     pub fn lower_triangle(&self) -> OMatrix<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let mut res = self.clone_owned();
         res.fill_upper_triangle(T::zero(), 1);
@@ -52,7 +52,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         I: IntoIterator<Item = &'a usize>,
         I::IntoIter: ExactSizeIterator + Clone,
-        DefaultAllocator: Allocator<T, Dyn, C>,
+        DefaultAllocator: Allocator<Dyn, C>,
     {
         let irows = irows.into_iter();
         let ncols = self.shape_generic().1;
@@ -89,7 +89,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         I: IntoIterator<Item = &'a usize>,
         I::IntoIter: ExactSizeIterator,
-        DefaultAllocator: Allocator<T, R, Dyn>,
+        DefaultAllocator: Allocator<R, Dyn>,
     {
         let icols = icols.into_iter();
         let nrows = self.shape_generic().0;
@@ -1037,7 +1037,7 @@ impl<T: Scalar> OMatrix<T, Dyn, Dyn> {
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<T: Scalar, C: Dim> OMatrix<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dyn, C>,
+    DefaultAllocator: Allocator<Dyn, C>,
 {
     /// Changes the number of rows of this matrix in-place.
     ///
@@ -1058,7 +1058,7 @@ where
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<T: Scalar, R: Dim> OMatrix<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dyn>,
+    DefaultAllocator: Allocator<R, Dyn>,
 {
     /// Changes the number of column of this matrix in-place.
     ///

--- a/src/base/interpolation.rs
+++ b/src/base/interpolation.rs
@@ -23,7 +23,7 @@ impl<T: Scalar + Zero + One + ClosedAdd + ClosedSub + ClosedMul, D: Dim, S: Stor
     #[must_use]
     pub fn lerp<S2: Storage<T, D>>(&self, rhs: &Vector<T, D, S2>, t: T) -> OVector<T, D>
     where
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut res = self.clone_owned();
         res.axpy(t.clone(), rhs, T::one() - t);
@@ -50,7 +50,7 @@ impl<T: Scalar + Zero + One + ClosedAdd + ClosedSub + ClosedMul, D: Dim, S: Stor
     pub fn slerp<S2: Storage<T, D>>(&self, rhs: &Vector<T, D, S2>, t: T) -> OVector<T, D>
     where
         T: RealField,
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let me = Unit::new_normalize(self.clone_owned());
         let rhs = Unit::new_normalize(rhs.clone_owned());
@@ -81,7 +81,7 @@ impl<T: RealField, D: Dim, S: Storage<T, D>> Unit<Vector<T, D, S>> {
         t: T,
     ) -> Unit<OVector<T, D>>
     where
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         // TODO: the result is wrong when self and rhs are collinear with opposite direction.
         self.try_slerp(rhs, t, T::default_epsilon())
@@ -100,7 +100,7 @@ impl<T: RealField, D: Dim, S: Storage<T, D>> Unit<Vector<T, D, S>> {
         epsilon: T,
     ) -> Option<Unit<OVector<T, D>>>
     where
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let c_hang = self.dot(rhs);
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -383,7 +383,7 @@ impl<T> RowDVector<T> {
     }
 }
 
-impl<T, R: Dim, C: Dim> UninitMatrix<T, R, C>
+impl<T: Scalar, R: Dim, C: Dim> UninitMatrix<T, R, C>
 where
     DefaultAllocator: Allocator<T, R, C>,
 {
@@ -533,7 +533,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         max_relative: T::Epsilon,
     ) -> bool
     where
-        T: RelativeEq,
+        T: RelativeEq + Scalar,
         R2: Dim,
         C2: Dim,
         SB: Storage<T, R2, C2>,

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -385,7 +385,7 @@ impl<T> RowDVector<T> {
 
 impl<T: Scalar, R: Dim, C: Dim> UninitMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     /// Assumes a matrix's entries to be initialized. This operation should be near zero-cost.
     ///
@@ -394,7 +394,7 @@ where
     /// or Undefined Behavior will immediately occur.
     #[inline(always)]
     pub unsafe fn assume_init(self) -> OMatrix<T, R, C> {
-        OMatrix::from_data(<DefaultAllocator as Allocator<T, R, C>>::assume_init(
+        OMatrix::from_data(<DefaultAllocator as Allocator<R, C>>::assume_init(
             self.data,
         ))
     }
@@ -568,7 +568,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: Scalar,
         S: Storage<T, R, C>,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         Matrix::from_data(self.data.into_owned())
     }
@@ -584,7 +584,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         S: Storage<T, R, C>,
         R2: Dim,
         C2: Dim,
-        DefaultAllocator: SameShapeAllocator<T, R, C, R2, C2>,
+        DefaultAllocator: SameShapeAllocator<R, C, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R, R2> + SameNumberOfColumns<C, C2>,
     {
         if TypeId::of::<SameShapeStorage<T, R, C, R2, C2>>() == TypeId::of::<Owned<T, R, C>>() {
@@ -609,7 +609,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: Scalar,
         S: Storage<T, R, C>,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         Matrix::from_data(self.data.clone_owned())
     }
@@ -624,7 +624,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         S: Storage<T, R, C>,
         R2: Dim,
         C2: Dim,
-        DefaultAllocator: SameShapeAllocator<T, R, C, R2, C2>,
+        DefaultAllocator: SameShapeAllocator<R, C, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R, R2> + SameNumberOfColumns<C, C2>,
     {
         let (nrows, ncols) = self.shape();
@@ -700,7 +700,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn transpose(&self) -> OMatrix<T, C, R>
     where
         T: Scalar,
-        DefaultAllocator: Allocator<T, C, R>,
+        DefaultAllocator: Allocator<C, R>,
     {
         let (nrows, ncols) = self.shape_generic();
 
@@ -719,7 +719,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn map<T2: Scalar, F: FnMut(T) -> T2>(&self, mut f: F) -> OMatrix<T2, R, C>
     where
         T: Scalar,
-        DefaultAllocator: Allocator<T2, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let (nrows, ncols) = self.shape_generic();
         let mut res = Matrix::uninit(nrows, ncols);
@@ -751,7 +751,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: Scalar,
         OMatrix<T2, R, C>: SupersetOf<Self>,
-        DefaultAllocator: Allocator<T2, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         crate::convert(self)
     }
@@ -769,7 +769,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: Scalar,
         Self: SupersetOf<OMatrix<T2, R, C>>,
-        DefaultAllocator: Allocator<T2, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         crate::try_convert(self)
     }
@@ -806,7 +806,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     ) -> OMatrix<T2, R, C>
     where
         T: Scalar,
-        DefaultAllocator: Allocator<T2, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let (nrows, ncols) = self.shape_generic();
         let mut res = Matrix::uninit(nrows, ncols);
@@ -836,7 +836,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         N3: Scalar,
         S2: RawStorage<T2, R, C>,
         F: FnMut(T, T2) -> N3,
-        DefaultAllocator: Allocator<N3, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let (nrows, ncols) = self.shape_generic();
         let mut res = Matrix::uninit(nrows, ncols);
@@ -880,7 +880,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         S2: RawStorage<T2, R, C>,
         S3: RawStorage<N3, R, C>,
         F: FnMut(T, T2, N3) -> N4,
-        DefaultAllocator: Allocator<N4, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let (nrows, ncols) = self.shape_generic();
         let mut res = Matrix::uninit(nrows, ncols);
@@ -1420,7 +1420,7 @@ impl<T: SimdComplexField, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C
     #[must_use = "Did you mean to use adjoint_mut()?"]
     pub fn adjoint(&self) -> OMatrix<T, C, R>
     where
-        DefaultAllocator: Allocator<T, C, R>,
+        DefaultAllocator: Allocator<C, R>,
     {
         let (nrows, ncols) = self.shape_generic();
 
@@ -1449,7 +1449,7 @@ impl<T: SimdComplexField, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C
     #[inline]
     pub fn conjugate_transpose(&self) -> OMatrix<T, C, R>
     where
-        DefaultAllocator: Allocator<T, C, R>,
+        DefaultAllocator: Allocator<C, R>,
     {
         self.adjoint()
     }
@@ -1459,7 +1459,7 @@ impl<T: SimdComplexField, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C
     #[must_use = "Did you mean to use conjugate_mut()?"]
     pub fn conjugate(&self) -> OMatrix<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         self.map(|e| e.simd_conjugate())
     }
@@ -1469,7 +1469,7 @@ impl<T: SimdComplexField, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C
     #[must_use = "Did you mean to use unscale_mut()?"]
     pub fn unscale(&self, real: T::SimdRealField) -> OMatrix<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         self.map(|e| e.simd_unscale(real.clone()))
     }
@@ -1479,7 +1479,7 @@ impl<T: SimdComplexField, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C
     #[must_use = "Did you mean to use scale_mut()?"]
     pub fn scale(&self, real: T::SimdRealField) -> OMatrix<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         self.map(|e| e.simd_scale(real.clone()))
     }
@@ -1547,7 +1547,7 @@ impl<T: Scalar, D: Dim, S: RawStorage<T, D, D>> SquareMatrix<T, D, S> {
     #[must_use]
     pub fn diagonal(&self) -> OVector<T, D>
     where
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         self.map_diagonal(|e| e)
     }
@@ -1559,7 +1559,7 @@ impl<T: Scalar, D: Dim, S: RawStorage<T, D, D>> SquareMatrix<T, D, S> {
     #[must_use]
     pub fn map_diagonal<T2: Scalar>(&self, mut f: impl FnMut(T) -> T2) -> OVector<T2, D>
     where
-        DefaultAllocator: Allocator<T2, D>,
+        DefaultAllocator: Allocator<D>,
     {
         assert!(
             self.is_square(),
@@ -1610,7 +1610,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     #[must_use]
     pub fn symmetric_part(&self) -> OMatrix<T, D, D>
     where
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         assert!(
             self.is_square(),
@@ -1627,7 +1627,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     #[must_use]
     pub fn hermitian_part(&self) -> OMatrix<T, D, D>
     where
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         assert!(
             self.is_square(),
@@ -1650,7 +1650,7 @@ impl<T: Scalar + Zero + One, D: DimAdd<U1> + IsNotStaticOne, S: RawStorage<T, D,
     #[must_use]
     pub fn to_homogeneous(&self) -> OMatrix<T, DimSum<D, U1>, DimSum<D, U1>>
     where
-        DefaultAllocator: Allocator<T, DimSum<D, U1>, DimSum<D, U1>>,
+        DefaultAllocator: Allocator<DimSum<D, U1>, DimSum<D, U1>>,
     {
         assert!(
             self.is_square(),
@@ -1671,7 +1671,7 @@ impl<T: Scalar + Zero, D: DimAdd<U1>, S: RawStorage<T, D>> Vector<T, D, S> {
     #[must_use]
     pub fn to_homogeneous(&self) -> OVector<T, DimSum<D, U1>>
     where
-        DefaultAllocator: Allocator<T, DimSum<D, U1>>,
+        DefaultAllocator: Allocator<DimSum<D, U1>>,
     {
         self.push(T::zero())
     }
@@ -1682,7 +1682,7 @@ impl<T: Scalar + Zero, D: DimAdd<U1>, S: RawStorage<T, D>> Vector<T, D, S> {
     pub fn from_homogeneous<SB>(v: Vector<T, DimSum<D, U1>, SB>) -> Option<OVector<T, D>>
     where
         SB: RawStorage<T, DimSum<D, U1>>,
-        DefaultAllocator: Allocator<T, D>,
+        DefaultAllocator: Allocator<D>,
     {
         if v[v.len() - 1].is_zero() {
             let nrows = D::from_usize(v.len() - 1);
@@ -1699,7 +1699,7 @@ impl<T: Scalar, D: DimAdd<U1>, S: RawStorage<T, D>> Vector<T, D, S> {
     #[must_use]
     pub fn push(&self, element: T) -> OVector<T, DimSum<D, U1>>
     where
-        DefaultAllocator: Allocator<T, DimSum<D, U1>>,
+        DefaultAllocator: Allocator<DimSum<D, U1>>,
     {
         let len = self.len();
         let hnrows = DimSum::<D, U1>::from_usize(len + 1);
@@ -2052,7 +2052,7 @@ impl<T: Scalar + ClosedAdd + ClosedSub + ClosedMul, R: Dim, C: Dim, S: RawStorag
         R2: Dim,
         C2: Dim,
         SB: RawStorage<T, R2, C2>,
-        DefaultAllocator: SameShapeAllocator<T, R, C, R2, C2>,
+        DefaultAllocator: SameShapeAllocator<R, C, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R, R2> + SameNumberOfColumns<C, C2>,
     {
         let shape = self.shape();
@@ -2252,7 +2252,7 @@ where
     where
         T: Scalar,
         OVector<T2, D>: SupersetOf<Vector<T, D, S>>,
-        DefaultAllocator: Allocator<T2, D, U1>,
+        DefaultAllocator: Allocator<D, U1>,
     {
         Unit::new_unchecked(crate::convert_ref(self.as_ref()))
     }

--- a/src/base/matrix_simba.rs
+++ b/src/base/matrix_simba.rs
@@ -15,7 +15,7 @@ where
     R: Dim,
     C: Dim,
     T::Element: Scalar,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Element = OMatrix<T::Element, R, C>;
     type SimdBool = T::SimdBool;

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -218,13 +218,13 @@ macro_rules! storage_impl(
             for $T<'a, T, R, C, RStride, CStride> {
             #[inline]
             fn into_owned(self) -> Owned<T, R, C>
-                where DefaultAllocator: Allocator<T, R, C> {
+                where DefaultAllocator: Allocator<R, C> {
                 self.clone_owned()
             }
 
             #[inline]
             fn clone_owned(&self) -> Owned<T, R, C>
-                where DefaultAllocator: Allocator<T, R, C> {
+                where DefaultAllocator: Allocator<R, C> {
                 let (nrows, ncols) = self.shape();
                 let it = MatrixIter::new(self).cloned();
                 DefaultAllocator::allocate_from_iterator(nrows, ncols, it)

--- a/src/base/norm.rs
+++ b/src/base/norm.rs
@@ -301,7 +301,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn normalize(&self) -> OMatrix<T, R, C>
     where
         T: SimdComplexField,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         self.unscale(self.norm())
     }
@@ -325,7 +325,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: SimdComplexField,
         T::Element: Scalar,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
         let le = n.clone().simd_le(min_norm);
@@ -356,7 +356,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn cap_magnitude(&self, max: T::RealField) -> OMatrix<T, R, C>
     where
         T: ComplexField,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
 
@@ -374,7 +374,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         T: SimdComplexField,
         T::Element: Scalar,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
         let scaled = self.scale(max.clone() / n.clone());
@@ -390,7 +390,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn try_normalize(&self, min_norm: T::RealField) -> Option<OMatrix<T, R, C>>
     where
         T: ComplexField,
-        DefaultAllocator: Allocator<T, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
 
@@ -430,7 +430,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: StorageMut<T, R, C>> Matrix<T, R, C, S> {
     where
         T: SimdComplexField,
         T::Element: Scalar,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+        DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
         let le = n.clone().simd_le(min_norm);
@@ -459,7 +459,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: StorageMut<T, R, C>> Matrix<T, R, C, S> {
 
 impl<T: SimdComplexField, R: Dim, C: Dim> Normed for OMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Norm = T::SimdRealField;
 
@@ -486,7 +486,7 @@ where
 
 impl<T: Scalar + ClosedNeg, R: Dim, C: Dim> Neg for Unit<OMatrix<T, R, C>>
 where
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Output = Unit<OMatrix<T, R, C>>;
 
@@ -503,7 +503,7 @@ where
 /// # Basis and orthogonalization
 impl<T: ComplexField, D: DimName> OVector<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// The i-the canonical basis element.
     #[inline]

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -81,7 +81,7 @@ impl<T, R: Dim, C: Dim, S> Neg for Matrix<T, R, C, S>
 where
     T: Scalar + ClosedNeg,
     S: Storage<T, R, C>,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Output = OMatrix<T, R, C>;
 
@@ -97,7 +97,7 @@ impl<'a, T, R: Dim, C: Dim, S> Neg for &'a Matrix<T, R, C, S>
 where
     T: Scalar + ClosedNeg,
     S: Storage<T, R, C>,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Output = OMatrix<T, R, C>;
 
@@ -262,7 +262,7 @@ macro_rules! componentwise_binop_impl(
                   T: Scalar + $bound,
                   SA: Storage<T, R1, C1>,
                   SB: Storage<T, R2, C2>,
-                  DefaultAllocator: SameShapeAllocator<T, R1, C1, R2, C2>,
+                  DefaultAllocator: SameShapeAllocator<R1, C1, R2, C2>,
                   ShapeConstraint:  SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2> {
             type Output = MatrixSum<T, R1, C1, R2, C2>;
 
@@ -280,7 +280,7 @@ macro_rules! componentwise_binop_impl(
                   T: Scalar + $bound,
                   SA: Storage<T, R1, C1>,
                   SB: Storage<T, R2, C2>,
-                  DefaultAllocator: SameShapeAllocator<T, R2, C2, R1, C1>,
+                  DefaultAllocator: SameShapeAllocator<R2, C2, R1, C1>,
                   ShapeConstraint:  SameNumberOfRows<R2, R1> + SameNumberOfColumns<C2, C1> {
             type Output = MatrixSum<T, R2, C2, R1, C1>;
 
@@ -298,7 +298,7 @@ macro_rules! componentwise_binop_impl(
                   T: Scalar + $bound,
                   SA: Storage<T, R1, C1>,
                   SB: Storage<T, R2, C2>,
-                  DefaultAllocator: SameShapeAllocator<T, R1, C1, R2, C2>,
+                  DefaultAllocator: SameShapeAllocator<R1, C1, R2, C2>,
                   ShapeConstraint:  SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2> {
             type Output = MatrixSum<T, R1, C1, R2, C2>;
 
@@ -313,7 +313,7 @@ macro_rules! componentwise_binop_impl(
                   T: Scalar + $bound,
                   SA: Storage<T, R1, C1>,
                   SB: Storage<T, R2, C2>,
-                  DefaultAllocator: SameShapeAllocator<T, R1, C1, R2, C2>,
+                  DefaultAllocator: SameShapeAllocator<R1, C1, R2, C2>,
                   ShapeConstraint:  SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2> {
             type Output = MatrixSum<T, R1, C1, R2, C2>;
 
@@ -367,7 +367,7 @@ componentwise_binop_impl!(Sub, sub, ClosedSub;
 impl<T, R: DimName, C: DimName> iter::Sum for OMatrix<T, R, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     fn sum<I: Iterator<Item = OMatrix<T, R, C>>>(iter: I) -> OMatrix<T, R, C> {
         iter.fold(Matrix::zero(), |acc, x| acc + x)
@@ -377,7 +377,7 @@ where
 impl<T, C: Dim> iter::Sum for OMatrix<T, Dyn, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, Dyn, C>,
+    DefaultAllocator: Allocator<Dyn, C>,
 {
     /// # Example
     /// ```
@@ -407,7 +407,7 @@ where
 impl<'a, T, R: DimName, C: DimName> iter::Sum<&'a OMatrix<T, R, C>> for OMatrix<T, R, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     fn sum<I: Iterator<Item = &'a OMatrix<T, R, C>>>(iter: I) -> OMatrix<T, R, C> {
         iter.fold(Matrix::zero(), |acc, x| acc + x)
@@ -417,7 +417,7 @@ where
 impl<'a, T, C: Dim> iter::Sum<&'a OMatrix<T, Dyn, C>> for OMatrix<T, Dyn, C>
 where
     T: Scalar + ClosedAdd + Zero,
-    DefaultAllocator: Allocator<T, Dyn, C>,
+    DefaultAllocator: Allocator<Dyn, C>,
 {
     /// # Example
     /// ```
@@ -458,7 +458,7 @@ macro_rules! componentwise_scalarop_impl(
         impl<T, R: Dim, C: Dim, S> $Trait<T> for Matrix<T, R, C, S>
             where T: Scalar + $bound,
                   S: Storage<T, R, C>,
-                  DefaultAllocator: Allocator<T, R, C> {
+                  DefaultAllocator: Allocator<R, C> {
             type Output = OMatrix<T, R, C>;
 
             #[inline]
@@ -482,7 +482,7 @@ macro_rules! componentwise_scalarop_impl(
         impl<'a, T, R: Dim, C: Dim, S> $Trait<T> for &'a Matrix<T, R, C, S>
             where T: Scalar + $bound,
                   S: Storage<T, R, C>,
-                  DefaultAllocator: Allocator<T, R, C> {
+                  DefaultAllocator: Allocator<R, C> {
             type Output = OMatrix<T, R, C>;
 
             #[inline]
@@ -512,7 +512,7 @@ componentwise_scalarop_impl!(Div, div, ClosedDiv; DivAssign, div_assign);
 macro_rules! left_scalar_mul_impl(
     ($($T: ty),* $(,)*) => {$(
         impl<R: Dim, C: Dim, S: Storage<$T, R, C>> Mul<Matrix<$T, R, C, S>> for $T
-            where DefaultAllocator: Allocator<$T, R, C> {
+            where DefaultAllocator: Allocator<R, C> {
             type Output = OMatrix<$T, R, C>;
 
             #[inline]
@@ -534,7 +534,7 @@ macro_rules! left_scalar_mul_impl(
         }
 
         impl<'b, R: Dim, C: Dim, S: Storage<$T, R, C>> Mul<&'b Matrix<$T, R, C, S>> for $T
-            where DefaultAllocator: Allocator<$T, R, C> {
+            where DefaultAllocator: Allocator<R, C> {
             type Output = OMatrix<$T, R, C>;
 
             #[inline]
@@ -554,7 +554,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     SA: Storage<T, R1, C1>,
     SB: Storage<T, R2, C2>,
-    DefaultAllocator: Allocator<T, R1, C2>,
+    DefaultAllocator: Allocator<R1, C2>,
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
 {
     type Output = OMatrix<T, R1, C2>;
@@ -576,7 +576,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     SB: Storage<T, R2, C2>,
     SA: Storage<T, R1, C1>,
-    DefaultAllocator: Allocator<T, R1, C2>,
+    DefaultAllocator: Allocator<R1, C2>,
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
 {
     type Output = OMatrix<T, R1, C2>;
@@ -593,7 +593,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     SB: Storage<T, R2, C2>,
     SA: Storage<T, R1, C1>,
-    DefaultAllocator: Allocator<T, R1, C2>,
+    DefaultAllocator: Allocator<R1, C2>,
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
 {
     type Output = OMatrix<T, R1, C2>;
@@ -610,7 +610,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     SB: Storage<T, R2, C2>,
     SA: Storage<T, R1, C1>,
-    DefaultAllocator: Allocator<T, R1, C2>,
+    DefaultAllocator: Allocator<R1, C2>,
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
 {
     type Output = OMatrix<T, R1, C2>;
@@ -633,7 +633,7 @@ where
     SB: Storage<T, R2, C1>,
     SA: StorageMut<T, R1, C1> + IsContiguous + Clone, // TODO: get rid of the IsContiguous
     ShapeConstraint: AreMultipliable<R1, C1, R2, C1>,
-    DefaultAllocator: Allocator<T, R1, C1, Buffer<T> = SA>,
+    DefaultAllocator: Allocator<R1, C1, Buffer<T> = SA>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Matrix<T, R2, C1, SB>) {
@@ -651,7 +651,7 @@ where
     SA: StorageMut<T, R1, C1> + IsContiguous + Clone, // TODO: get rid of the IsContiguous
     ShapeConstraint: AreMultipliable<R1, C1, R2, C1>,
     // TODO: this is too restrictive. See comments for the non-ref version.
-    DefaultAllocator: Allocator<T, R1, C1, Buffer<T> = SA>,
+    DefaultAllocator: Allocator<R1, C1, Buffer<T> = SA>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: &'b Matrix<T, R2, C1, SB>) {
@@ -671,7 +671,7 @@ where
     pub fn tr_mul<R2: Dim, C2: Dim, SB>(&self, rhs: &Matrix<T, R2, C2, SB>) -> OMatrix<T, C1, C2>
     where
         SB: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, C1, C2>,
+        DefaultAllocator: Allocator<C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
         let mut res = Matrix::uninit(self.shape_generic().1, rhs.shape_generic().1);
@@ -687,7 +687,7 @@ where
     where
         T: SimdComplexField,
         SB: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, C1, C2>,
+        DefaultAllocator: Allocator<C1, C2>,
         ShapeConstraint: SameNumberOfRows<R1, R2>,
     {
         let mut res = Matrix::uninit(self.shape_generic().1, rhs.shape_generic().1);
@@ -803,7 +803,7 @@ where
         R1: DimMul<R2>,
         C1: DimMul<C2>,
         SB: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, DimProd<R1, R2>, DimProd<C1, C2>>,
+        DefaultAllocator: Allocator<DimProd<R1, R2>, DimProd<C1, C2>>,
     {
         let (nrows1, ncols1) = self.shape_generic();
         let (nrows2, ncols2) = rhs.shape_generic();
@@ -836,7 +836,7 @@ where
 impl<T, D: DimName> iter::Product for OMatrix<T, D, D>
 where
     T: Scalar + Zero + One + ClosedMul + ClosedAdd,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     fn product<I: Iterator<Item = OMatrix<T, D, D>>>(iter: I) -> OMatrix<T, D, D> {
         iter.fold(Matrix::one(), |acc, x| acc * x)
@@ -846,7 +846,7 @@ where
 impl<'a, T, D: DimName> iter::Product<&'a OMatrix<T, D, D>> for OMatrix<T, D, D>
 where
     T: Scalar + Zero + One + ClosedMul + ClosedAdd,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     fn product<I: Iterator<Item = &'a OMatrix<T, D, D>>>(iter: I) -> OMatrix<T, D, D> {
         iter.fold(Matrix::one(), |acc, x| acc * x)

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -633,7 +633,7 @@ where
     SB: Storage<T, R2, C1>,
     SA: StorageMut<T, R1, C1> + IsContiguous + Clone, // TODO: get rid of the IsContiguous
     ShapeConstraint: AreMultipliable<R1, C1, R2, C1>,
-    DefaultAllocator: Allocator<T, R1, C1, Buffer = SA>,
+    DefaultAllocator: Allocator<T, R1, C1, Buffer<T> = SA>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Matrix<T, R2, C1, SB>) {
@@ -651,7 +651,7 @@ where
     SA: StorageMut<T, R1, C1> + IsContiguous + Clone, // TODO: get rid of the IsContiguous
     ShapeConstraint: AreMultipliable<R1, C1, R2, C1>,
     // TODO: this is too restrictive. See comments for the non-ref version.
-    DefaultAllocator: Allocator<T, R1, C1, Buffer = SA>,
+    DefaultAllocator: Allocator<T, R1, C1, Buffer<T> = SA>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: &'b Matrix<T, R2, C1, SB>) {

--- a/src/base/properties.rs
+++ b/src/base/properties.rs
@@ -91,7 +91,7 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         T: Zero + One + ClosedAdd + ClosedMul + RelativeEq,
         S: Storage<T, R, C>,
         T::Epsilon: Clone,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<T, C, C>,
+        DefaultAllocator: Allocator<R, C> + Allocator<C, C>,
     {
         (self.ad_mul(self)).is_identity(eps)
     }
@@ -99,7 +99,7 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 
 impl<T: RealField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Checks that this matrix is orthogonal and has a determinant equal to 1.
     #[inline]
@@ -107,7 +107,7 @@ where
     pub fn is_special_orthogonal(&self, eps: T) -> bool
     where
         D: DimMin<D, Output = D>,
-        DefaultAllocator: Allocator<(usize, usize), D>,
+        DefaultAllocator: Allocator<D>,
     {
         self.is_square() && self.is_orthogonal(eps) && self.determinant() > T::zero()
     }

--- a/src/base/statistics.rs
+++ b/src/base/statistics.rs
@@ -16,7 +16,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         f: impl Fn(VectorView<'_, T, R, S::RStride, S::CStride>) -> T,
     ) -> RowOVector<T, C>
     where
-        DefaultAllocator: Allocator<T, U1, C>,
+        DefaultAllocator: Allocator<U1, C>,
     {
         let ncols = self.shape_generic().1;
         let mut res = Matrix::uninit(Const::<1>, ncols);
@@ -44,7 +44,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         f: impl Fn(VectorView<'_, T, R, S::RStride, S::CStride>) -> T,
     ) -> OVector<T, C>
     where
-        DefaultAllocator: Allocator<T, C>,
+        DefaultAllocator: Allocator<C>,
     {
         let ncols = self.shape_generic().1;
         let mut res = Matrix::uninit(ncols, Const::<1>);
@@ -70,7 +70,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         f: impl Fn(&mut OVector<T, R>, VectorView<'_, T, R, S::RStride, S::CStride>),
     ) -> OVector<T, R>
     where
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let mut res = init;
 
@@ -133,7 +133,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_sum(&self) -> RowOVector<T, C>
     where
         T: ClosedAdd + Zero,
-        DefaultAllocator: Allocator<T, U1, C>,
+        DefaultAllocator: Allocator<U1, C>,
     {
         self.compress_rows(|col| col.sum())
     }
@@ -160,7 +160,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_sum_tr(&self) -> OVector<T, C>
     where
         T: ClosedAdd + Zero,
-        DefaultAllocator: Allocator<T, C>,
+        DefaultAllocator: Allocator<C>,
     {
         self.compress_rows_tr(|col| col.sum())
     }
@@ -187,7 +187,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn column_sum(&self) -> OVector<T, R>
     where
         T: ClosedAdd + Zero,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let nrows = self.shape_generic().0;
         self.compress_columns(OVector::zeros_generic(nrows, Const::<1>), |out, col| {
@@ -244,7 +244,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_product(&self) -> RowOVector<T, C>
     where
         T: ClosedMul + One,
-        DefaultAllocator: Allocator<T, U1, C>,
+        DefaultAllocator: Allocator<U1, C>,
     {
         self.compress_rows(|col| col.product())
     }
@@ -271,7 +271,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_product_tr(&self) -> OVector<T, C>
     where
         T: ClosedMul + One,
-        DefaultAllocator: Allocator<T, C>,
+        DefaultAllocator: Allocator<C>,
     {
         self.compress_rows_tr(|col| col.product())
     }
@@ -298,7 +298,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn column_product(&self) -> OVector<T, R>
     where
         T: ClosedMul + One,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let nrows = self.shape_generic().0;
         self.compress_columns(
@@ -361,7 +361,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_variance(&self) -> RowOVector<T, C>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, U1, C>,
+        DefaultAllocator: Allocator<U1, C>,
     {
         self.compress_rows(|col| col.variance())
     }
@@ -382,7 +382,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_variance_tr(&self) -> OVector<T, C>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, C>,
+        DefaultAllocator: Allocator<C>,
     {
         self.compress_rows_tr(|col| col.variance())
     }
@@ -404,7 +404,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn column_variance(&self) -> OVector<T, R>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let (nrows, ncols) = self.shape_generic();
 
@@ -469,7 +469,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_mean(&self) -> RowOVector<T, C>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, U1, C>,
+        DefaultAllocator: Allocator<U1, C>,
     {
         self.compress_rows(|col| col.mean())
     }
@@ -490,7 +490,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn row_mean_tr(&self) -> OVector<T, C>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, C>,
+        DefaultAllocator: Allocator<C>,
     {
         self.compress_rows_tr(|col| col.mean())
     }
@@ -511,7 +511,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub fn column_mean(&self) -> OVector<T, R>
     where
         T: Field + SupersetOf<f64>,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let (nrows, ncols) = self.shape_generic();
         let denom = T::one() / crate::convert::<_, T>(ncols.value() as f64);

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -12,22 +12,22 @@ use crate::base::Scalar;
  */
 /// The data storage for the sum of two matrices with dimensions `(R1, C1)` and `(R2, C2)`.
 pub type SameShapeStorage<T, R1, C1, R2, C2> =
-    <DefaultAllocator as Allocator<T, SameShapeR<R1, R2>, SameShapeC<C1, C2>>>::Buffer<T>;
+    <DefaultAllocator as Allocator<SameShapeR<R1, R2>, SameShapeC<C1, C2>>>::Buffer<T>;
 
 // TODO: better name than Owned ?
 /// The owned data storage that can be allocated from `S`.
-pub type Owned<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::Buffer<T>;
+pub type Owned<T, R, C = U1> = <DefaultAllocator as Allocator<R, C>>::Buffer<T>;
 
 /// The owned data storage that can be allocated from `S`.
-pub type OwnedUninit<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::BufferUninit<T>;
+pub type OwnedUninit<T, R, C = U1> = <DefaultAllocator as Allocator<R, C>>::BufferUninit<T>;
 
 /// The row-stride of the owned data storage for a buffer of dimension `(R, C)`.
 pub type RStride<T, R, C = U1> =
-    <<DefaultAllocator as Allocator<T, R, C>>::Buffer<T> as RawStorage<T, R, C>>::RStride;
+    <<DefaultAllocator as Allocator<R, C>>::Buffer<T> as RawStorage<T, R, C>>::RStride;
 
 /// The column-stride of the owned data storage for a buffer of dimension `(R, C)`.
 pub type CStride<T, R, C = U1> =
-    <<DefaultAllocator as Allocator<T, R, C>>::Buffer<T> as RawStorage<T, R, C>>::CStride;
+    <<DefaultAllocator as Allocator<R, C>>::Buffer<T> as RawStorage<T, R, C>>::CStride;
 
 /// The trait shared by all matrix data storage.
 ///
@@ -143,12 +143,12 @@ pub unsafe trait Storage<T: Scalar, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     /// Builds a matrix data storage that does not contain any reference.
     fn into_owned(self) -> Owned<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>;
+        DefaultAllocator: Allocator<R, C>;
 
     /// Clones this data storage to one that does not contain any reference.
     fn clone_owned(&self) -> Owned<T, R, C>
     where
-        DefaultAllocator: Allocator<T, R, C>;
+        DefaultAllocator: Allocator<R, C>;
 }
 
 /// Trait implemented by matrix data storage that can provide a mutable access to its elements.

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -12,22 +12,22 @@ use crate::base::Scalar;
  */
 /// The data storage for the sum of two matrices with dimensions `(R1, C1)` and `(R2, C2)`.
 pub type SameShapeStorage<T, R1, C1, R2, C2> =
-    <DefaultAllocator as Allocator<T, SameShapeR<R1, R2>, SameShapeC<C1, C2>>>::Buffer;
+    <DefaultAllocator as Allocator<T, SameShapeR<R1, R2>, SameShapeC<C1, C2>>>::Buffer<T>;
 
 // TODO: better name than Owned ?
 /// The owned data storage that can be allocated from `S`.
-pub type Owned<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::Buffer;
+pub type Owned<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::Buffer<T>;
 
 /// The owned data storage that can be allocated from `S`.
-pub type OwnedUninit<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::BufferUninit;
+pub type OwnedUninit<T, R, C = U1> = <DefaultAllocator as Allocator<T, R, C>>::BufferUninit<T>;
 
 /// The row-stride of the owned data storage for a buffer of dimension `(R, C)`.
 pub type RStride<T, R, C = U1> =
-    <<DefaultAllocator as Allocator<T, R, C>>::Buffer as RawStorage<T, R, C>>::RStride;
+    <<DefaultAllocator as Allocator<T, R, C>>::Buffer<T> as RawStorage<T, R, C>>::RStride;
 
 /// The column-stride of the owned data storage for a buffer of dimension `(R, C)`.
 pub type CStride<T, R, C = U1> =
-    <<DefaultAllocator as Allocator<T, R, C>>::Buffer as RawStorage<T, R, C>>::CStride;
+    <<DefaultAllocator as Allocator<T, R, C>>::Buffer<T> as RawStorage<T, R, C>>::CStride;
 
 /// The trait shared by all matrix data storage.
 ///
@@ -139,7 +139,7 @@ pub unsafe trait RawStorage<T, R: Dim, C: Dim = U1>: Sized {
 /// should **not** allow the user to modify the size of the underlying buffer with safe methods
 /// (for example the `VecStorage::data_mut` method is unsafe because the user could change the
 /// vector's size so that it no longer contains enough elements: this will lead to UB.
-pub unsafe trait Storage<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
+pub unsafe trait Storage<T: Scalar, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     /// Builds a matrix data storage that does not contain any reference.
     fn into_owned(self) -> Owned<T, R, C>
     where
@@ -260,12 +260,12 @@ pub unsafe trait RawStorageMut<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
 /// # Safety
 ///
 /// See safety note for `Storage`, `RawStorageMut`.
-pub unsafe trait StorageMut<T, R: Dim, C: Dim = U1>:
+pub unsafe trait StorageMut<T: Scalar, R: Dim, C: Dim = U1>:
     Storage<T, R, C> + RawStorageMut<T, R, C>
 {
 }
 
-unsafe impl<S, T, R, C> StorageMut<T, R, C> for S
+unsafe impl<S, T: Scalar, R, C> StorageMut<T, R, C> for S
 where
     R: Dim,
     C: Dim,

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -303,7 +303,7 @@ impl<T: Scalar + simba::simd::PrimitiveSimdValue, R: Dim, C: Dim>
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 2]>,
     T::Element: Scalar,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [Unit<OMatrix<T::Element, R, C>>; 2]) -> Self {
@@ -319,7 +319,7 @@ impl<T: Scalar + simba::simd::PrimitiveSimdValue, R: Dim, C: Dim>
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 4]>,
     T::Element: Scalar,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [Unit<OMatrix<T::Element, R, C>>; 4]) -> Self {
@@ -337,7 +337,7 @@ impl<T: Scalar + simba::simd::PrimitiveSimdValue, R: Dim, C: Dim>
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 8]>,
     T::Element: Scalar,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [Unit<OMatrix<T::Element, R, C>>; 8]) -> Self {
@@ -359,7 +359,7 @@ impl<T: Scalar + simba::simd::PrimitiveSimdValue, R: Dim, C: Dim>
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 16]>,
     T::Element: Scalar,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn from(arr: [Unit<OMatrix<T::Element, R, C>>; 16]) -> Self {

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -264,12 +264,12 @@ unsafe impl<T, C: Dim> RawStorage<T, Dyn, C> for VecStorage<T, Dyn, C> {
 
 unsafe impl<T: Scalar, C: Dim> Storage<T, Dyn, C> for VecStorage<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dyn, C, Buffer<T> = Self>,
+    DefaultAllocator: Allocator<Dyn, C, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, Dyn, C>
     where
-        DefaultAllocator: Allocator<T, Dyn, C>,
+        DefaultAllocator: Allocator<Dyn, C>,
     {
         self
     }
@@ -277,7 +277,7 @@ where
     #[inline]
     fn clone_owned(&self) -> Owned<T, Dyn, C>
     where
-        DefaultAllocator: Allocator<T, Dyn, C>,
+        DefaultAllocator: Allocator<Dyn, C>,
     {
         self.clone()
     }
@@ -315,12 +315,12 @@ unsafe impl<T, R: DimName> RawStorage<T, R, Dyn> for VecStorage<T, R, Dyn> {
 
 unsafe impl<T: Scalar, R: DimName> Storage<T, R, Dyn> for VecStorage<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dyn, Buffer<T> = Self>,
+    DefaultAllocator: Allocator<R, Dyn, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, R, Dyn>
     where
-        DefaultAllocator: Allocator<T, R, Dyn>,
+        DefaultAllocator: Allocator<R, Dyn>,
     {
         self
     }
@@ -328,7 +328,7 @@ where
     #[inline]
     fn clone_owned(&self) -> Owned<T, R, Dyn>
     where
-        DefaultAllocator: Allocator<T, R, Dyn>,
+        DefaultAllocator: Allocator<R, Dyn>,
     {
         self.clone()
     }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -264,7 +264,7 @@ unsafe impl<T, C: Dim> RawStorage<T, Dyn, C> for VecStorage<T, Dyn, C> {
 
 unsafe impl<T: Scalar, C: Dim> Storage<T, Dyn, C> for VecStorage<T, Dyn, C>
 where
-    DefaultAllocator: Allocator<T, Dyn, C, Buffer = Self>,
+    DefaultAllocator: Allocator<T, Dyn, C, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, Dyn, C>
@@ -315,7 +315,7 @@ unsafe impl<T, R: DimName> RawStorage<T, R, Dyn> for VecStorage<T, R, Dyn> {
 
 unsafe impl<T: Scalar, R: DimName> Storage<T, R, Dyn> for VecStorage<T, R, Dyn>
 where
-    DefaultAllocator: Allocator<T, R, Dyn, Buffer = Self>,
+    DefaultAllocator: Allocator<T, R, Dyn, Buffer<T> = Self>,
 {
     #[inline]
     fn into_owned(self) -> Owned<T, R, Dyn>

--- a/src/debug/random_orthogonal.rs
+++ b/src/debug/random_orthogonal.rs
@@ -14,14 +14,14 @@ use simba::scalar::ComplexField;
 #[derive(Clone, Debug)]
 pub struct RandomOrthogonal<T: Scalar, D: Dim = Dyn>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     m: OMatrix<T, D, D>,
 }
 
 impl<T: ComplexField, D: Dim> RandomOrthogonal<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Retrieve the generated matrix.
     pub fn unwrap(self) -> OMatrix<T, D, D> {
@@ -45,7 +45,7 @@ where
 #[cfg(feature = "arbitrary")]
 impl<T: ComplexField + Arbitrary + Send, D: Dim> Arbitrary for RandomOrthogonal<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     Owned<T, D, D>: Clone + Send,
 {
     fn arbitrary(g: &mut Gen) -> Self {

--- a/src/debug/random_sdp.rs
+++ b/src/debug/random_sdp.rs
@@ -15,14 +15,14 @@ use crate::debug::RandomOrthogonal;
 #[derive(Clone, Debug)]
 pub struct RandomSDP<T: Scalar, D: Dim = Dyn>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     m: OMatrix<T, D, D>,
 }
 
 impl<T: ComplexField, D: Dim> RandomSDP<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Retrieve the generated matrix.
     pub fn unwrap(self) -> OMatrix<T, D, D> {
@@ -48,7 +48,7 @@ where
 #[cfg(feature = "arbitrary")]
 impl<T: ComplexField + Arbitrary + Send, D: Dim> Arbitrary for RandomSDP<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     Owned<T, D, D>: Clone + Send,
 {
     fn arbitrary(g: &mut Gen) -> Self {

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -58,14 +58,14 @@ use rkyv::bytecheck;
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(serialize = "R: Serialize,
-                     DefaultAllocator: Allocator<T, Const<D>>,
+                     DefaultAllocator: Allocator<Const<D>>,
                      Owned<T, Const<D>>: Serialize,
                      T: Scalar"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(deserialize = "R: Deserialize<'de>,
-                       DefaultAllocator: Allocator<T, Const<D>>,
+                       DefaultAllocator: Allocator<Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>,
                        T: Scalar"))
 )]
@@ -433,7 +433,7 @@ impl<T: SimdRealField, R, const D: usize> Isometry<T, R, D> {
     where
         Const<D>: DimNameAdd<U1>,
         R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     {
         let mut res: OMatrix<T, _, _> = crate::convert_ref(&self.rotation);
         res.fixed_view_mut::<D, 1>(0, D)
@@ -465,7 +465,7 @@ impl<T: SimdRealField, R, const D: usize> Isometry<T, R, D> {
     where
         Const<D>: DimNameAdd<U1>,
         R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     {
         self.to_homogeneous()
     }

--- a/src/geometry/isometry_conversion.rs
+++ b/src/geometry/isometry_conversion.rs
@@ -9,7 +9,7 @@ use crate::geometry::{
     AbstractRotation, Isometry, Isometry3, Similarity, SuperTCategoryOf, TAffine, Transform,
     Translation, UnitDualQuaternion, UnitQuaternion,
 };
-use crate::{Point, SVector};
+use crate::{ArrayStorage, Point, SVector};
 
 /*
  * This file provides the following conversions:
@@ -105,13 +105,11 @@ where
         + SubsetOf<OMatrix<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>
         + SubsetOf<OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .is_special_orthogonal()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     // + Allocator<T1, D>
-    // + Allocator<(usize, usize), D>
-    // + Allocator<T2, D, D>
-    // + Allocator<T2, D>
+    // + Allocator<D>
+    // + Allocator<D, D>
+    // + Allocator<D>
 {
     #[inline]
     fn to_superset(&self) -> Transform<T2, C, D> {
@@ -138,13 +136,8 @@ where
         + SubsetOf<OMatrix<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>
         + SubsetOf<OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .is_special_orthogonal()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<(usize, usize), D>
-                                                                             // + Allocator<T2, D, D>
-                                                                             // + Allocator<T2, D>
-                                                                             // + Allocator<T1, D>
-                                                                             // + Allocator<T1, D, D>
+    DefaultAllocator: Allocator<Const<D>, Const<1>, Buffer<T1> = ArrayStorage<T1, D, 1>>
+        + Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn to_superset(&self) -> OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
@@ -191,7 +184,7 @@ impl<T: SimdRealField, R, const D: usize> From<Isometry<T, R, D>>
 where
     Const<D>: DimNameAdd<U1>,
     R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<T, D>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<D>,
 {
     #[inline]
     fn from(iso: Isometry<T, R, D>) -> Self {

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -49,13 +49,13 @@ use std::mem::MaybeUninit;
         T: rkyv::Archive,
         T::Archived: Scalar,
         OVector<T, D>: rkyv::Archive<Archived = OVector<T::Archived, D>>,
-        DefaultAllocator: Allocator<T::Archived, D>,
+        DefaultAllocator: Allocator<D>,
     ")
     )
 )]
 pub struct OPoint<T: Scalar, D: DimName>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// The coordinates of this point, i.e., the shift from the origin.
     pub coords: OVector<T, D>,
@@ -63,7 +63,7 @@ where
 
 impl<T: Scalar + fmt::Debug, D: DimName> fmt::Debug for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.coords.as_slice().fmt(formatter)
@@ -72,7 +72,7 @@ where
 
 impl<T: Scalar + hash::Hash, D: DimName> hash::Hash for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.coords.hash(state)
@@ -81,7 +81,7 @@ where
 
 impl<T: Scalar + Copy, D: DimName> Copy for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
     OVector<T, D>: Copy,
 {
 }
@@ -90,7 +90,7 @@ where
 unsafe impl<T: Scalar, D: DimName> bytemuck::Zeroable for OPoint<T, D>
 where
     OVector<T, D>: bytemuck::Zeroable,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
 }
 
@@ -99,15 +99,15 @@ unsafe impl<T: Scalar, D: DimName> bytemuck::Pod for OPoint<T, D>
 where
     T: Copy,
     OVector<T, D>: bytemuck::Pod,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
 }
 
 #[cfg(feature = "serde-serialize-no-std")]
 impl<T: Scalar, D: DimName> Serialize for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
-    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Serialize,
+    DefaultAllocator: Allocator<D>,
+    <DefaultAllocator as Allocator<D>>::Buffer<T>: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -120,8 +120,8 @@ where
 #[cfg(feature = "serde-serialize-no-std")]
 impl<'a, T: Scalar, D: DimName> Deserialize<'a> for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
-    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Deserialize<'a>,
+    DefaultAllocator: Allocator<D>,
+    <DefaultAllocator as Allocator<D>>::Buffer<T>: Deserialize<'a>,
 {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where
@@ -135,7 +135,7 @@ where
 
 impl<T: Scalar, D: DimName> OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Returns a point containing the result of `f` applied to each of its entries.
     ///
@@ -153,7 +153,7 @@ where
     #[must_use]
     pub fn map<T2: Scalar, F: FnMut(T) -> T2>(&self, f: F) -> OPoint<T2, D>
     where
-        DefaultAllocator: Allocator<T2, D>,
+        DefaultAllocator: Allocator<D>,
     {
         self.coords.map(f).into()
     }
@@ -198,7 +198,7 @@ where
     where
         T: One,
         D: DimNameAdd<U1>,
-        DefaultAllocator: Allocator<T, DimNameSum<D, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<D, U1>>,
     {
         // TODO: this is mostly a copy-past from Vector::push.
         //       But we can’t use Vector::push because of the DimAdd bound
@@ -304,7 +304,7 @@ where
     #[inline]
     pub fn iter(
         &self,
-    ) -> MatrixIter<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer<T>> {
+    ) -> MatrixIter<'_, T, D, Const<1>, <DefaultAllocator as Allocator<D>>::Buffer<T>> {
         self.coords.iter()
     }
 
@@ -335,7 +335,7 @@ where
     #[inline]
     pub fn iter_mut(
         &mut self,
-    ) -> MatrixIterMut<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer<T>> {
+    ) -> MatrixIterMut<'_, T, D, Const<1>, <DefaultAllocator as Allocator<D>>::Buffer<T>> {
         self.coords.iter_mut()
     }
 
@@ -364,7 +364,7 @@ where
 impl<T: Scalar + AbsDiffEq, D: DimName> AbsDiffEq for OPoint<T, D>
 where
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     type Epsilon = T::Epsilon;
 
@@ -382,7 +382,7 @@ where
 impl<T: Scalar + RelativeEq, D: DimName> RelativeEq for OPoint<T, D>
 where
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -404,7 +404,7 @@ where
 impl<T: Scalar + UlpsEq, D: DimName> UlpsEq for OPoint<T, D>
 where
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn default_max_ulps() -> u32 {
@@ -417,11 +417,11 @@ where
     }
 }
 
-impl<T: Scalar + Eq, D: DimName> Eq for OPoint<T, D> where DefaultAllocator: Allocator<T, D> {}
+impl<T: Scalar + Eq, D: DimName> Eq for OPoint<T, D> where DefaultAllocator: Allocator<D> {}
 
 impl<T: Scalar, D: DimName> PartialEq for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn eq(&self, right: &Self) -> bool {
@@ -431,7 +431,7 @@ where
 
 impl<T: Scalar + PartialOrd, D: DimName> PartialOrd for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -464,7 +464,7 @@ where
  */
 impl<T: Scalar + SimdPartialOrd, D: DimName> OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Computes the infimum (aka. componentwise min) of two points.
     #[inline]
@@ -496,7 +496,7 @@ where
  */
 impl<T: Scalar + fmt::Display, D: DimName> fmt::Display for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -107,7 +107,7 @@ where
 impl<T: Scalar, D: DimName> Serialize for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
-    <DefaultAllocator as Allocator<T, D>>::Buffer: Serialize,
+    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -121,7 +121,7 @@ where
 impl<'a, T: Scalar, D: DimName> Deserialize<'a> for OPoint<T, D>
 where
     DefaultAllocator: Allocator<T, D>,
-    <DefaultAllocator as Allocator<T, D>>::Buffer: Deserialize<'a>,
+    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Deserialize<'a>,
 {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
     where
@@ -304,7 +304,7 @@ where
     #[inline]
     pub fn iter(
         &self,
-    ) -> MatrixIter<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer> {
+    ) -> MatrixIter<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer<T>> {
         self.coords.iter()
     }
 
@@ -335,7 +335,7 @@ where
     #[inline]
     pub fn iter_mut(
         &mut self,
-    ) -> MatrixIterMut<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer> {
+    ) -> MatrixIterMut<'_, T, D, Const<1>, <DefaultAllocator as Allocator<T, D>>::Buffer<T>> {
         self.coords.iter_mut()
     }
 

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -174,7 +174,7 @@ where
 #[cfg(feature = "arbitrary")]
 impl<T: Scalar + Arbitrary + Send, D: DimName> Arbitrary for OPoint<T, D>
 where
-    <DefaultAllocator as Allocator<T, D>>::Buffer: Send,
+    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Send,
     DefaultAllocator: Allocator<T, D>,
 {
     #[inline]

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -21,7 +21,7 @@ use crate::geometry::Point;
 
 impl<T: Scalar + Zero, D: DimName> Default for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     fn default() -> Self {
         Self::origin()
@@ -31,7 +31,7 @@ where
 /// # Other construction methods
 impl<T: Scalar, D: DimName> OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Creates a new point with all coordinates equal to zero.
     ///
@@ -110,7 +110,7 @@ where
     where
         T: Scalar + Zero + One + ClosedDiv,
         D: DimNameAdd<U1>,
-        DefaultAllocator: Allocator<T, DimNameSum<D, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<D, U1>>,
     {
         if !v[D::dim()].is_zero() {
             let coords = v.generic_view((0, 0), (D::name(), Const::<1>)) / v[D::dim()].clone();
@@ -132,7 +132,7 @@ where
     pub fn cast<To: Scalar>(self) -> OPoint<To, D>
     where
         OPoint<To, D>: SupersetOf<Self>,
-        DefaultAllocator: Allocator<To, D>,
+        DefaultAllocator: Allocator<D>,
     {
         crate::convert(self)
     }
@@ -145,7 +145,7 @@ where
  */
 impl<T: Scalar + Bounded, D: DimName> Bounded for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn max_value() -> Self {
@@ -162,7 +162,7 @@ where
 impl<T: Scalar, D: DimName> Distribution<OPoint<T, D>> for Standard
 where
     Standard: Distribution<T>,
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Generate a `Point` where each coordinate is an independent variate from `[0, 1)`.
     #[inline]
@@ -174,8 +174,8 @@ where
 #[cfg(feature = "arbitrary")]
 impl<T: Scalar + Arbitrary + Send, D: DimName> Arbitrary for OPoint<T, D>
 where
-    <DefaultAllocator as Allocator<T, D>>::Buffer<T>: Send,
-    DefaultAllocator: Allocator<T, D>,
+    <DefaultAllocator as Allocator<D>>::Buffer<T>: Send,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn arbitrary(g: &mut Gen) -> Self {

--- a/src/geometry/point_conversion.rs
+++ b/src/geometry/point_conversion.rs
@@ -21,7 +21,7 @@ impl<T1, T2, D: DimName> SubsetOf<OPoint<T2, D>> for OPoint<T1, D>
 where
     T1: Scalar,
     T2: Scalar + SupersetOf<T1>,
-    DefaultAllocator: Allocator<T1, D> + Allocator<T2, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn to_superset(&self) -> OPoint<T2, D> {
@@ -46,12 +46,9 @@ where
     D: DimNameAdd<U1>,
     T1: Scalar,
     T2: Scalar + Zero + One + ClosedDiv + SupersetOf<T1>,
-    DefaultAllocator: Allocator<T1, D>
-        + Allocator<T2, D>
-        + Allocator<T1, DimNameSum<D, U1>>
-        + Allocator<T2, DimNameSum<D, U1>>,
+    DefaultAllocator: Allocator<D> + Allocator<DimNameSum<D, U1>>,
     // + Allocator<T1, D>
-    // + Allocator<T2, D>,
+    // + Allocator<D>,
 {
     #[inline]
     fn to_superset(&self) -> OVector<T2, DimNameSum<D, U1>> {
@@ -76,7 +73,7 @@ where
 impl<T: Scalar + Zero + One, D: DimName> From<OPoint<T, D>> for OVector<T, DimNameSum<D, U1>>
 where
     D: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<D, U1>> + Allocator<T, D>,
+    DefaultAllocator: Allocator<DimNameSum<D, U1>> + Allocator<D>,
 {
     #[inline]
     fn from(t: OPoint<T, D>) -> Self {
@@ -102,7 +99,7 @@ impl<T: Scalar, const D: usize> From<Point<T, D>> for [T; D] {
 
 impl<T: Scalar, D: DimName> From<OVector<T, D>> for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn from(coords: OVector<T, D>) -> Self {
@@ -115,7 +112,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 2]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
+    <DefaultAllocator as Allocator<Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 2]) -> Self {
@@ -128,7 +125,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 4]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
+    <DefaultAllocator as Allocator<Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 4]) -> Self {
@@ -146,7 +143,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 8]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
+    <DefaultAllocator as Allocator<Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 8]) -> Self {
@@ -168,7 +165,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 16]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
+    <DefaultAllocator as Allocator<Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 16]) -> Self {

--- a/src/geometry/point_conversion.rs
+++ b/src/geometry/point_conversion.rs
@@ -115,7 +115,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 2]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer: Copy,
+    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 2]) -> Self {
@@ -128,7 +128,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 4]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer: Copy,
+    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 4]) -> Self {
@@ -146,7 +146,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 8]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer: Copy,
+    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 8]) -> Self {
@@ -168,7 +168,7 @@ impl<T: Scalar + Copy + PrimitiveSimdValue, const D: usize> From<[Point<T::Eleme
 where
     T: From<[<T as simba::simd::SimdValue>::Element; 16]>,
     T::Element: Scalar + Copy,
-    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer: Copy,
+    <DefaultAllocator as Allocator<T::Element, Const<D>>>::Buffer<T::Element>: Copy,
 {
     #[inline]
     fn from(arr: [Point<T::Element, D>; 16]) -> Self {

--- a/src/geometry/point_ops.rs
+++ b/src/geometry/point_ops.rs
@@ -23,7 +23,7 @@ use crate::DefaultAllocator;
  */
 impl<T: Scalar, D: DimName> Index<usize> for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     type Output = T;
 
@@ -35,7 +35,7 @@ where
 
 impl<T: Scalar, D: DimName> IndexMut<usize> for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
@@ -50,7 +50,7 @@ where
  */
 impl<T: Scalar + ClosedNeg, D: DimName> Neg for OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     type Output = Self;
 
@@ -62,7 +62,7 @@ where
 
 impl<'a, T: Scalar + ClosedNeg, D: DimName> Neg for &'a OPoint<T, D>
 where
-    DefaultAllocator: Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     type Output = OPoint<T, D>;
 
@@ -81,25 +81,25 @@ where
 // Point - Point
 add_sub_impl!(Sub, sub, ClosedSub;
     (D, U1), (D, U1) -> (D, U1)
-    const; for D; where D: DimName, DefaultAllocator: Allocator<T, D>;
+    const; for D; where D: DimName, DefaultAllocator: Allocator<D>;
     self: &'a OPoint<T, D>, right: &'b OPoint<T, D>, Output = OVector<T, D>;
     &self.coords - &right.coords; 'a, 'b);
 
 add_sub_impl!(Sub, sub, ClosedSub;
     (D, U1), (D, U1) -> (D, U1)
-    const; for D; where D: DimName, DefaultAllocator: Allocator<T, D>;
+    const; for D; where D: DimName, DefaultAllocator: Allocator<D>;
     self: &'a OPoint<T, D>, right: OPoint<T, D>, Output = OVector<T, D>;
     &self.coords - right.coords; 'a);
 
 add_sub_impl!(Sub, sub, ClosedSub;
     (D, U1), (D, U1) -> (D, U1)
-    const; for D; where D: DimName, DefaultAllocator: Allocator<T, D>;
+    const; for D; where D: DimName, DefaultAllocator: Allocator<D>;
     self: OPoint<T, D>, right: &'b OPoint<T, D>, Output = OVector<T, D>;
     self.coords - &right.coords; 'b);
 
 add_sub_impl!(Sub, sub, ClosedSub;
     (D, U1), (D, U1) -> (D, U1)
-    const; for D; where D: DimName, DefaultAllocator: Allocator<T, D>;
+    const; for D; where D: DimName, DefaultAllocator: Allocator<D>;
     self: OPoint<T, D>, right: OPoint<T, D>, Output = OVector<T, D>;
     self.coords - right.coords; );
 
@@ -108,7 +108,7 @@ add_sub_impl!(Sub, sub, ClosedSub;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: &'a OPoint<T, D1>, right: &'b Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(&self.coords - right); 'a, 'b);
 
@@ -116,7 +116,7 @@ add_sub_impl!(Sub, sub, ClosedSub;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: &'a OPoint<T, D1>, right: Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(&self.coords - &right); 'a); // TODO: should not be a ref to `right`.
 
@@ -124,7 +124,7 @@ add_sub_impl!(Sub, sub, ClosedSub;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: OPoint<T, D1>, right: &'b Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(self.coords - right); 'b);
 
@@ -132,7 +132,7 @@ add_sub_impl!(Sub, sub, ClosedSub;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: OPoint<T, D1>, right: Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(self.coords - right); );
 
@@ -141,7 +141,7 @@ add_sub_impl!(Add, add, ClosedAdd;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: &'a OPoint<T, D1>, right: &'b Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(&self.coords + right); 'a, 'b);
 
@@ -149,7 +149,7 @@ add_sub_impl!(Add, add, ClosedAdd;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: &'a OPoint<T, D1>, right: Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(&self.coords + &right); 'a); // TODO: should not be a ref to `right`.
 
@@ -157,7 +157,7 @@ add_sub_impl!(Add, add, ClosedAdd;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: OPoint<T, D1>, right: &'b Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(self.coords + right); 'b);
 
@@ -165,7 +165,7 @@ add_sub_impl!(Add, add, ClosedAdd;
     (D1, U1), (D2, U1) -> (D1, U1)
     const;
     for D1, D2, SB;
-    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<T, D1>;
+    where D1: DimName, D2: Dim, SB: Storage<T, D2>, DefaultAllocator: Allocator<D1>;
     self: OPoint<T, D1>, right: Vector<T, D2, SB>, Output = OPoint<T, D1>;
     Self::Output::from(self.coords + right); );
 
@@ -176,7 +176,7 @@ macro_rules! op_assign_impl(
             where T: Scalar + $bound,
                   SB: Storage<T, D2>,
                   ShapeConstraint: SameNumberOfRows<D1, D2>,
-                  DefaultAllocator: Allocator<T, D1> {
+                  DefaultAllocator: Allocator<D1> {
 
             #[inline]
             fn $method_assign(&mut self, right: &'b Vector<T, D2, SB>) {
@@ -188,7 +188,7 @@ macro_rules! op_assign_impl(
             where T: Scalar + $bound,
                   SB: Storage<T, D2>,
                   ShapeConstraint: SameNumberOfRows<D1, D2>,
-                  DefaultAllocator: Allocator<T, D1> {
+                  DefaultAllocator: Allocator<D1> {
 
             #[inline]
             fn $method_assign(&mut self, right: Vector<T, D2, SB>) {
@@ -231,7 +231,7 @@ macro_rules! componentwise_scalarop_impl(
     ($Trait: ident, $method: ident, $bound: ident;
      $TraitAssign: ident, $method_assign: ident) => {
         impl<T: Scalar + $bound, D: DimName> $Trait<T> for OPoint<T, D>
-        where DefaultAllocator: Allocator<T, D>
+        where DefaultAllocator: Allocator<D>
         {
             type Output = OPoint<T, D>;
 
@@ -242,7 +242,7 @@ macro_rules! componentwise_scalarop_impl(
         }
 
         impl<'a, T: Scalar + $bound, D: DimName> $Trait<T> for &'a OPoint<T, D>
-        where DefaultAllocator: Allocator<T, D>
+        where DefaultAllocator: Allocator<D>
         {
             type Output = OPoint<T, D>;
 
@@ -253,7 +253,7 @@ macro_rules! componentwise_scalarop_impl(
         }
 
         impl<T: Scalar + $bound, D: DimName> $TraitAssign<T> for OPoint<T, D>
-            where DefaultAllocator: Allocator<T, D>
+            where DefaultAllocator: Allocator<D>
         {
             #[inline]
             fn $method_assign(&mut self, right: T) {
@@ -269,7 +269,7 @@ componentwise_scalarop_impl!(Div, div, ClosedDiv; DivAssign, div_assign);
 macro_rules! left_scalar_mul_impl(
     ($($T: ty),* $(,)*) => {$(
         impl<D: DimName> Mul<OPoint<$T, D>> for $T
-        where DefaultAllocator: Allocator<$T, D>
+        where DefaultAllocator: Allocator<D>
         {
             type Output = OPoint<$T, D>;
 
@@ -280,7 +280,7 @@ macro_rules! left_scalar_mul_impl(
         }
 
         impl<'b, D: DimName> Mul<&'b OPoint<$T, D>> for $T
-        where DefaultAllocator: Allocator<$T, D>
+        where DefaultAllocator: Allocator<D>
         {
             type Output = OPoint<$T, D>;
 

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -77,7 +77,7 @@ impl<T: fmt::Debug, const D: usize> fmt::Debug for Rotation<T, D> {
 
 impl<T: Scalar + hash::Hash, const D: usize> hash::Hash for Rotation<T, D>
 where
-    <DefaultAllocator as Allocator<T, Const<D>, Const<D>>>::Buffer: hash::Hash,
+    <DefaultAllocator as Allocator<T, Const<D>, Const<D>>>::Buffer<T>: hash::Hash,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.matrix.hash(state)

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -77,7 +77,7 @@ impl<T: fmt::Debug, const D: usize> fmt::Debug for Rotation<T, D> {
 
 impl<T: Scalar + hash::Hash, const D: usize> hash::Hash for Rotation<T, D>
 where
-    <DefaultAllocator as Allocator<T, Const<D>, Const<D>>>::Buffer<T>: hash::Hash,
+    <DefaultAllocator as Allocator<Const<D>, Const<D>>>::Buffer<T>: hash::Hash,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.matrix.hash(state)
@@ -265,7 +265,7 @@ impl<T: Scalar, const D: usize> Rotation<T, D> {
     where
         T: Zero + One,
         Const<D>: DimNameAdd<U1>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     {
         // We could use `SMatrix::to_homogeneous()` here, but that would imply
         // adding the additional traits `DimAdd` and `IsNotStaticOne`. Maybe

--- a/src/geometry/rotation_conversion.rs
+++ b/src/geometry/rotation_conversion.rs
@@ -1,5 +1,6 @@
 use num::Zero;
 
+use crate::ArrayStorage;
 use simba::scalar::{RealField, SubsetOf, SupersetOf};
 use simba::simd::{PrimitiveSimdValue, SimdValue};
 
@@ -169,11 +170,9 @@ where
     T2: RealField + SupersetOf<T1>,
     C: SuperTCategoryOf<TAffine>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .is_special_orthogonal()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
-    // + Allocator<(usize, usize), D>,
-    // Allocator<T1, D, D>
-    //     + Allocator<T2, D, D>
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    // + Allocator<D>,
+    //     + Allocator<D, D>
 {
     // needed by .is_special_orthogonal()
     #[inline]
@@ -198,10 +197,9 @@ where
     T1: RealField,
     T2: RealField + SupersetOf<T1>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .is_special_orthogonal()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<(usize, usize), D>,
-                                                                             // + Allocator<T1, D, D>
-                                                                             // + Allocator<T2, D, D>
+    DefaultAllocator: Allocator<Const<D>, Const<D>, Buffer<T1> = ArrayStorage<T1, D, D>>
+        + Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<D>,
+                                                                    // + Allocator<D, D>
 {
     // needed by .is_special_orthogonal()
     #[inline]

--- a/src/geometry/rotation_ops.rs
+++ b/src/geometry/rotation_ops.rs
@@ -77,7 +77,7 @@ md_impl_all!(
     const D1;
     for R2, C2, SB;
     where R2: Dim, C2: Dim, SB: Storage<T, R2, C2>,
-          DefaultAllocator: Allocator<T, Const<D1>, C2>,
+          DefaultAllocator: Allocator<Const<D1>, C2>,
           ShapeConstraint: AreMultipliable<Const<D1>, Const<D1>, R2, C2>;
     self: Rotation<T, D1>, right: Matrix<T, R2, C2, SB>, Output = OMatrix<T, Const<D1>, C2>;
     [val val] => self.into_inner() * right;
@@ -93,7 +93,7 @@ md_impl_all!(
     const D2;
     for R1, C1, SA;
     where R1: Dim, C1: Dim, SA: Storage<T, R1, C1>,
-          DefaultAllocator: Allocator<T, R1, Const<D2>>,
+          DefaultAllocator: Allocator<R1, Const<D2>>,
           ShapeConstraint:  AreMultipliable<R1, C1, Const<D2>, Const<D2>>;
     self: Matrix<T, R1, C1, SA>, right: Rotation<T, D2>, Output = OMatrix<T, R1, Const<D2>>;
     [val val] => self * right.into_inner();
@@ -109,7 +109,7 @@ md_impl_all!(
     const D2;
     for R1, C1, SA;
     where R1: Dim, C1: Dim, SA: Storage<T, R1, C1>,
-          DefaultAllocator: Allocator<T, R1, Const<D2>>,
+          DefaultAllocator: Allocator<R1, Const<D2>>,
           ShapeConstraint: AreMultipliable<R1, C1, Const<D2>, Const<D2>>;
     self: Matrix<T, R1, C1, SA>, right: Rotation<T, D2>, Output = OMatrix<T, R1, Const<D2>>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * right.inverse() };

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -221,8 +221,8 @@ impl<T: Scalar, const D: usize> Scale<T, D> {
     where
         T: Zero + One + Clone,
         Const<D>: DimNameAdd<U1>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-            + Allocator<T, DimNameSum<Const<D>, U1>, U1>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+            + Allocator<DimNameSum<Const<D>, U1>, U1>,
     {
         // TODO: use self.vector.push() instead. We can’t right now because
         //       that would require the DimAdd bound (but here we use DimNameAdd).

--- a/src/geometry/scale_conversion.rs
+++ b/src/geometry/scale_conversion.rs
@@ -48,9 +48,8 @@ where
     T2: RealField + SupersetOf<T1>,
     C: SuperTCategoryOf<TAffine>,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T1, DimNameSum<Const<D>, U1>, U1>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>, U1>,
 {
     #[inline]
     fn to_superset(&self) -> Transform<T2, C, D> {
@@ -74,9 +73,8 @@ where
     T1: RealField,
     T2: RealField + SupersetOf<T1>,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T1, DimNameSum<Const<D>, U1>, U1>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>, U1>,
 {
     #[inline]
     fn to_superset(&self) -> OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
@@ -113,9 +111,9 @@ impl<T: Scalar + Zero + One, const D: usize> From<Scale<T, D>>
     for OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T, DimNameSum<Const<D>, U1>, U1>
-        + Allocator<T, Const<D>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>, U1>
+        + Allocator<Const<D>>,
 {
     #[inline]
     fn from(t: Scale<T, D>) -> Self {

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -26,14 +26,14 @@ use rkyv::bytecheck;
     feature = "serde-serialize-no-std",
     serde(bound(serialize = "T: Scalar + Serialize,
                      R: Serialize,
-                     DefaultAllocator: Allocator<T, Const<D>>,
+                     DefaultAllocator: Allocator<Const<D>>,
                      Owned<T, Const<D>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(deserialize = "T: Scalar + Deserialize<'de>,
                        R: Deserialize<'de>,
-                       DefaultAllocator: Allocator<T, Const<D>>,
+                       DefaultAllocator: Allocator<Const<D>>,
                        Owned<T, Const<D>>: Deserialize<'de>"))
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
@@ -307,7 +307,7 @@ impl<T: SimdRealField, R, const D: usize> Similarity<T, R, D> {
     where
         Const<D>: DimNameAdd<U1>,
         R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     {
         let mut res = self.isometry.to_homogeneous();
 

--- a/src/geometry/similarity_conversion.rs
+++ b/src/geometry/similarity_conversion.rs
@@ -1,5 +1,6 @@
 use num::Zero;
 
+use crate::ArrayStorage;
 use simba::scalar::{RealField, SubsetOf, SupersetOf};
 use simba::simd::{PrimitiveSimdValue, SimdRealField, SimdValue};
 
@@ -56,14 +57,12 @@ where
         + SubsetOf<OMatrix<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>
         + SubsetOf<OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .determinant()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
-    // + Allocator<(usize, usize), D>
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    // + Allocator<D>
     // + Allocator<T1, D>
     // + Allocator<T1, D, D>
-    // + Allocator<T2, D, D>
-    // + Allocator<T2, D>,
+    // + Allocator<D, D>
+    // + Allocator<D>,
 {
     #[inline]
     fn to_superset(&self) -> Transform<T2, C, D> {
@@ -91,13 +90,8 @@ where
         + SubsetOf<OMatrix<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>
         + SubsetOf<OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
     Const<D>: DimNameAdd<U1> + DimMin<Const<D>, Output = Const<D>>, // needed by .determinant()
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<(usize, usize), D>
-                                                                             // + Allocator<T1, D>
-                                                                             // + Allocator<T1, D, D>
-                                                                             // + Allocator<T2, D, D>
-                                                                             // + Allocator<T2, D>
+    DefaultAllocator: Allocator<Const<D>, Const<1>, Buffer<T1> = ArrayStorage<T1, D, 1>>
+        + Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn to_superset(&self) -> OMatrix<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
@@ -178,7 +172,7 @@ impl<T: SimdRealField, R, const D: usize> From<Similarity<T, R, D>>
 where
     Const<D>: DimNameAdd<U1>,
     R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<T, D>
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>, // + Allocator<D>
 {
     #[inline]
     fn from(sim: Similarity<T, R, D>) -> Self {

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -32,7 +32,7 @@ pub trait TCategory: Any + Debug + Copy + PartialEq + Send {
     fn check_homogeneous_invariants<T: RealField, D: DimName>(mat: &OMatrix<T, D, D>) -> bool
     where
         T::Epsilon: Clone,
-        DefaultAllocator: Allocator<T, D, D>;
+        DefaultAllocator: Allocator<D, D>;
 }
 
 /// Traits that gives the `Transform` category that is compatible with the result of the
@@ -75,7 +75,7 @@ impl TCategory for TGeneral {
     fn check_homogeneous_invariants<T: RealField, D: DimName>(_: &OMatrix<T, D, D>) -> bool
     where
         T::Epsilon: Clone,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         true
     }
@@ -86,7 +86,7 @@ impl TCategory for TProjective {
     fn check_homogeneous_invariants<T: RealField, D: DimName>(mat: &OMatrix<T, D, D>) -> bool
     where
         T::Epsilon: Clone,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         mat.is_invertible()
     }
@@ -102,7 +102,7 @@ impl TCategory for TAffine {
     fn check_homogeneous_invariants<T: RealField, D: DimName>(mat: &OMatrix<T, D, D>) -> bool
     where
         T::Epsilon: Clone,
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let last = D::dim() - 1;
         mat.is_invertible()
@@ -160,7 +160,7 @@ super_tcategory_impl!(
 pub struct Transform<T: RealField, C: TCategory, const D: usize>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     matrix: OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     _phantom: PhantomData<C>,
@@ -169,7 +169,7 @@ where
 impl<T: RealField + Debug, C: TCategory, const D: usize> Debug for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.matrix.fmt(formatter)
@@ -179,7 +179,7 @@ where
 impl<T: RealField + hash::Hash, C: TCategory, const D: usize> hash::Hash for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: hash::Hash,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -190,7 +190,7 @@ where
 impl<T: RealField + Copy, C: TCategory, const D: usize> Copy for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: Copy,
 {
 }
@@ -198,7 +198,7 @@ where
 impl<T: RealField, C: TCategory, const D: usize> Clone for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn clone(&self) -> Self {
@@ -211,7 +211,7 @@ unsafe impl<T, C: TCategory, const D: usize> bytemuck::Zeroable for Transform<T,
 where
     T: RealField + bytemuck::Zeroable,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Zeroable,
 {
 }
@@ -221,7 +221,7 @@ unsafe impl<T, C: TCategory, const D: usize> bytemuck::Pod for Transform<T, C, D
 where
     T: RealField + bytemuck::Pod,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: bytemuck::Pod,
     Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: Copy,
 {
@@ -231,7 +231,7 @@ where
 impl<T: RealField, C: TCategory, const D: usize> Serialize for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -246,7 +246,7 @@ where
 impl<'a, T: RealField, C: TCategory, const D: usize> Deserialize<'a> for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     Owned<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>: Deserialize<'a>,
 {
     fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error>
@@ -264,14 +264,14 @@ where
 impl<T: RealField + Eq, C: TCategory, const D: usize> Eq for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
 }
 
 impl<T: RealField, C: TCategory, const D: usize> PartialEq for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn eq(&self, right: &Self) -> bool {
@@ -282,7 +282,7 @@ where
 impl<T: RealField, C: TCategory, const D: usize> Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     /// Creates a new transformation from the given homogeneous matrix. The transformation category
     /// of `Self` is not checked to be verified by the given matrix.
@@ -523,9 +523,9 @@ where
     T: RealField,
     C: TCategory,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T, DimNameSum<Const<D>, U1>>, // + Allocator<T, D, D>
-                                                  // + Allocator<T, D>
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>>, // + Allocator<D, D>
+                                               // + Allocator<D>
 {
     /// Transform the given point by this transformation.
     ///
@@ -551,9 +551,9 @@ impl<T: RealField, C: TCategory, const D: usize> Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
     C: SubTCategoryOf<TProjective>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T, DimNameSum<Const<D>, U1>>, // + Allocator<T, D, D>
-                                                  // + Allocator<T, D>
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>>, // + Allocator<D, D>
+                                               // + Allocator<D>
 {
     /// Transform the given point by the inverse of this transformation.
     /// This may be cheaper than inverting the transformation and transforming
@@ -577,7 +577,7 @@ where
 impl<T: RealField, const D: usize> Transform<T, TGeneral, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     /// A mutable reference to underlying matrix. Use `.matrix_mut_unchecked` instead if this
     /// transformation category is not `TGeneral`.
@@ -593,7 +593,7 @@ impl<T: RealField, C: TCategory, const D: usize> AbsDiffEq for Transform<T, C, D
 where
     Const<D>: DimNameAdd<U1>,
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     type Epsilon = T::Epsilon;
 
@@ -612,7 +612,7 @@ impl<T: RealField, C: TCategory, const D: usize> RelativeEq for Transform<T, C, 
 where
     Const<D>: DimNameAdd<U1>,
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -635,7 +635,7 @@ impl<T: RealField, C: TCategory, const D: usize> UlpsEq for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
     T::Epsilon: Clone,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn default_max_ulps() -> u32 {

--- a/src/geometry/transform_construction.rs
+++ b/src/geometry/transform_construction.rs
@@ -11,7 +11,7 @@ use crate::geometry::{TCategory, Transform};
 impl<T: RealField, C: TCategory, const D: usize> Default for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     fn default() -> Self {
         Self::identity()
@@ -21,7 +21,7 @@ where
 impl<T: RealField, C: TCategory, const D: usize> Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     /// Creates a new identity transform.
     ///
@@ -64,7 +64,7 @@ where
 impl<T: RealField, C: TCategory, const D: usize> One for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     /// Creates a new identity transform.
     #[inline]

--- a/src/geometry/transform_conversion.rs
+++ b/src/geometry/transform_conversion.rs
@@ -13,8 +13,7 @@ where
     C1: TCategory,
     C2: SuperTCategoryOf<C1>,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     T1::Epsilon: Copy,
     T2::Epsilon: Copy,
 {
@@ -42,8 +41,7 @@ where
     T2: RealField,
     C: TCategory,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T1, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T2, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     T1::Epsilon: Copy,
     T2::Epsilon: Copy,
 {
@@ -70,7 +68,7 @@ impl<T: RealField, C, const D: usize> From<Transform<T, C, D>>
 where
     Const<D>: DimNameAdd<U1>,
     C: TCategory,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn from(t: Transform<T, C, D>) -> Self {

--- a/src/geometry/transform_ops.rs
+++ b/src/geometry/transform_ops.rs
@@ -85,7 +85,7 @@ use crate::geometry::{
 impl<T: RealField, C: TCategory, const D: usize> Index<(usize, usize)> for Transform<T, C, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     type Output = T;
 
@@ -99,7 +99,7 @@ where
 impl<T: RealField, const D: usize> IndexMut<(usize, usize)> for Transform<T, TGeneral, D>
 where
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn index_mut(&mut self, ij: (usize, usize)) -> &mut T {
@@ -114,7 +114,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: SVector<T, D>, Output = SVector<T, D>;
     [val val] => &self * &rhs;
     [ref val] =>  self * &rhs;
@@ -142,7 +142,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Point<T, D>, Output = Point<T, D>;
     [val val] => &self * &rhs;
     [ref val] =>  self * &rhs;
@@ -172,7 +172,7 @@ md_impl_all!(
     const D;
     for CA, CB;
     where Const<D>: DimNameAdd<U1>, CA: TCategoryMul<CB>, CB: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, CA, D>, rhs: Transform<T, CB, D>, Output = Transform<T, CA::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.into_inner());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.into_inner());
@@ -188,7 +188,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Rotation<T, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
@@ -203,7 +203,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Rotation<T, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -274,7 +274,7 @@ md_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Isometry<T, R, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
@@ -289,7 +289,7 @@ md_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Isometry<T, R, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -304,7 +304,7 @@ md_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Similarity<T, R, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
@@ -319,7 +319,7 @@ md_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Similarity<T, R, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -342,7 +342,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Translation<T, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
     [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
@@ -357,7 +357,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Translation<T, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
     [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -372,7 +372,7 @@ md_impl_all!(
     const D;
     for CA, CB;
     where Const<D>: DimNameAdd<U1>, CA: TCategoryMul<CB>, CB: SubTCategoryOf<TProjective>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, CA, D>, rhs: Transform<T, CB, D>, Output = Transform<T, CA::Representative, D>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
     [ref val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
@@ -387,7 +387,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Rotation<T, D>, Output = Transform<T, C::Representative, D>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
     [ref val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
@@ -402,7 +402,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Rotation<T, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self.inverse() * rhs };
     [ref val] => #[allow(clippy::suspicious_arithmetic_impl)] { self.inverse() * rhs };
@@ -443,7 +443,7 @@ md_impl_all!(
 //          Div, div where T: RealField;
 //          (DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>), (Const<D>, U1)
 //          for Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >
-//          where SB::Alloc: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
+//          where SB::Alloc: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
 //          self: Transform<T, C, D>, rhs: Isometry<T, R, D>, Output = Transform<T, C::Representative, D>;
 //          [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.inverse().to_homogeneous());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.inverse().to_homogeneous());
@@ -456,7 +456,7 @@ md_impl_all!(
 //          Div, div where T: RealField;
 //          (Const<D>, U1), (DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>)
 //          for Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >
-//          where SA::Alloc: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
+//          where SA::Alloc: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
 //          self: Isometry<T, R, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
 //          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -469,8 +469,8 @@ md_impl_all!(
 //          Div, div where T: RealField;
 //          (DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>), (Const<D>, U1)
 //          for Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >
-//          where SB::Alloc: Allocator<T, D, D >
-//          where SB::Alloc: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
+//          where SB::Alloc: Allocator<D, D >
+//          where SB::Alloc: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
 //          self: Transform<T, C, D>, rhs: Similarity<T, R, D>, Output = Transform<T, C::Representative, D>;
 //          [val val] => Self::Output::from_matrix_unchecked(self.into_inner() * rhs.to_homogeneous());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.matrix() * rhs.to_homogeneous());
@@ -483,8 +483,8 @@ md_impl_all!(
 //          Div, div where T: RealField;
 //          (Const<D>, U1), (DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>)
 //          for Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >
-//          where SA::Alloc: Allocator<T, D, D >
-//          where SA::Alloc: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
+//          where SA::Alloc: Allocator<D, D >
+//          where SA::Alloc: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1> >;
 //          self: Similarity<T, R, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
 //          [val val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
 //          [ref val] => Self::Output::from_matrix_unchecked(self.to_homogeneous() * rhs.into_inner());
@@ -499,7 +499,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Translation<T, D>, Output = Transform<T, C::Representative, D>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
     [ref val] => #[allow(clippy::suspicious_arithmetic_impl)] { self * rhs.inverse() };
@@ -514,7 +514,7 @@ md_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategoryMul<TAffine>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Translation<T, D>, rhs: Transform<T, C, D>, Output = Transform<T, C::Representative, D>;
     [val val] => #[allow(clippy::suspicious_arithmetic_impl)] { self.inverse() * rhs };
     [ref val] => #[allow(clippy::suspicious_arithmetic_impl)] { self.inverse() * rhs };
@@ -529,7 +529,7 @@ md_assign_impl_all!(
     const D;
     for CA, CB;
     where Const<D>: DimNameAdd<U1>, CA: TCategory, CB: SubTCategoryOf<CA>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, CA, D>, rhs: Transform<T, CB, D>;
     [val] => *self.matrix_mut_unchecked() *= rhs.into_inner();
     [ref] => *self.matrix_mut_unchecked() *= rhs.matrix();
@@ -542,7 +542,7 @@ md_assign_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategory, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Similarity<T, R, D>;
     [val] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
     [ref] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
@@ -555,7 +555,7 @@ md_assign_impl_all!(
     const D;
     for C, R;
     where Const<D>: DimNameAdd<U1>, C: TCategory, R: SubsetOf<OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> >,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Isometry<T, R, D>;
     [val] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
     [ref] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
@@ -576,7 +576,7 @@ md_assign_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Translation<T, D>;
     [val] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
     [ref] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
@@ -589,7 +589,7 @@ md_assign_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Rotation<T, D>;
     [val] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
     [ref] => *self.matrix_mut_unchecked() *= rhs.to_homogeneous();
@@ -626,7 +626,7 @@ md_assign_impl_all!(
     const D;
     for CA, CB;
     where Const<D>: DimNameAdd<U1>, CA: SuperTCategoryOf<CB>, CB: SubTCategoryOf<TProjective>,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, CA, D>, rhs: Transform<T, CB, D>;
     [val] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.inverse() };
     [ref] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.clone().inverse() };
@@ -660,7 +660,7 @@ md_assign_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Translation<T, D>;
     [val] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.inverse() };
     [ref] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.inverse() };
@@ -673,7 +673,7 @@ md_assign_impl_all!(
     const D;
     for C;
     where Const<D>: DimNameAdd<U1>, C: TCategory,
-          DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
+          DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>;
     self: Transform<T, C, D>, rhs: Rotation<T, D>;
     [val] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.inverse() };
     [ref] => #[allow(clippy::suspicious_op_assign_impl)] { *self *= rhs.inverse() };

--- a/src/geometry/transform_simba.rs
+++ b/src/geometry/transform_simba.rs
@@ -12,8 +12,7 @@ where
     T::Element: Scalar,
     C: TCategory,
     Const<D>: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T::Element, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     type Element = Transform<T::Element, C, D>;
     type SimdBool = T::SimdBool;

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -153,7 +153,7 @@ impl<T: Scalar, const D: usize> Translation<T, D> {
     where
         T: Zero + One,
         Const<D>: DimNameAdd<U1>,
-        DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+        DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     {
         let mut res = OMatrix::<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>::identity();
         res.fixed_view_mut::<D, 1>(0, D).copy_from(&self.vector);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ pub fn abs<T: Signed>(a: &T) -> T {
 pub fn inf<T, R: Dim, C: Dim>(a: &OMatrix<T, R, C>, b: &OMatrix<T, R, C>) -> OMatrix<T, R, C>
 where
     T: Scalar + SimdPartialOrd,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     a.inf(b)
 }
@@ -286,7 +286,7 @@ where
 pub fn sup<T, R: Dim, C: Dim>(a: &OMatrix<T, R, C>, b: &OMatrix<T, R, C>) -> OMatrix<T, R, C>
 where
     T: Scalar + SimdPartialOrd,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     a.sup(b)
 }
@@ -300,7 +300,7 @@ pub fn inf_sup<T, R: Dim, C: Dim>(
 ) -> (OMatrix<T, R, C>, OMatrix<T, R, C>)
 where
     T: Scalar + SimdPartialOrd,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     a.inf_sup(b)
 }

--- a/src/linalg/balancing.rs
+++ b/src/linalg/balancing.rs
@@ -13,7 +13,7 @@ use crate::base::{Const, DefaultAllocator, OMatrix, OVector};
 /// See <https://arxiv.org/pdf/1401.5766.pdf>
 pub fn balance_parlett_reinsch<T: RealField, D: Dim>(matrix: &mut OMatrix<T, D, D>) -> OVector<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     assert!(matrix.is_square(), "Unable to balance a non-square matrix.");
 
@@ -68,7 +68,7 @@ where
 /// Computes in-place `D * m * D.inverse()`, where `D` is the matrix with diagonal `d`.
 pub fn unbalance<T: RealField, D: Dim>(m: &mut OMatrix<T, D, D>, d: &OVector<T, D>)
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     assert!(m.is_square(), "Unable to unbalance a non-square matrix.");
     assert_eq!(m.nrows(), d.len(), "Unbalancing: mismatched dimensions.");

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -16,9 +16,9 @@ use std::mem::MaybeUninit;
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(serialize = "DimMinimum<R, C>: DimSub<U1>,
-         DefaultAllocator: Allocator<T, R, C>             +
-                           Allocator<T, DimMinimum<R, C>> +
-                           Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+         DefaultAllocator: Allocator<R, C>             +
+                           Allocator<DimMinimum<R, C>> +
+                           Allocator<DimDiff<DimMinimum<R, C>, U1>>,
          OMatrix<T, R, C>: Serialize,
          OVector<T, DimMinimum<R, C>>: Serialize,
          OVector<T, DimDiff<DimMinimum<R, C>, U1>>: Serialize"))
@@ -26,9 +26,9 @@ use std::mem::MaybeUninit;
 #[cfg_attr(
     feature = "serde-serialize-no-std",
     serde(bound(deserialize = "DimMinimum<R, C>: DimSub<U1>,
-         DefaultAllocator: Allocator<T, R, C>             +
-                           Allocator<T, DimMinimum<R, C>> +
-                           Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+         DefaultAllocator: Allocator<R, C>             +
+                           Allocator<DimMinimum<R, C>> +
+                           Allocator<DimDiff<DimMinimum<R, C>, U1>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>,
          OVector<T, DimDiff<DimMinimum<R, C>, U1>>: Deserialize<'de>"))
@@ -37,9 +37,8 @@ use std::mem::MaybeUninit;
 pub struct Bidiagonal<T: ComplexField, R: DimMin<C>, C: Dim>
 where
     DimMinimum<R, C>: DimSub<U1>,
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+    DefaultAllocator:
+        Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
 {
     // TODO: perhaps we should pack the axes into different vectors so that axes for `v_t` are
     // contiguous. This prevents some useless copies.
@@ -54,9 +53,8 @@ where
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Copy for Bidiagonal<T, R, C>
 where
     DimMinimum<R, C>: DimSub<U1>,
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+    DefaultAllocator:
+        Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     OMatrix<T, R, C>: Copy,
     OVector<T, DimMinimum<R, C>>: Copy,
     OVector<T, DimDiff<DimMinimum<R, C>, U1>>: Copy,
@@ -66,11 +64,11 @@ where
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Bidiagonal<T, R, C>
 where
     DimMinimum<R, C>: DimSub<U1>,
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, C>
-        + Allocator<T, R>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+    DefaultAllocator: Allocator<R, C>
+        + Allocator<C>
+        + Allocator<R>
+        + Allocator<DimMinimum<R, C>>
+        + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
 {
     /// Computes the Bidiagonal decomposition using householder reflections.
     pub fn new(mut matrix: OMatrix<T, R, C>) -> Self {
@@ -177,9 +175,9 @@ where
         OMatrix<T, DimMinimum<R, C>, C>,
     )
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, DimMinimum<R, C>>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, DimMinimum<R, C>>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>, C>,
     {
         // TODO: optimize by calling a reallocator.
         (self.u(), self.d(), self.v_t())
@@ -190,7 +188,7 @@ where
     #[must_use]
     pub fn d(&self) -> OMatrix<T, DimMinimum<R, C>, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.uv.shape_generic();
 
@@ -218,7 +216,7 @@ where
     #[must_use]
     pub fn u(&self) -> OMatrix<T, R, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.uv.shape_generic();
 
@@ -253,7 +251,7 @@ where
     #[must_use]
     pub fn v_t(&self) -> OMatrix<T, DimMinimum<R, C>, C>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, C>,
     {
         let (nrows, ncols) = self.uv.shape_generic();
         let min_nrows_ncols = nrows.min(ncols);
@@ -293,7 +291,7 @@ where
     #[must_use]
     pub fn diagonal(&self) -> OVector<T::RealField, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T::RealField, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>>,
     {
         self.diagonal.map(|e| e.modulus())
     }
@@ -302,7 +300,7 @@ where
     #[must_use]
     pub fn off_diagonal(&self) -> OVector<T::RealField, DimDiff<DimMinimum<R, C>, U1>>
     where
-        DefaultAllocator: Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     {
         self.off_diagonal.map(|e| e.modulus())
     }
@@ -314,8 +312,8 @@ where
 }
 
 // impl<T: ComplexField, D: DimMin<D, Output = D> + DimSub<Dyn>> Bidiagonal<T, D, D>
-//     where DefaultAllocator: Allocator<T, D, D> +
-//                             Allocator<T, D> {
+//     where DefaultAllocator: Allocator<D, D> +
+//                             Allocator<D> {
 //     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
 //     pub fn solve<R2: Dim, C2: Dim, S2>(&self, b: &Matrix<T, R2, C2, S2>) -> OMatrix<T, R2, C2>
 //         where S2: StorageMut<T, R2, C2>,

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -15,32 +15,32 @@ use crate::storage::{Storage, StorageMut};
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D>,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Cholesky<T: SimdComplexField, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     chol: OMatrix<T, D, D>,
 }
 
 impl<T: SimdComplexField, D: Dim> Copy for Cholesky<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     OMatrix<T, D, D>: Copy,
 {
 }
 
 impl<T: SimdComplexField, D: Dim> Cholesky<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Computes the Cholesky decomposition of `matrix` without checking that the matrix is definite-positive.
     ///
@@ -133,7 +133,7 @@ where
     pub fn solve<R2: Dim, C2: Dim, S2>(&self, b: &Matrix<T, R2, C2, S2>) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -186,7 +186,7 @@ where
 
 impl<T: ComplexField, D: Dim> Cholesky<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     /// Attempts to compute the Cholesky decomposition of `matrix`.
     ///
@@ -268,7 +268,7 @@ where
     pub fn rank_one_update<R2: Dim, S2>(&mut self, x: &Vector<T, R2, S2>, sigma: T::RealField)
     where
         S2: Storage<T, R2, U1>,
-        DefaultAllocator: Allocator<T, R2, U1>,
+        DefaultAllocator: Allocator<R2, U1>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         Self::xx_rank_one_update(&mut self.chol, &mut x.clone_owned(), sigma)
@@ -285,7 +285,7 @@ where
         D: DimAdd<U1>,
         R2: Dim,
         S2: Storage<T, R2, U1>,
-        DefaultAllocator: Allocator<T, DimSum<D, U1>, DimSum<D, U1>> + Allocator<T, R2>,
+        DefaultAllocator: Allocator<DimSum<D, U1>, DimSum<D, U1>> + Allocator<R2>,
         ShapeConstraint: SameNumberOfRows<R2, DimSum<D, U1>>,
     {
         let mut col = col.into_owned();
@@ -357,7 +357,7 @@ where
     pub fn remove_column(&self, j: usize) -> Cholesky<T, DimDiff<D, U1>>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, DimDiff<D, U1>, DimDiff<D, U1>> + Allocator<T, D>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>, DimDiff<D, U1>> + Allocator<D>,
     {
         let n = self.chol.nrows();
         assert!(n > 0, "The matrix needs at least one column.");

--- a/src/linalg/col_piv_qr.rs
+++ b/src/linalg/col_piv_qr.rs
@@ -17,16 +17,16 @@ use std::mem::MaybeUninit;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize,
          OVector<T, DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>"))
@@ -34,9 +34,7 @@ use std::mem::MaybeUninit;
 #[derive(Clone, Debug)]
 pub struct ColPivQR<T: ComplexField, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     col_piv_qr: OMatrix<T, R, C>,
     p: PermutationSequence<DimMinimum<R, C>>,
@@ -45,9 +43,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Copy for ColPivQR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     PermutationSequence<DimMinimum<R, C>>: Copy,
     OVector<T, DimMinimum<R, C>>: Copy,
@@ -56,10 +52,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> ColPivQR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C>
-        + Allocator<T, R>
-        + Allocator<T, DimMinimum<R, C>>
-        + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<R> + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the `ColPivQR` decomposition using householder reflections.
     pub fn new(mut matrix: OMatrix<T, R, C>) -> Self {
@@ -102,7 +95,7 @@ where
     #[must_use]
     pub fn r(&self) -> OMatrix<T, DimMinimum<R, C>, C>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, C>,
     {
         let (nrows, ncols) = self.col_piv_qr.shape_generic();
         let mut res = self
@@ -134,7 +127,7 @@ where
     #[must_use]
     pub fn q(&self) -> OMatrix<T, R, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.col_piv_qr.shape_generic();
 
@@ -171,9 +164,9 @@ where
     )
     where
         DimMinimum<R, C>: DimMin<C, Output = DimMinimum<R, C>>,
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>
             + Reallocator<T, R, C, DimMinimum<R, C>, C>
-            + Allocator<(usize, usize), DimMinimum<R, C>>,
+            + Allocator<DimMinimum<R, C>>,
     {
         (self.q(), self.r(), self.p)
     }
@@ -202,8 +195,7 @@ where
 
 impl<T: ComplexField, D: DimMin<D, Output = D>> ColPivQR<T, D, D>
 where
-    DefaultAllocator:
-        Allocator<T, D, D> + Allocator<T, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D> + Allocator<DimMinimum<D, D>>,
 {
     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
     ///
@@ -216,7 +208,7 @@ where
     where
         S2: StorageMut<T, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let mut res = b.clone_owned();
 

--- a/src/linalg/convolution.rs
+++ b/src/linalg/convolution.rs
@@ -25,7 +25,7 @@ impl<T: RealField, D1: Dim, S1: Storage<T, D1>> Vector<T, D1, S1> {
         D2: DimAdd<D1, Output = DimSum<D1, D2>>,
         DimSum<D1, D2>: DimSub<U1>,
         S2: Storage<T, D2>,
-        DefaultAllocator: Allocator<T, DimDiff<DimSum<D1, D2>, U1>>,
+        DefaultAllocator: Allocator<DimDiff<DimSum<D1, D2>, U1>>,
     {
         let vec = self.len();
         let ker = kernel.len();
@@ -78,7 +78,7 @@ impl<T: RealField, D1: Dim, S1: Storage<T, D1>> Vector<T, D1, S1> {
         D2: Dim,
         DimSum<D1, U1>: DimSub<D2>,
         S2: Storage<T, D2>,
-        DefaultAllocator: Allocator<T, DimDiff<DimSum<D1, U1>, D2>>,
+        DefaultAllocator: Allocator<DimDiff<DimSum<D1, U1>, D2>>,
     {
         let vec = self.len();
         let ker = kernel.len();
@@ -117,7 +117,7 @@ impl<T: RealField, D1: Dim, S1: Storage<T, D1>> Vector<T, D1, S1> {
     where
         D2: Dim,
         S2: Storage<T, D2>,
-        DefaultAllocator: Allocator<T, D1>,
+        DefaultAllocator: Allocator<D1>,
     {
         let vec = self.len();
         let ker = kernel.len();

--- a/src/linalg/decomposition.rs
+++ b/src/linalg/decomposition.rs
@@ -24,11 +24,11 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>,
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     {
         Bidiagonal::new(self.into_owned())
     }
@@ -39,7 +39,7 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn full_piv_lu(self) -> FullPivLU<T, R, C>
     where
         R: DimMin<C>,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     {
         FullPivLU::new(self.into_owned())
     }
@@ -48,7 +48,7 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn lu(self) -> LU<T, R, C>
     where
         R: DimMin<C>,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     {
         LU::new(self.into_owned())
     }
@@ -57,7 +57,7 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn qr(self) -> QR<T, R, C>
     where
         R: DimMin<C>,
-        DefaultAllocator: Allocator<T, R, C> + Allocator<T, R> + Allocator<T, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C> + Allocator<R> + Allocator<DimMinimum<R, C>>,
     {
         QR::new(self.into_owned())
     }
@@ -66,10 +66,10 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     pub fn col_piv_qr(self) -> ColPivQR<T, R, C>
     where
         R: DimMin<C>,
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, R>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<(usize, usize), DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<R>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>,
     {
         ColPivQR::new(self.into_owned())
     }
@@ -81,17 +81,13 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<(usize, usize), DimMinimum<R, C>>
-            + Allocator<(T::RealField, usize), DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>,
     {
         SVD::new(self.into_owned(), compute_u, compute_v)
     }
@@ -103,15 +99,13 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>,
     {
         SVD::new_unordered(self.into_owned(), compute_u, compute_v)
     }
@@ -138,17 +132,13 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<(usize, usize), DimMinimum<R, C>>
-            + Allocator<(T::RealField, usize), DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>,
     {
         SVD::try_new(self.into_owned(), compute_u, compute_v, eps, max_niter)
     }
@@ -175,15 +165,15 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     {
         SVD::try_new_unordered(self.into_owned(), compute_u, compute_v, eps, max_niter)
     }
@@ -193,19 +183,19 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, DimMinimum<R, C>, R>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T, R, R>
-            + Allocator<T, DimMinimum<R, C>, DimMinimum<R, C>>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<DimMinimum<R, C>, R>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<R, R>
+            + Allocator<DimMinimum<R, C>, DimMinimum<R, C>>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     {
         SVD::new_unordered(self.into_owned(), true, true)
             .to_polar()
@@ -226,19 +216,19 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     where
         R: DimMin<C>,
         DimMinimum<R, C>: DimSub<U1>, // for Bidiagonal.
-        DefaultAllocator: Allocator<T, R, C>
-            + Allocator<T, DimMinimum<R, C>, R>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T, R, R>
-            + Allocator<T, DimMinimum<R, C>, DimMinimum<R, C>>
-            + Allocator<T, C>
-            + Allocator<T, R>
-            + Allocator<T, DimDiff<DimMinimum<R, C>, U1>>
-            + Allocator<T, DimMinimum<R, C>, C>
-            + Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimMinimum<R, C>>
-            + Allocator<T::RealField, DimDiff<DimMinimum<R, C>, U1>>,
+        DefaultAllocator: Allocator<R, C>
+            + Allocator<DimMinimum<R, C>, R>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<R, R>
+            + Allocator<DimMinimum<R, C>, DimMinimum<R, C>>
+            + Allocator<C>
+            + Allocator<R>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>
+            + Allocator<DimMinimum<R, C>, C>
+            + Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>>
+            + Allocator<DimDiff<DimMinimum<R, C>, U1>>,
     {
         SVD::try_new_unordered(self.into_owned(), true, true, eps, max_niter)
             .and_then(|svd| svd.to_polar())
@@ -265,7 +255,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     /// to be symmetric and only the lower-triangular part is read.
     pub fn cholesky(self) -> Option<Cholesky<T, D>>
     where
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         Cholesky::new(self.into_owned())
     }
@@ -277,7 +267,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn udu(self) -> Option<UDU<T, D>>
     where
         T: RealField,
-        DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D> + Allocator<D, D>,
     {
         UDU::new(self.into_owned())
     }
@@ -286,7 +276,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn hessenberg(self) -> Hessenberg<T, D>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, D, D> + Allocator<T, D> + Allocator<T, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<D, D> + Allocator<D> + Allocator<DimDiff<D, U1>>,
     {
         Hessenberg::new(self.into_owned())
     }
@@ -295,10 +285,10 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn schur(self) -> Schur<T, D>
     where
         D: DimSub<U1>, // For Hessenberg.
-        DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
-            + Allocator<T, DimDiff<D, U1>>
-            + Allocator<T, D, D>
-            + Allocator<T, D>,
+        DefaultAllocator: Allocator<D, DimDiff<D, U1>>
+            + Allocator<DimDiff<D, U1>>
+            + Allocator<D, D>
+            + Allocator<D>,
     {
         Schur::new(self.into_owned())
     }
@@ -317,10 +307,10 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn try_schur(self, eps: T::RealField, max_niter: usize) -> Option<Schur<T, D>>
     where
         D: DimSub<U1>, // For Hessenberg.
-        DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
-            + Allocator<T, DimDiff<D, U1>>
-            + Allocator<T, D, D>
-            + Allocator<T, D>,
+        DefaultAllocator: Allocator<D, DimDiff<D, U1>>
+            + Allocator<DimDiff<D, U1>>
+            + Allocator<D, D>
+            + Allocator<D>,
     {
         Schur::try_new(self.into_owned(), eps, max_niter)
     }
@@ -331,10 +321,8 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn symmetric_eigen(self) -> SymmetricEigen<T, D>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, D, D>
-            + Allocator<T, DimDiff<D, U1>>
-            + Allocator<T::RealField, D>
-            + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator:
+            Allocator<D, D> + Allocator<DimDiff<D, U1>> + Allocator<D> + Allocator<DimDiff<D, U1>>,
     {
         SymmetricEigen::new(self.into_owned())
     }
@@ -357,10 +345,8 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     ) -> Option<SymmetricEigen<T, D>>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, D, D>
-            + Allocator<T, DimDiff<D, U1>>
-            + Allocator<T::RealField, D>
-            + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator:
+            Allocator<D, D> + Allocator<DimDiff<D, U1>> + Allocator<D> + Allocator<DimDiff<D, U1>>,
     {
         SymmetricEigen::try_new(self.into_owned(), eps, max_niter)
     }
@@ -371,7 +357,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     pub fn symmetric_tridiagonalize(self) -> SymmetricTridiagonal<T, D>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
     {
         SymmetricTridiagonal::new(self.into_owned())
     }

--- a/src/linalg/determinant.rs
+++ b/src/linalg/determinant.rs
@@ -15,7 +15,7 @@ impl<T: ComplexField, D: DimMin<D, Output = D>, S: Storage<T, D, D>> SquareMatri
     #[must_use]
     pub fn determinant(&self) -> T
     where
-        DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), D>,
+        DefaultAllocator: Allocator<D, D> + Allocator<D>,
     {
         assert!(
             self.is_square(),

--- a/src/linalg/eigen.rs
+++ b/src/linalg/eigen.rs
@@ -23,20 +23,20 @@ use crate::linalg::Schur;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D>,
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Eigen<T: ComplexField, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     pub eigenvectors: OMatrix<T, D, D>,
     pub eigenvalues: OVector<T, D>,
@@ -44,7 +44,7 @@ where
 
 impl<T: ComplexField, D: Dim> Copy for Eigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T, D>: Copy,
 {
@@ -54,12 +54,10 @@ impl<T: ComplexField, D: Dim> Eigen<T, D>
 where
     D: DimSub<U1>,                               // For Hessenberg.
     ShapeConstraint: DimEq<Dyn, DimDiff<D, U1>>, // For Hessenberg.
-    DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
-        + Allocator<T, DimDiff<D, U1>>
-        + Allocator<T, D, D>
-        + Allocator<T, D>,
+    DefaultAllocator:
+        Allocator<D, DimDiff<D, U1>> + Allocator<DimDiff<D, U1>> + Allocator<D, D> + Allocator<D>,
     // XXX: for debug
-    DefaultAllocator: Allocator<usize, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     OMatrix<T, D, D>: Display,
 {
     /// Computes the eigendecomposition of a diagonalizable matrix with Complex eigenvalues.

--- a/src/linalg/exp.rs
+++ b/src/linalg/exp.rs
@@ -57,7 +57,7 @@ struct ExpmPadeHelper<T, D>
 where
     T: ComplexField,
     D: DimMin<D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimMinimum<D, D>>,
 {
     use_exact_norm: bool,
     ident: OMatrix<T, D, D>,
@@ -84,7 +84,7 @@ impl<T, D> ExpmPadeHelper<T, D>
 where
     T: ComplexField,
     D: DimMin<D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimMinimum<D, D>>,
 {
     fn new(a: OMatrix<T, D, D>, use_exact_norm: bool) -> Self {
         let (nrows, ncols) = a.shape_generic();
@@ -397,7 +397,7 @@ fn onenorm_matrix_power_nonm<T, D>(a: &OMatrix<T, D, D>, p: usize) -> T
 where
     T: RealField,
     D: Dim,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     let nrows = a.shape_generic().0;
     let mut v = crate::OVector::<T, D>::repeat_generic(nrows, Const::<1>, convert(1.0));
@@ -414,10 +414,7 @@ fn ell<T, D>(a: &OMatrix<T, D, D>, m: usize) -> u64
 where
     T: ComplexField,
     D: Dim,
-    DefaultAllocator: Allocator<T, D, D>
-        + Allocator<T, D>
-        + Allocator<T::RealField, D>
-        + Allocator<T::RealField, D, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D> + Allocator<D> + Allocator<D, D>,
 {
     let a_abs = a.map(|x| x.abs());
 
@@ -449,7 +446,7 @@ fn solve_p_q<T, D>(u: OMatrix<T, D, D>, v: OMatrix<T, D, D>) -> OMatrix<T, D, D>
 where
     T: ComplexField,
     D: DimMin<D, Output = D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), DimMinimum<D, D>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimMinimum<D, D>>,
 {
     let p = &u + &v;
     let q = &v - &u;
@@ -461,7 +458,7 @@ fn one_norm<T, D>(m: &OMatrix<T, D, D>) -> T::RealField
 where
     T: ComplexField,
     D: Dim,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     let mut max = <T as ComplexField>::RealField::zero();
 
@@ -481,11 +478,11 @@ where
 impl<T: ComplexField, D> OMatrix<T, D, D>
 where
     D: DimMin<D, Output = D>,
-    DefaultAllocator: Allocator<T, D, D>
-        + Allocator<(usize, usize), DimMinimum<D, D>>
-        + Allocator<T, D>
-        + Allocator<T::RealField, D>
-        + Allocator<T::RealField, D, D>,
+    DefaultAllocator: Allocator<D, D>
+        + Allocator<DimMinimum<D, D>>
+        + Allocator<D>
+        + Allocator<D>
+        + Allocator<D, D>,
 {
     /// Computes exponential of this matrix
     #[must_use]

--- a/src/linalg/full_piv_lu.rs
+++ b/src/linalg/full_piv_lu.rs
@@ -15,22 +15,22 @@ use crate::linalg::PermutationSequence;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<(usize, usize), DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<(usize, usize), DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct FullPivLU<T: ComplexField, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     lu: OMatrix<T, R, C>,
     p: PermutationSequence<DimMinimum<R, C>>,
@@ -39,7 +39,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Copy for FullPivLU<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     PermutationSequence<DimMinimum<R, C>>: Copy,
 {
@@ -47,7 +47,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> FullPivLU<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the LU decomposition with full pivoting of `matrix`.
     ///
@@ -99,7 +99,7 @@ where
     #[must_use]
     pub fn l(&self) -> OMatrix<T, R, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.lu.shape_generic();
         let mut m = self.lu.columns_generic(0, nrows.min(ncols)).into_owned();
@@ -113,7 +113,7 @@ where
     #[must_use]
     pub fn u(&self) -> OMatrix<T, DimMinimum<R, C>, C>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, C>,
     {
         let (nrows, ncols) = self.lu.shape_generic();
         self.lu.rows_generic(0, nrows.min(ncols)).upper_triangle()
@@ -144,7 +144,7 @@ where
         PermutationSequence<DimMinimum<R, C>>,
     )
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>> + Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>> + Allocator<DimMinimum<R, C>, C>,
     {
         // Use reallocation for either l or u.
         let l = self.l();
@@ -158,7 +158,7 @@ where
 
 impl<T: ComplexField, D: DimMin<D, Output = D>> FullPivLU<T, D, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
     ///
@@ -171,7 +171,7 @@ where
     where
         S2: Storage<T, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let mut res = b.clone_owned();
         if self.solve_mut(&mut res) {

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -14,22 +14,22 @@ use std::mem::MaybeUninit;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Serialize,
          OVector<T, DimDiff<D, U1>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Deserialize<'de>,
          OVector<T, DimDiff<D, U1>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Hessenberg<T: ComplexField, D: DimSub<U1>>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     hess: OMatrix<T, D, D>,
     subdiag: OVector<T, DimDiff<D, U1>>,
@@ -37,7 +37,7 @@ where
 
 impl<T: ComplexField, D: DimSub<U1>> Copy for Hessenberg<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
     OMatrix<T, D, D>: Copy,
     OVector<T, DimDiff<D, U1>>: Copy,
 {
@@ -45,7 +45,7 @@ where
 
 impl<T: ComplexField, D: DimSub<U1>> Hessenberg<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D> + Allocator<DimDiff<D, U1>>,
 {
     /// Computes the Hessenberg decomposition using householder reflections.
     pub fn new(hess: OMatrix<T, D, D>) -> Self {

--- a/src/linalg/householder.rs
+++ b/src/linalg/householder.rs
@@ -65,7 +65,7 @@ pub fn clear_column_unchecked<T: ComplexField, R: Dim, C: Dim>(
     bilateral: Option<&mut OVector<T, R>>,
 ) -> T
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, R>,
+    DefaultAllocator: Allocator<R, C> + Allocator<R>,
 {
     let (mut left, mut right) = matrix.columns_range_pair_mut(icol, icol + 1..);
     let mut axis = left.rows_range_mut(icol + shift..);
@@ -98,7 +98,7 @@ pub fn clear_row_unchecked<T: ComplexField, R: Dim, C: Dim>(
     shift: usize,
 ) -> T
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, R> + Allocator<T, C>,
+    DefaultAllocator: Allocator<R, C> + Allocator<R> + Allocator<C>,
 {
     let (mut top, mut bottom) = matrix.rows_range_pair_mut(irow, irow + 1..);
     let mut axis = axis_packed.rows_range_mut(irow + shift..);
@@ -129,7 +129,7 @@ where
 #[doc(hidden)]
 pub fn assemble_q<T: ComplexField, D: Dim>(m: &OMatrix<T, D, D>, signs: &[T]) -> OMatrix<T, D, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     assert!(m.is_square());
     let dim = m.shape_generic().0;

--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -17,7 +17,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     #[must_use = "Did you mean to use try_inverse_mut()?"]
     pub fn try_inverse(self) -> Option<OMatrix<T, D, D>>
     where
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         let mut me = self.into_owned();
         if me.try_inverse_mut() {
@@ -38,7 +38,7 @@ impl<T: ComplexField, D: Dim, S: StorageMut<T, D, D>> SquareMatrix<T, D, S> {
     #[inline]
     pub fn try_inverse_mut(&mut self) -> bool
     where
-        DefaultAllocator: Allocator<T, D, D>,
+        DefaultAllocator: Allocator<D, D>,
     {
         assert!(self.is_square(), "Unable to invert a non-square matrix.");
 
@@ -141,7 +141,7 @@ fn do_inverse4<T: ComplexField, D: Dim, S: StorageMut<T, D, D>>(
     out: &mut SquareMatrix<T, D, S>,
 ) -> bool
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     let m = m.as_slice();
 

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -15,22 +15,22 @@ use crate::linalg::PermutationSequence;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<(usize, usize), DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          PermutationSequence<DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<(usize, usize), DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct LU<T: ComplexField, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     lu: OMatrix<T, R, C>,
     p: PermutationSequence<DimMinimum<R, C>>,
@@ -38,7 +38,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Copy for LU<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     PermutationSequence<DimMinimum<R, C>>: Copy,
 {
@@ -53,7 +53,7 @@ pub fn try_invert_to<T: ComplexField, D: Dim, S>(
 ) -> bool
 where
     S: StorageMut<T, D, D>,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     assert!(
         matrix.is_square(),
@@ -86,7 +86,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> LU<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<(usize, usize), DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the LU decomposition with partial (row) pivoting of `matrix`.
     pub fn new(mut matrix: OMatrix<T, R, C>) -> Self {
@@ -130,7 +130,7 @@ where
     #[must_use]
     pub fn l(&self) -> OMatrix<T, R, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.lu.shape_generic();
         let mut m = self.lu.columns_generic(0, nrows.min(ncols)).into_owned();
@@ -174,7 +174,7 @@ where
     #[must_use]
     pub fn u(&self) -> OMatrix<T, DimMinimum<R, C>, C>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, C>,
     {
         let (nrows, ncols) = self.lu.shape_generic();
         self.lu.rows_generic(0, nrows.min(ncols)).upper_triangle()
@@ -197,8 +197,8 @@ where
         OMatrix<T, DimMinimum<R, C>, C>,
     )
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>
-            + Allocator<T, DimMinimum<R, C>, C>
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>
+            + Allocator<DimMinimum<R, C>, C>
             + Reallocator<T, R, C, R, DimMinimum<R, C>>,
     {
         // Use reallocation for either l or u.
@@ -211,7 +211,7 @@ where
 
 impl<T: ComplexField, D: DimMin<D, Output = D>> LU<T, D, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
     ///
@@ -224,7 +224,7 @@ where
     where
         S2: Storage<T, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let mut res = b.clone_owned();
         if self.solve_mut(&mut res) {

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -15,18 +15,18 @@ use crate::storage::StorageMut;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<(usize, usize), D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D>,
          OVector<(usize, usize), D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<(usize, usize), D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OVector<(usize, usize), D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct PermutationSequence<D: Dim>
 where
-    DefaultAllocator: Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D>,
 {
     len: usize,
     ipiv: OVector<(usize, usize), D>,
@@ -34,14 +34,14 @@ where
 
 impl<D: Dim> Copy for PermutationSequence<D>
 where
-    DefaultAllocator: Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D>,
     OVector<(usize, usize), D>: Copy,
 {
 }
 
 impl<D: DimName> PermutationSequence<D>
 where
-    DefaultAllocator: Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Creates a new statically-allocated sequence of `D` identity permutations.
     #[inline]
@@ -53,7 +53,7 @@ where
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl PermutationSequence<Dyn>
 where
-    DefaultAllocator: Allocator<(usize, usize), Dyn>,
+    DefaultAllocator: Allocator<Dyn>,
 {
     /// Creates a new dynamically-allocated sequence of `n` identity permutations.
     #[inline]
@@ -64,7 +64,7 @@ where
 
 impl<D: Dim> PermutationSequence<D>
 where
-    DefaultAllocator: Allocator<(usize, usize), D>,
+    DefaultAllocator: Allocator<D>,
 {
     /// Creates a new sequence of D identity permutations.
     #[inline]

--- a/src/linalg/pow.rs
+++ b/src/linalg/pow.rs
@@ -13,7 +13,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     D: DimMin<D, Output = D>,
     S: StorageMut<T, D, D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Raises this matrix to an integral power `exp` in-place.
     pub fn pow_mut(&mut self, mut exp: u32) {
@@ -59,7 +59,7 @@ where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
     D: DimMin<D, Output = D>,
     S: StorageMut<T, D, D>,
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Raise this matrix to an integral power `exp`.
     #[must_use]

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -17,22 +17,22 @@ use std::mem::MaybeUninit;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Serialize,
          OVector<T, DimMinimum<R, C>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, R, C> +
-                           Allocator<T, DimMinimum<R, C>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<R, C> +
+                           Allocator<DimMinimum<R, C>>,
          OMatrix<T, R, C>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct QR<T: ComplexField, R: DimMin<C>, C: Dim>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
 {
     qr: OMatrix<T, R, C>,
     diag: OVector<T, DimMinimum<R, C>>,
@@ -40,7 +40,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> Copy for QR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
     OMatrix<T, R, C>: Copy,
     OVector<T, DimMinimum<R, C>>: Copy,
 {
@@ -48,7 +48,7 @@ where
 
 impl<T: ComplexField, R: DimMin<C>, C: Dim> QR<T, R, C>
 where
-    DefaultAllocator: Allocator<T, R, C> + Allocator<T, R> + Allocator<T, DimMinimum<R, C>>,
+    DefaultAllocator: Allocator<R, C> + Allocator<R> + Allocator<DimMinimum<R, C>>,
 {
     /// Computes the QR decomposition using householder reflections.
     pub fn new(mut matrix: OMatrix<T, R, C>) -> Self {
@@ -79,7 +79,7 @@ where
     #[must_use]
     pub fn r(&self) -> OMatrix<T, DimMinimum<R, C>, C>
     where
-        DefaultAllocator: Allocator<T, DimMinimum<R, C>, C>,
+        DefaultAllocator: Allocator<DimMinimum<R, C>, C>,
     {
         let (nrows, ncols) = self.qr.shape_generic();
         let mut res = self.qr.rows_generic(0, nrows.min(ncols)).upper_triangle();
@@ -106,7 +106,7 @@ where
     #[must_use]
     pub fn q(&self) -> OMatrix<T, R, DimMinimum<R, C>>
     where
-        DefaultAllocator: Allocator<T, R, DimMinimum<R, C>>,
+        DefaultAllocator: Allocator<R, DimMinimum<R, C>>,
     {
         let (nrows, ncols) = self.qr.shape_generic();
 
@@ -137,7 +137,7 @@ where
     where
         DimMinimum<R, C>: DimMin<C, Output = DimMinimum<R, C>>,
         DefaultAllocator:
-            Allocator<T, R, DimMinimum<R, C>> + Reallocator<T, R, C, DimMinimum<R, C>, C>,
+            Allocator<R, DimMinimum<R, C>> + Reallocator<T, R, C, DimMinimum<R, C>, C>,
     {
         (self.q(), self.unpack_r())
     }
@@ -172,7 +172,7 @@ where
 
 impl<T: ComplexField, D: DimMin<D, Output = D>> QR<T, D, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
     ///
@@ -185,7 +185,7 @@ where
     where
         S2: Storage<T, R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
     {
         let mut res = b.clone_owned();
 

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -25,18 +25,18 @@ use std::mem::MaybeUninit;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D>,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct Schur<T: ComplexField, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     q: OMatrix<T, D, D>,
     t: OMatrix<T, D, D>,
@@ -44,7 +44,7 @@ where
 
 impl<T: ComplexField, D: Dim> Copy for Schur<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
     OMatrix<T, D, D>: Copy,
 {
 }
@@ -52,10 +52,8 @@ where
 impl<T: ComplexField, D: Dim> Schur<T, D>
 where
     D: DimSub<U1>, // For Hessenberg.
-    DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
-        + Allocator<T, DimDiff<D, U1>>
-        + Allocator<T, D, D>
-        + Allocator<T, D>,
+    DefaultAllocator:
+        Allocator<D, DimDiff<D, U1>> + Allocator<DimDiff<D, U1>> + Allocator<D, D> + Allocator<D>,
 {
     /// Computes the Schur decomposition of a square matrix.
     pub fn new(m: OMatrix<T, D, D>) -> Self {
@@ -295,7 +293,7 @@ where
     fn do_complex_eigenvalues(t: &OMatrix<T, D, D>, out: &mut UninitVector<NumComplex<T>, D>)
     where
         T: RealField,
-        DefaultAllocator: Allocator<NumComplex<T>, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let dim = t.nrows();
         let mut m = 0;
@@ -340,7 +338,7 @@ where
     fn delimit_subproblem(t: &mut OMatrix<T, D, D>, eps: T::RealField, end: usize) -> (usize, usize)
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>>,
     {
         let mut n = end;
 
@@ -406,7 +404,7 @@ where
     pub fn complex_eigenvalues(&self) -> OVector<NumComplex<T>, D>
     where
         T: RealField,
-        DefaultAllocator: Allocator<NumComplex<T>, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut out = Matrix::uninit(self.t.shape_generic().0, Const::<1>);
         Self::do_complex_eigenvalues(&self.t, &mut out);
@@ -420,7 +418,7 @@ fn decompose_2x2<T: ComplexField, D: Dim>(
     compute_q: bool,
 ) -> Option<(Option<OMatrix<T, D, D>>, OMatrix<T, D, D>)>
 where
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     let dim = m.shape_generic().0;
     let mut q = None;
@@ -508,10 +506,8 @@ fn compute_2x2_basis<T: ComplexField, S: Storage<T, U2, U2>>(
 impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S>
 where
     D: DimSub<U1>, // For Hessenberg.
-    DefaultAllocator: Allocator<T, D, DimDiff<D, U1>>
-        + Allocator<T, DimDiff<D, U1>>
-        + Allocator<T, D, D>
-        + Allocator<T, D>,
+    DefaultAllocator:
+        Allocator<D, DimDiff<D, U1>> + Allocator<DimDiff<D, U1>> + Allocator<D, D> + Allocator<D>,
 {
     /// Computes the eigenvalues of this matrix.
     #[must_use]
@@ -561,7 +557,7 @@ where
     // TODO: add balancing?
     where
         T: RealField,
-        DefaultAllocator: Allocator<NumComplex<T>, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let dim = self.shape_generic().0;
         let mut work = Matrix::zeros_generic(dim, Const::<1>);

--- a/src/linalg/solve.rs
+++ b/src/linalg/solve.rs
@@ -18,7 +18,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -39,7 +39,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -196,7 +196,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -217,7 +217,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -288,7 +288,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -309,7 +309,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -457,7 +457,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -475,7 +475,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -594,7 +594,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -612,7 +612,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -666,7 +666,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();
@@ -684,7 +684,7 @@ impl<T: SimdComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
     ) -> OMatrix<T, R2, C2>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<R2, D>,
     {
         let mut res = b.clone_owned();

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -17,22 +17,22 @@ use crate::linalg::SymmetricTridiagonal;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T::RealField, D>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<D>,
          OVector<T::RealField, D>: Serialize,
          OMatrix<T, D, D>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T::RealField, D>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<D>,
          OVector<T::RealField, D>: Deserialize<'de>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct SymmetricEigen<T: ComplexField, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T::RealField, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// The eigenvectors of the decomposed matrix.
     pub eigenvectors: OMatrix<T, D, D>,
@@ -43,7 +43,7 @@ where
 
 impl<T: ComplexField, D: Dim> Copy for SymmetricEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T::RealField, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
     OMatrix<T, D, D>: Copy,
     OVector<T::RealField, D>: Copy,
 {
@@ -51,7 +51,7 @@ where
 
 impl<T: ComplexField, D: Dim> SymmetricEigen<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T::RealField, D>,
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
 {
     /// Computes the eigendecomposition of the given symmetric matrix.
     ///
@@ -59,7 +59,7 @@ where
     pub fn new(m: OMatrix<T, D, D>) -> Self
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, DimDiff<D, U1>> + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>> + Allocator<DimDiff<D, U1>>,
     {
         Self::try_new(m, T::RealField::default_epsilon(), 0).unwrap()
     }
@@ -78,7 +78,7 @@ where
     pub fn try_new(m: OMatrix<T, D, D>, eps: T::RealField, max_niter: usize) -> Option<Self>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, DimDiff<D, U1>> + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>> + Allocator<DimDiff<D, U1>>,
     {
         Self::do_decompose(m, true, eps, max_niter).map(|(vals, vecs)| SymmetricEigen {
             eigenvectors: vecs.unwrap(),
@@ -94,7 +94,7 @@ where
     ) -> Option<(OVector<T::RealField, D>, Option<OMatrix<T, D, D>>)>
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T, DimDiff<D, U1>> + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>> + Allocator<DimDiff<D, U1>>,
     {
         assert!(
             matrix.is_square(),
@@ -244,7 +244,7 @@ where
     ) -> (usize, usize)
     where
         D: DimSub<U1>,
-        DefaultAllocator: Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>>,
     {
         let mut n = end;
 
@@ -321,10 +321,8 @@ pub fn wilkinson_shift<T: ComplexField>(tmm: T, tnn: T, tmn: T) -> T {
  */
 impl<T: ComplexField, D: DimSub<U1>, S: Storage<T, D, D>> SquareMatrix<T, D, S>
 where
-    DefaultAllocator: Allocator<T, D, D>
-        + Allocator<T, DimDiff<D, U1>>
-        + Allocator<T::RealField, D>
-        + Allocator<T::RealField, DimDiff<D, U1>>,
+    DefaultAllocator:
+        Allocator<D, D> + Allocator<DimDiff<D, U1>> + Allocator<D> + Allocator<DimDiff<D, U1>>,
 {
     /// Computes the eigenvalues of this symmetric matrix.
     ///

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -14,22 +14,22 @@ use std::mem::MaybeUninit;
 #[cfg_attr(feature = "serde-serialize-no-std", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(serialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(serialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Serialize,
          OVector<T, DimDiff<D, U1>>: Serialize"))
 )]
 #[cfg_attr(
     feature = "serde-serialize-no-std",
-    serde(bound(deserialize = "DefaultAllocator: Allocator<T, D, D> +
-                           Allocator<T, DimDiff<D, U1>>,
+    serde(bound(deserialize = "DefaultAllocator: Allocator<D, D> +
+                           Allocator<DimDiff<D, U1>>,
          OMatrix<T, D, D>: Deserialize<'de>,
          OVector<T, DimDiff<D, U1>>: Deserialize<'de>"))
 )]
 #[derive(Clone, Debug)]
 pub struct SymmetricTridiagonal<T: ComplexField, D: DimSub<U1>>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     tri: OMatrix<T, D, D>,
     off_diagonal: OVector<T, DimDiff<D, U1>>,
@@ -37,7 +37,7 @@ where
 
 impl<T: ComplexField, D: DimSub<U1>> Copy for SymmetricTridiagonal<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
     OMatrix<T, D, D>: Copy,
     OVector<T, DimDiff<D, U1>>: Copy,
 {
@@ -45,7 +45,7 @@ where
 
 impl<T: ComplexField, D: DimSub<U1>> SymmetricTridiagonal<T, D>
 where
-    DefaultAllocator: Allocator<T, D, D> + Allocator<T, DimDiff<D, U1>>,
+    DefaultAllocator: Allocator<D, D> + Allocator<DimDiff<D, U1>>,
 {
     /// Computes the tridiagonalization of the symmetric matrix `m`.
     ///
@@ -108,7 +108,7 @@ where
         OVector<T::RealField, DimDiff<D, U1>>,
     )
     where
-        DefaultAllocator: Allocator<T::RealField, D> + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<D> + Allocator<DimDiff<D, U1>>,
     {
         let diag = self.diagonal();
         let q = self.q();
@@ -124,7 +124,7 @@ where
         OVector<T::RealField, DimDiff<D, U1>>,
     )
     where
-        DefaultAllocator: Allocator<T::RealField, D> + Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<D> + Allocator<DimDiff<D, U1>>,
     {
         (self.diagonal(), self.off_diagonal.map(T::modulus))
     }
@@ -133,7 +133,7 @@ where
     #[must_use]
     pub fn diagonal(&self) -> OVector<T::RealField, D>
     where
-        DefaultAllocator: Allocator<T::RealField, D>,
+        DefaultAllocator: Allocator<D>,
     {
         self.tri.map_diagonal(|e| e.real())
     }
@@ -142,7 +142,7 @@ where
     #[must_use]
     pub fn off_diagonal(&self) -> OVector<T::RealField, DimDiff<D, U1>>
     where
-        DefaultAllocator: Allocator<T::RealField, DimDiff<D, U1>>,
+        DefaultAllocator: Allocator<DimDiff<D, U1>>,
     {
         self.off_diagonal.map(T::modulus)
     }

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -21,7 +21,7 @@ use simba::scalar::RealField;
 #[derive(Clone, Debug)]
 pub struct UDU<T: RealField, D: Dim>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     /// The upper triangular matrix resulting from the factorization
     pub u: OMatrix<T, D, D>,
@@ -31,7 +31,7 @@ where
 
 impl<T: RealField, D: Dim> Copy for UDU<T, D>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
     OVector<T, D>: Copy,
     OMatrix<T, D, D>: Copy,
 {
@@ -39,7 +39,7 @@ where
 
 impl<T: RealField, D: Dim> UDU<T, D>
 where
-    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D, D>,
 {
     /// Computes the UDU^T factorization.
     ///

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -257,7 +257,7 @@ where
     ScalarStrategy::Value: Scalar,
     R: Dim,
     C: Dim,
-    DefaultAllocator: Allocator<ScalarStrategy::Value, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     matrix_(value_strategy, rows.into(), cols.into())
 }
@@ -273,7 +273,7 @@ where
     ScalarStrategy::Value: Scalar,
     R: Dim,
     C: Dim,
-    DefaultAllocator: Allocator<ScalarStrategy::Value, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     let nrows = rows.lower_bound().value()..=rows.upper_bound().value();
     let ncols = cols.lower_bound().value()..=cols.upper_bound().value();
@@ -327,7 +327,7 @@ where
     ScalarStrategy: Strategy + Clone + 'static,
     ScalarStrategy::Value: Scalar,
     D: Dim,
-    DefaultAllocator: Allocator<ScalarStrategy::Value, D>,
+    DefaultAllocator: Allocator<D>,
 {
     matrix_(value_strategy, length.into(), Const::<1>.into())
 }
@@ -395,7 +395,7 @@ where
     R: Dim,
     C: Dim,
     MatrixParameters<T::Parameters, R, C>: Default,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Parameters = MatrixParameters<T::Parameters, R, C>;
 
@@ -413,7 +413,7 @@ pub struct MatrixStrategy<NStrategy, R: Dim, C: Dim>
 where
     NStrategy: Strategy,
     NStrategy::Value: Scalar,
-    DefaultAllocator: Allocator<NStrategy::Value, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     // For now we only internally hold a boxed strategy. The reason for introducing this
     // separate wrapper struct is so that we can replace the strategy logic with custom logic
@@ -427,7 +427,7 @@ where
     NStrategy::Value: Scalar,
     R: Dim,
     C: Dim,
-    DefaultAllocator: Allocator<NStrategy::Value, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Tree = MatrixValueTree<NStrategy::Value, R, C>;
     type Value = OMatrix<NStrategy::Value, R, C>;
@@ -446,7 +446,7 @@ where
     T: Scalar,
     R: Dim,
     C: Dim,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     // For now we only wrap a boxed value tree. The reason for wrapping is that this allows us
     // to swap out the value tree logic down the road without significant breaking changes.
@@ -458,7 +458,7 @@ where
     T: Scalar,
     R: Dim,
     C: Dim,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Value = OMatrix<T, R, C>;
 

--- a/src/sparse/cs_matrix.rs
+++ b/src/sparse/cs_matrix.rs
@@ -106,7 +106,7 @@ pub trait CsStorageMut<T, R, C = U1>:
 #[derive(Clone, Debug, PartialEq)]
 pub struct CsVecStorage<T: Scalar, R: Dim, C: Dim>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     pub(crate) shape: (R, C),
     pub(crate) p: OVector<usize, C>,
@@ -116,7 +116,7 @@ where
 
 impl<T: Scalar, R: Dim, C: Dim> CsVecStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     /// The value buffer of this storage.
     #[must_use]
@@ -137,11 +137,11 @@ where
     }
 }
 
-impl<T: Scalar, R: Dim, C: Dim> CsVecStorage<T, R, C> where DefaultAllocator: Allocator<usize, C> {}
+impl<T: Scalar, R: Dim, C: Dim> CsVecStorage<T, R, C> where DefaultAllocator: Allocator<C> {}
 
 impl<'a, T: Scalar, R: Dim, C: Dim> CsStorageIter<'a, T, R, C> for CsVecStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     type ColumnEntries = ColumnEntries<'a, T>;
     type ColumnRowIndices = iter::Cloned<slice::Iter<'a, usize>>;
@@ -161,7 +161,7 @@ where
 
 impl<T: Scalar, R: Dim, C: Dim> CsStorage<T, R, C> for CsVecStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     #[inline]
     fn shape(&self) -> (R, C) {
@@ -207,7 +207,7 @@ where
 
 impl<'a, T: Scalar, R: Dim, C: Dim> CsStorageIterMut<'a, T, R, C> for CsVecStorage<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     type ValuesMut = slice::IterMut<'a, T>;
     type ColumnEntriesMut = iter::Zip<iter::Cloned<slice::Iter<'a, usize>>, slice::IterMut<'a, T>>;
@@ -228,7 +228,7 @@ where
 }
 
 impl<T: Scalar, R: Dim, C: Dim> CsStorageMut<T, R, C> for CsVecStorage<T, R, C> where
-    DefaultAllocator: Allocator<usize, C>
+    DefaultAllocator: Allocator<C>
 {
 }
 
@@ -257,7 +257,7 @@ pub type CsVector<T, R = Dyn, S = CsVecStorage<T, R, U1>> = CsMatrix<T, R, U1, S
 
 impl<T: Scalar, R: Dim, C: Dim> CsMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     /// Creates a new compressed sparse column matrix with the specified dimension and
     /// `nvals` possible non-zero values.
@@ -295,7 +295,7 @@ where
     ) -> Self
     where
         T: Zero + ClosedAdd,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         assert_eq!(ncols.value(), p.len(), "Invalid inptr size.");
         assert_eq!(i.len(), vals.len(), "Invalid value size.");
@@ -421,7 +421,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: CsStorage<T, R, C>> CsMatrix<T, R, C, S> {
     #[must_use = "This function does not mutate the matrix. Consider using the return value or removing the function call. There's also transpose_mut() for square matrices."]
     pub fn transpose(&self) -> CsMatrix<T, C, R>
     where
-        DefaultAllocator: Allocator<usize, R>,
+        DefaultAllocator: Allocator<R>,
     {
         let (nrows, ncols) = self.data.shape();
 
@@ -462,12 +462,12 @@ impl<T: Scalar, R: Dim, C: Dim, S: CsStorageMut<T, R, C>> CsMatrix<T, R, C, S> {
 
 impl<T: Scalar, R: Dim, C: Dim> CsMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C>,
+    DefaultAllocator: Allocator<C>,
 {
     pub(crate) fn sort(&mut self)
     where
         T: Zero,
-        DefaultAllocator: Allocator<T, R>,
+        DefaultAllocator: Allocator<R>,
     {
         // Size = R
         let nrows = self.data.shape().0;

--- a/src/sparse/cs_matrix_cholesky.rs
+++ b/src/sparse/cs_matrix_cholesky.rs
@@ -8,7 +8,7 @@ use crate::{Const, DefaultAllocator, Dim, Matrix, OVector, RealField};
 /// The cholesky decomposition of a column compressed sparse matrix.
 pub struct CsCholesky<T: RealField, D: Dim>
 where
-    DefaultAllocator: Allocator<usize, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D>,
 {
     // Non-zero pattern of the original matrix upper-triangular part.
     // Unlike the original matrix, the `original_p` array does contain the last sentinel value
@@ -28,7 +28,7 @@ where
 
 impl<T: RealField, D: Dim> CsCholesky<T, D>
 where
-    DefaultAllocator: Allocator<usize, D> + Allocator<T, D>,
+    DefaultAllocator: Allocator<D> + Allocator<D>,
 {
     /// Computes the cholesky decomposition of the sparse matrix `m`.
     pub fn new(m: &CsMatrix<T, D, D>) -> Self {

--- a/src/sparse/cs_matrix_conversion.rs
+++ b/src/sparse/cs_matrix_conversion.rs
@@ -22,7 +22,7 @@ impl<'a, T: Scalar + Zero + ClosedAdd> CsMatrix<T> {
 
 impl<'a, T: Scalar + Zero + ClosedAdd, R: Dim, C: Dim> CsMatrix<T, R, C>
 where
-    DefaultAllocator: Allocator<usize, C> + Allocator<T, R>,
+    DefaultAllocator: Allocator<C> + Allocator<R>,
 {
     /// Creates a column-compressed sparse matrix from a sparse matrix in triplet form.
     pub fn from_triplet_generic(
@@ -68,7 +68,7 @@ where
 impl<'a, T: Scalar + Zero, R: Dim, C: Dim, S> From<CsMatrix<T, R, C, S>> for OMatrix<T, R, C>
 where
     S: CsStorage<T, R, C>,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     fn from(m: CsMatrix<T, R, C, S>) -> Self {
         let (nrows, ncols) = m.data.shape();
@@ -87,7 +87,7 @@ where
 impl<'a, T: Scalar + Zero, R: Dim, C: Dim, S> From<Matrix<T, R, C, S>> for CsMatrix<T, R, C>
 where
     S: Storage<T, R, C>,
-    DefaultAllocator: Allocator<T, R, C> + Allocator<usize, C>,
+    DefaultAllocator: Allocator<R, C> + Allocator<C>,
 {
     fn from(m: Matrix<T, R, C, S>) -> Self {
         let (nrows, ncols) = m.data.shape();

--- a/src/sparse/cs_matrix_ops.rs
+++ b/src/sparse/cs_matrix_ops.rs
@@ -21,7 +21,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: CsStorage<T, R, C>> CsMatrix<T, R, C, S> {
     ) -> usize
     where
         T: ClosedAdd + ClosedMul,
-        DefaultAllocator: Allocator<usize, C2>,
+        DefaultAllocator: Allocator<C2>,
     {
         for (i, val) in self.data.column_entries(j) {
             if timestamps[i] < timestamp {
@@ -134,7 +134,7 @@ where
     S1: CsStorage<T, R1, C1>,
     S2: CsStorage<T, R2, C2>,
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
-    DefaultAllocator: Allocator<usize, C2> + Allocator<usize, R1> + Allocator<T, R1>,
+    DefaultAllocator: Allocator<C2> + Allocator<R1> + Allocator<R1>,
 {
     type Output = CsMatrix<T, R1, C2>;
 
@@ -227,7 +227,7 @@ where
     S1: CsStorage<T, R1, C1>,
     S2: CsStorage<T, R2, C2>,
     ShapeConstraint: DimEq<R1, R2> + DimEq<C1, C2>,
-    DefaultAllocator: Allocator<usize, C2> + Allocator<usize, R1> + Allocator<T, R1>,
+    DefaultAllocator: Allocator<C2> + Allocator<R1> + Allocator<R1>,
 {
     type Output = CsMatrix<T, R1, C2>;
 

--- a/src/sparse/cs_matrix_solve.rs
+++ b/src/sparse/cs_matrix_solve.rs
@@ -13,7 +13,7 @@ impl<T: RealField, D: Dim, S: CsStorage<T, D, D>> CsMatrix<T, D, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<D, R2>,
     {
         let mut b = b.clone_owned();
@@ -32,7 +32,7 @@ impl<T: RealField, D: Dim, S: CsStorage<T, D, D>> CsMatrix<T, D, D, S> {
     ) -> Option<OMatrix<T, R2, C2>>
     where
         S2: Storage<T, R2, C2>,
-        DefaultAllocator: Allocator<T, R2, C2>,
+        DefaultAllocator: Allocator<R2, C2>,
         ShapeConstraint: SameNumberOfRows<D, R2>,
     {
         let mut b = b.clone_owned();
@@ -144,7 +144,7 @@ impl<T: RealField, D: Dim, S: CsStorage<T, D, D>> CsMatrix<T, D, D, S> {
     ) -> Option<CsVector<T, D2>>
     where
         S2: CsStorage<T, D2>,
-        DefaultAllocator: Allocator<bool, D> + Allocator<T, D2> + Allocator<usize, D2>,
+        DefaultAllocator: Allocator<D> + Allocator<D2>,
         ShapeConstraint: SameNumberOfRows<D, D2>,
     {
         let mut reach = Vec::new();
@@ -208,7 +208,7 @@ impl<T: RealField, D: Dim, S: CsStorage<T, D, D>> CsMatrix<T, D, D, S> {
         xi: &mut Vec<usize>,
     ) where
         S2: CsStorage<T, D2>,
-        DefaultAllocator: Allocator<bool, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut visited = OVector::repeat_generic(self.data.shape().1, U1, false);
         let mut stack = Vec::new();
@@ -252,7 +252,7 @@ impl<T: RealField, D: Dim, S: CsStorage<T, D, D>> CsMatrix<T, D, D, S> {
     fn lower_triangular_reach<D2: Dim, S2>(&self, b: &CsVector<T, D2, S2>, xi: &mut Vec<usize>)
     where
         S2: CsStorage<T, D2>,
-        DefaultAllocator: Allocator<bool, D>,
+        DefaultAllocator: Allocator<D>,
     {
         let mut visited = OVector::repeat_generic(self.data.shape().1, Const::<1>, false);
         let mut stack = Vec::new();

--- a/src/sparse/cs_utils.rs
+++ b/src/sparse/cs_utils.rs
@@ -3,7 +3,7 @@ use crate::{DefaultAllocator, Dim, OVector};
 
 pub fn cumsum<D: Dim>(a: &mut OVector<usize, D>, b: &mut OVector<usize, D>) -> usize
 where
-    DefaultAllocator: Allocator<usize, D>,
+    DefaultAllocator: Allocator<D>,
 {
     assert!(a.len() == b.len());
     let mut sum = 0;

--- a/src/third_party/alga/alga_matrix.rs
+++ b/src/third_party/alga/alga_matrix.rs
@@ -27,7 +27,7 @@ use std::mem::MaybeUninit;
 impl<T, R: DimName, C: DimName> Identity<Additive> for OMatrix<T, R, C>
 where
     T: Scalar + Zero,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn identity() -> Self {
@@ -38,7 +38,7 @@ where
 impl<T, R: DimName, C: DimName> AbstractMagma<Additive> for OMatrix<T, R, C>
 where
     T: Scalar + ClosedAdd,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn operate(&self, other: &Self) -> Self {
@@ -49,7 +49,7 @@ where
 impl<T, R: DimName, C: DimName> TwoSidedInverse<Additive> for OMatrix<T, R, C>
 where
     T: Scalar + ClosedNeg,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     #[must_use = "Did you mean to use two_sided_inverse_mut()?"]
@@ -67,7 +67,7 @@ macro_rules! inherit_additive_structure(
     ($($marker: ident<$operator: ident> $(+ $bounds: ident)*),* $(,)*) => {$(
         impl<T, R: DimName, C: DimName> $marker<$operator> for OMatrix<T, R, C>
             where T: Scalar + $marker<$operator> $(+ $bounds)*,
-                  DefaultAllocator: Allocator<T, R, C> { }
+                  DefaultAllocator: Allocator<R, C> { }
     )*}
 );
 
@@ -83,7 +83,7 @@ inherit_additive_structure!(
 impl<T, R: DimName, C: DimName> AbstractModule for OMatrix<T, R, C>
 where
     T: Scalar + RingCommutative,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type AbstractRing = T;
 
@@ -96,7 +96,7 @@ where
 impl<T, R: DimName, C: DimName> Module for OMatrix<T, R, C>
 where
     T: Scalar + RingCommutative,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Ring = T;
 }
@@ -104,7 +104,7 @@ where
 impl<T, R: DimName, C: DimName> VectorSpace for OMatrix<T, R, C>
 where
     T: Scalar + Field,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type Field = T;
 }
@@ -112,7 +112,7 @@ where
 impl<T, R: DimName, C: DimName> FiniteDimVectorSpace for OMatrix<T, R, C>
 where
     T: Scalar + Field,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn dimension() -> usize {
@@ -154,7 +154,7 @@ impl<
     > NormedSpace for OMatrix<T, R, C>
 where
     <T as ComplexField>::RealField: simba::scalar::RealField,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     type RealField = <T as ComplexField>::RealField;
     type ComplexField = T;
@@ -202,7 +202,7 @@ impl<
     > InnerSpace for OMatrix<T, R, C>
 where
     <T as ComplexField>::RealField: simba::scalar::RealField,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn angle(&self, other: &Self) -> <T as ComplexField>::RealField {
@@ -226,7 +226,7 @@ impl<
     > FiniteDimInnerSpace for OMatrix<T, R, C>
 where
     <T as ComplexField>::RealField: simba::scalar::RealField,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn orthonormalize(vs: &mut [Self]) -> usize {
@@ -362,7 +362,7 @@ where
 impl<T, D: DimName> Identity<Multiplicative> for OMatrix<T, D, D>
 where
     T: Scalar + Zero + One,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     #[inline]
     fn identity() -> Self {
@@ -373,7 +373,7 @@ where
 impl<T, D: DimName> AbstractMagma<Multiplicative> for OMatrix<T, D, D>
 where
     T: Scalar + Zero + One + ClosedAdd + ClosedMul,
-    DefaultAllocator: Allocator<T, D, D>,
+    DefaultAllocator: Allocator<D, D>,
 {
     #[inline]
     fn operate(&self, other: &Self) -> Self {
@@ -385,7 +385,7 @@ macro_rules! impl_multiplicative_structure(
     ($($marker: ident<$operator: ident> $(+ $bounds: ident)*),* $(,)*) => {$(
         impl<T, D: DimName> $marker<$operator> for OMatrix<T, D, D>
             where T: Scalar + Zero + One + ClosedAdd + ClosedMul + $marker<$operator> $(+ $bounds)*,
-                  DefaultAllocator: Allocator<T, D, D> { }
+                  DefaultAllocator: Allocator<D, D> { }
     )*}
 );
 
@@ -402,7 +402,7 @@ impl_multiplicative_structure!(
 impl<T, R: Dim, C: Dim> MeetSemilattice for OMatrix<T, R, C>
 where
     T: Scalar + MeetSemilattice,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn meet(&self, other: &Self) -> Self {
@@ -413,7 +413,7 @@ where
 impl<T, R: Dim, C: Dim> JoinSemilattice for OMatrix<T, R, C>
 where
     T: Scalar + JoinSemilattice,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn join(&self, other: &Self) -> Self {
@@ -424,7 +424,7 @@ where
 impl<T, R: Dim, C: Dim> Lattice for OMatrix<T, R, C>
 where
     T: Scalar + Lattice,
-    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<R, C>,
 {
     #[inline]
     fn meet_join(&self, other: &Self) -> (Self, Self) {

--- a/src/third_party/alga/alga_transform.rs
+++ b/src/third_party/alga/alga_transform.rs
@@ -20,7 +20,7 @@ impl<T: RealField + simba::scalar::RealField, C, const D: usize> Identity<Multip
 where
     Const<D>: DimNameAdd<U1>,
     C: TCategory,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn identity() -> Self {
@@ -33,7 +33,7 @@ impl<T: RealField + simba::scalar::RealField, C, const D: usize> TwoSidedInverse
 where
     Const<D>: DimNameAdd<U1>,
     C: SubTCategoryOf<TProjective>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     #[must_use = "Did you mean to use two_sided_inverse_mut()?"]
@@ -52,7 +52,7 @@ impl<T: RealField + simba::scalar::RealField, C, const D: usize> AbstractMagma<M
 where
     Const<D>: DimNameAdd<U1>,
     C: TCategory,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn operate(&self, rhs: &Self) -> Self {
@@ -66,7 +66,7 @@ macro_rules! impl_multiplicative_structures(
             where
                   Const<D>: DimNameAdd<U1>,
                   C: TCategory,
-                  DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> { }
+                  DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> { }
     )*}
 );
 
@@ -76,7 +76,7 @@ macro_rules! impl_inversible_multiplicative_structures(
             where
                   Const<D>: DimNameAdd<U1>,
                   C: SubTCategoryOf<TProjective>,
-                  DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> { }
+                  DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> { }
     )*}
 );
 
@@ -101,8 +101,8 @@ where
     Const<D>: DimNameAdd<U1>,
     T: RealField + simba::scalar::RealField,
     C: TCategory,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn transform_point(&self, pt: &Point<T, D>) -> Point<T, D> {
@@ -120,8 +120,8 @@ where
     Const<D>: DimNameAdd<U1>,
     T: RealField + simba::scalar::RealField,
     C: SubTCategoryOf<TProjective>,
-    DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
-        + Allocator<T, DimNameSum<Const<D>, U1>>,
+    DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>
+        + Allocator<DimNameSum<Const<D>, U1>>,
 {
     #[inline]
     fn inverse_transform_point(&self, pt: &Point<T, D>) -> Point<T, D> {
@@ -139,7 +139,7 @@ where
 // impl<T, C, const D: usize> AffineTransformation<Point<T, D>> for Transform<T, C, D>
 //     where T:  RealField,
 //           C: SubTCategoryOf<TAffine>,
-//           DefaultAllocator: Allocator<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
+//           DefaultAllocator: Allocator<DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
 //     type PreRotation       = Rotation<T, D>;
 //     type NonUniformScaling = OVector<T, D>;
 //     type PostRotation      = Rotation<T, D>;

--- a/src/third_party/mint/mint_matrix.rs
+++ b/src/third_party/mint/mint_matrix.rs
@@ -11,7 +11,7 @@ macro_rules! impl_from_into_mint_1D(
     ($($NRows: ident => $VT:ident [$SZ: expr]);* $(;)*) => {$(
         impl<T> From<mint::$VT<T>> for OMatrix<T, $NRows, U1>
         where T: Scalar,
-              DefaultAllocator: Allocator<T, $NRows, U1> {
+              DefaultAllocator: Allocator<$NRows, U1> {
             #[inline]
             fn from(v: mint::$VT<T>) -> Self {
                 unsafe {
@@ -81,7 +81,7 @@ macro_rules! impl_from_into_mint_2D(
     ($(($NRows: ty, $NCols: ty) => $MV:ident{ $($component:ident),* }[$SZRows: expr]);* $(;)*) => {$(
         impl<T> From<mint::$MV<T>> for OMatrix<T, $NRows, $NCols>
         where T: Scalar,
-              DefaultAllocator: Allocator<T, $NRows, $NCols> {
+              DefaultAllocator: Allocator<$NRows, $NCols> {
             #[inline]
             fn from(m: mint::$MV<T>) -> Self {
                 unsafe {
@@ -101,7 +101,7 @@ macro_rules! impl_from_into_mint_2D(
 
         impl<T> Into<mint::$MV<T>> for OMatrix<T, $NRows, $NCols>
         where T: Scalar,
-              DefaultAllocator: Allocator<T, $NRows, $NCols> {
+              DefaultAllocator: Allocator<$NRows, $NCols> {
             #[inline]
             fn into(self) -> mint::$MV<T> {
                 unsafe {

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -1161,8 +1161,8 @@ fn generic_omatrix_to_string<D>(
 ) -> (String, String)
 where
     D: nalgebra::Dim,
-    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<f64, D>,
-    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<f64, D, D>,
+    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<D>,
+    nalgebra::DefaultAllocator: nalgebra::base::allocator::Allocator<D, D>,
 {
     (vector.to_string(), matrix.to_string())
 }

--- a/tests/linalg/eigen.rs
+++ b/tests/linalg/eigen.rs
@@ -208,8 +208,8 @@ fn very_small_deviation_from_identity_issue_1368() {
 // fn verify_eigenvectors<D: Dim>(m: OMatrix<f64, D>, mut eig: RealEigen<f64, D>) -> bool
 //     where DefaultAllocator: Allocator<f64, D, D>   +
 //                             Allocator<f64, D>      +
-//                             Allocator<usize, D, D> +
-//                             Allocator<usize, D>,
+//                             Allocator<D, D> +
+//                             Allocator<D>,
 //           OMatrix<f64, D>: Display,
 //           OVector<f64, D>: Display {
 //     let mv = &m * &eig.eigenvectors;

--- a/tests/proptest/mod.rs
+++ b/tests/proptest/mod.rs
@@ -105,7 +105,7 @@ pub fn dmatrix_<ScalarStrategy>(
 where
     ScalarStrategy: Strategy + Clone + 'static,
     ScalarStrategy::Value: Scalar,
-    DefaultAllocator: Allocator<ScalarStrategy::Value, Dyn, Dyn>,
+    DefaultAllocator: Allocator<Dyn, Dyn>,
 {
     matrix(scalar_strategy, PROPTEST_MATRIX_DIM, PROPTEST_MATRIX_DIM)
 }
@@ -114,7 +114,7 @@ where
 // where
 //     RangeInclusive<T>: Strategy<Value = T>,
 //     T: Scalar + PartialEq + Copy,
-//     DefaultAllocator: Allocator<T, Dyn>,
+//     DefaultAllocator: Allocator<Dyn>,
 // {
 //     vector(range, PROPTEST_MATRIX_DIM)
 // }


### PR DESCRIPTION
This is based on https://github.com/dimforge/nalgebra/issues/1396. I thought GAT was only stabilized for lifetime parameters, but it looks like it also works for actual type parameters.

This doesn’t eliminate the need for explicit `DefaultAllocator: Allocator` bounds, bust it least simplifies it by not exposing implementation details about the scalar type.

I haven’t been very diligent at checking if we now have some duplicate bounds. For example if `Allocator<N1, R, C> + Allocator<N2, R, C>` got transformed to `Allocator<R, C> + Allocator<R, C>` so one of them can be removed.