### PR TITLE
Fix typo in ArrayStorage documentation comment

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -27,7 +27,7 @@ use std::mem;
  * Static RawStorage.
  *
  */
-/// A array-based statically sized matrix data storage.
+/// An array-based statically sized matrix data storage.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(


### PR DESCRIPTION
This fixes a typo in the `ArrayStorage` documentation comment. 
It currently says "A array-based statically sized matrix data storage", the fix is to say "An array-based [...]".