### PR TITLE
Update inverse.rs - improved code doc try_inverse_mut

### DIFF
--- a/src/linalg/inverse.rs
+++ b/src/linalg/inverse.rs
@@ -29,8 +29,8 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S> {
 }
 
 impl<T: ComplexField, D: Dim, S: StorageMut<T, D, D>> SquareMatrix<T, D, S> {
-    /// Attempts to invert this square matrix in-place. Returns `false` and leaves `self` untouched if
-    /// inversion fails.
+    /// Attempts to invert this square matrix in-place. Returns `false` if the
+    /// inversion fails. Note that `self` may be modified even if the inversion fails.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The "and leaves `self` untouched" part of the code doc was wrong. Self may be modified before early false return.