### PR TITLE
Add AsRef<[T]> and AsMut<[T]> trait implementations

### DIFF
--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -78,6 +78,20 @@ impl<T: Debug, const R: usize, const C: usize> Debug for ArrayStorage<T, R, C> {
     }
 }
 
+impl<T, const R: usize, const C: usize> AsRef<[T]> for ArrayStorage<T, R, C> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, const R: usize, const C: usize> AsMut<[T]> for ArrayStorage<T, R, C> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
 unsafe impl<T, const R: usize, const C: usize> RawStorage<T, Const<R>, Const<C>>
     for ArrayStorage<T, R, C>
 {

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1351,6 +1351,20 @@ impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C> + IsContiguous> Matrix<T, R, C
     }
 }
 
+impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> Matrix<T, R, C, S> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C> + IsContiguous> Matrix<T, R, C, S> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
 impl<T: Scalar, D: Dim, S: RawStorageMut<T, D, D>> Matrix<T, D, D, S> {
     /// Transposes the square matrix `self` in-place.
     pub fn transpose_mut(&mut self) {

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -226,6 +226,20 @@ impl<T, R: Dim, C: Dim> From<VecStorage<T, R, C>> for Vec<T> {
     }
 }
 
+impl<T, R: Dim, C: Dim> AsRef<[T]> for VecStorage<T, R, C> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, R: Dim, C: Dim> AsMut<[T]> for VecStorage<T, R, C> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
 /*
  *
  * Dyn − Static


### PR DESCRIPTION
This adds `AsRef<[T]>` and `AsMut<[T]>` for `ArrayStorage`, `VecStorage` and `Matrix` types with `IsContiguous` storage implementations.

---

I understand it is a bit of a duplication given the `as_slice` and `as_mut_slice` implementations, but I am hoping that given the `core::convert` types, this makes adoption even easier. I stumbled over the lack of these implementations while attempting to implement `nalgebra` support in my `no_std`-targeted Kalman Filtering library (https://github.com/sunsided/minikalman-rs/issues/13).