### PR TITLE
Release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,27 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## [0.33.0] (23 June 2024)
+
+### Fixed
+
+- Fix a memory leak in `Matrix::generic_resize`.
+- Fix `glm::is_null` to check the vector magnitude instead of individual components.
+- Ensure that inverting a 4x4 matrix leaves it unchanged if the inversion fails.
 
 ### Added
 
 - Add the `glam-0.28` feature to enable conversion from/to types from `glam` v0.28.
+- Add a `stack!` macro for concatenating matrices. See [#1375](https://github.com/dimforge/nalgebra/pull/1375).
 
-### Removed
+### Modified
 
-- The `cuda` feature has been removed, as the toolchain it depends on
-  is long abandoned.
+- The `cuda` feature has been removed, as the toolchain it depends on is long abandoned.
+- Update to `simba` 0.9. See the [changelog](https://github.com/dimforge/simba/blob/master/CHANGELOG) of `simba` for
+  details.
+- Update the `nalgebra-macros` crate to `syn` 2.0.
+- Remove the scalar type `T` from the `Allocator` trait parameters. Instead of `Allocator<T, R, C>`, use the simpler
+  `Allocator<R, C>`.
 
 ## [0.32.6] (12 June 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."
@@ -74,7 +74,7 @@ slow-tests = []
 rkyv-safe-deser = ["rkyv-serialize", "rkyv/validation"]
 
 [dependencies]
-nalgebra-macros = { version = "0.2.1", path = "nalgebra-macros", optional = true }
+nalgebra-macros = { version = "0.2.2", path = "nalgebra-macros", optional = true }
 typenum = "1.12"
 rand-package = { package = "rand", version = "0.8", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
     <a href="https://discord.gg/vt9DJSW">
         <img src="https://img.shields.io/discord/507548572338880513.svg?logo=discord&colorB=7289DA">
     </a>
-    <a href="https://circleci.com/gh/dimforge/nalgebra">
-        <img src="https://circleci.com/gh/dimforge/nalgebra.svg?style=svg" alt="Build status">
-    </a>
     <a href="https://crates.io/crates/nalgebra">
          <img src="https://img.shields.io/crates/v/nalgebra.svg?style=flat-square" alt="crates.io">
     </a>
@@ -17,7 +14,7 @@
 </p>
 <p align = "center">
     <strong>
-        <a href="https://nalgebra.org">Users guide</a> | <a href="https://docs.rs/nalgebra/latest/nalgebra/">Documentation</a> | <a href="https://discourse.nphysics.org/c/nalgebra">Forum</a>
+        <a href="https://nalgebra.org">Users guide</a> | <a href="https://docs.rs/nalgebra/latest/nalgebra/">Documentation</a>
     </strong>
 </p>
 

--- a/examples/cargo/Cargo.toml
+++ b/examples/cargo/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name    = "example-using-nalgebra"
+name = "example-using-nalgebra"
 version = "0.0.0"
-authors = [ "You" ]
+authors = ["You"]
 
 [dependencies]
-nalgebra = "0.32.0"
+nalgebra = "0.33.0"
 
 [[bin]]
 name = "example"

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-glm"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["sebcrozet <developer@crozet.re>"]
 
 description = "A computer-graphics oriented API for nalgebra, inspired by the C++ GLM library."
@@ -35,4 +35,4 @@ convert-glam018 = ["nalgebra/glam018"]
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 simba = { version = "0.9", default-features = false }
-nalgebra = { path = "..", version = "0.32", default-features = false }
+nalgebra = { path = "..", version = "0.33", default-features = false }

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-lapack"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>"]
 
 description = "Matrix decompositions using nalgebra matrices and Lapack bindings."
@@ -29,7 +29,7 @@ accelerate = ["lapack-src/accelerate"]
 intel-mkl = ["lapack-src/intel-mkl"]
 
 [dependencies]
-nalgebra = { version = "0.32", path = ".." }
+nalgebra = { version = "0.33", path = ".." }
 num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }
 simba = "0.9"
@@ -39,7 +39,7 @@ lapack-src = { version = "0.8", default-features = false }
 # clippy = "*"
 
 [dev-dependencies]
-nalgebra = { version = "0.32", features = ["arbitrary", "rand"], path = ".." }
+nalgebra = { version = "0.33", features = ["arbitrary", "rand"], path = ".." }
 proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = "1"
 approx = "0.5"

--- a/nalgebra-macros/Cargo.toml
+++ b/nalgebra-macros/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "nalgebra-macros"
-version = "0.2.1"
-authors = [ "Andreas Longva", "Sébastien Crozet <developer@crozet.re>" ]
+version = "0.2.2"
+authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
 edition = "2018"
 description = "Procedural macros for nalgebra"
 documentation = "https://www.nalgebra.org/docs"
 homepage = "https://nalgebra.org"
 repository = "https://github.com/dimforge/nalgebra"
 readme = "../README.md"
-categories = [ "science", "mathematics" ]
-keywords = [ "linear", "algebra", "matrix", "vector", "math" ]
+categories = ["science", "mathematics"]
+keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
 
 [lib]
@@ -21,4 +21,4 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-nalgebra = { version = "0.32.1", path = ".." }
+nalgebra = { version = "0.33", path = ".." }

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -1,44 +1,44 @@
 [package]
 name = "nalgebra-sparse"
-version = "0.9.0"
-authors = [ "Andreas Longva", "Sébastien Crozet <developer@crozet.re>" ]
+version = "0.10.0"
+authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
 edition = "2018"
 description = "Sparse matrix computation based on nalgebra."
 documentation = "https://www.nalgebra.org/docs"
 homepage = "https://nalgebra.org"
 repository = "https://github.com/dimforge/nalgebra"
 readme = "../README.md"
-categories = [ "science", "mathematics", "wasm", "no-std" ]
-keywords = [ "linear", "algebra", "matrix", "vector", "math" ]
+categories = ["science", "mathematics", "wasm", "no-std"]
+keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
 
 [features]
 proptest-support = ["proptest", "nalgebra/proptest-support"]
-compare = [ "matrixcompare-core" ]
-serde-serialize = [ "serde/std" ]
+compare = ["matrixcompare-core"]
+serde-serialize = ["serde/std"]
 
 # Enable matrix market I/O
-io      = [ "pest", "pest_derive" ]
+io = ["pest", "pest_derive"]
 
 # Enable to enable running some tests that take a lot of time to run
 slow-tests = []
 
 [dependencies]
-nalgebra = { version="0.32", path = "../" }
+nalgebra = { version = "0.33", path = "../" }
 num-traits = { version = "0.2", default-features = false }
 proptest = { version = "1.0", optional = true }
 matrixcompare-core = { version = "0.1.0", optional = true }
-pest           = { version = "2", optional = true }
-pest_derive    = { version = "2", optional = true }
-serde = { version = "1.0", default-features = false, features = [ "derive" ], optional = true }
+pest = { version = "2", optional = true }
+pest_derive = { version = "2", optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 itertools = "0.13"
-matrixcompare = { version = "0.3.0", features = [ "proptest-support" ] }
-nalgebra = { version="0.32", path = "../", features = ["compare"] }
+matrixcompare = { version = "0.3.0", features = ["proptest-support"] }
+nalgebra = { version = "0.33", path = "../", features = ["compare"] }
 tempfile = "3.3"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]
 # Enable certain features when building docs for docs.rs
-features = [ "proptest-support", "compare", "io"]
+features = ["proptest-support", "compare", "io"]


### PR DESCRIPTION
## [0.33.0] (23 June 2024)

### Fixed

- Fix a memory leak in `Matrix::generic_resize`.
- Fix `glm::is_null` to check the vector magnitude instead of individual components.
- Ensure that inverting a 4x4 matrix leaves it unchanged if the inversion fails.

### Added

- Add the `glam-0.28` feature to enable conversion from/to types from `glam` v0.28.
- Add a `stack!` macro for concatenating matrices. See [#1375](https://github.com/dimforge/nalgebra/pull/1375).

### Modified

- The `cuda` feature has been removed, as the toolchain it depends on is long abandoned.
- Update to `simba` 0.9. See the [changelog](https://github.com/dimforge/simba/blob/master/CHANGELOG) of `simba` for details.
- Update the `nalgebra-macros` crate to `syn` 2.0.
- Remove the scalar type `T` from the `Allocator` trait parameters. Instead of `Allocator<T, R, C>`, use the simpler
  `Allocator<R, C>`.