### PR TITLE
clippy: Fix `clippy::doc_lazy_continuation` lints

### DIFF
--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -236,7 +236,7 @@ impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> Matrix<T, R, C, S> {
     /// * If `shift = 0` then the diagonal is overwritten as well.
     /// * If `shift = 1` then the diagonal is left untouched.
     /// * If `shift > 1`, then the diagonal and the first `shift - 1` subdiagonals are left
-    /// untouched.
+    ///   untouched.
     #[inline]
     pub fn fill_lower_triangle(&mut self, val: T, shift: usize)
     where
@@ -255,7 +255,7 @@ impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> Matrix<T, R, C, S> {
     /// * If `shift = 0` then the diagonal is overwritten as well.
     /// * If `shift = 1` then the diagonal is left untouched.
     /// * If `shift > 1`, then the diagonal and the first `shift - 1` superdiagonals are left
-    /// untouched.
+    ///   untouched.
     #[inline]
     pub fn fill_upper_triangle(&mut self, val: T, shift: usize)
     where

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -140,18 +140,18 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
 /// - `R`: for the matrix number of rows.
 /// - `C`: for the matrix number of columns.
 /// - `S`: for the matrix data storage, i.e., the buffer that actually contains the matrix
-/// components.
+///   components.
 ///
 /// The matrix dimensions parameters `R` and `C` can either be:
 /// - type-level unsigned integer constants (e.g. `U1`, `U124`) from the `nalgebra::` root module.
-/// All numbers from 0 to 127 are defined that way.
+///   All numbers from 0 to 127 are defined that way.
 /// - type-level unsigned integer constants (e.g. `U1024`, `U10000`) from the `typenum::` crate.
-/// Using those, you will not get error messages as nice as for numbers smaller than 128 defined on
-/// the `nalgebra::` module.
+///   Using those, you will not get error messages as nice as for numbers smaller than 128 defined on
+///   the `nalgebra::` module.
 /// - the special value `Dyn` from the `nalgebra::` root module. This indicates that the
-/// specified dimension is not known at compile-time. Note that this will generally imply that the
-/// matrix data storage `S` performs a dynamic allocation and contains extra metadata for the
-/// matrix shape.
+///   specified dimension is not known at compile-time. Note that this will generally imply that the
+///   matrix data storage `S` performs a dynamic allocation and contains extra metadata for the
+///   matrix shape.
 ///
 /// Note that mixing `Dyn` with type-level unsigned integers is allowed. Actually, a
 /// dynamically-sized column vector should be represented as a `Matrix<T, Dyn, U1, S>` (given
@@ -778,9 +778,9 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     ///
     /// The initialization closure is given the first component of this matrix:
     /// - If the matrix has no component (0 rows or 0 columns) then `init_f` is called with `None`
-    /// and its return value is the value returned by this method.
+    ///   and its return value is the value returned by this method.
     /// - If the matrix has has least one component, then `init_f` is called with the first component
-    /// to compute the initial value. Folding then continues on all the remaining components of the matrix.
+    ///   to compute the initial value. Folding then continues on all the remaining components of the matrix.
     #[inline]
     #[must_use]
     pub fn fold_with<T2>(

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -656,8 +656,7 @@ where
     /// * `other`: the second quaternion to interpolate toward.
     /// * `t`: the interpolation parameter. Should be between 0 and 1.
     /// * `epsilon`: the value below which the sinus of the angle separating
-    ///   both quaternion
-    /// must be to return `None`.
+    ///   both quaternion must be to return `None`.
     #[inline]
     #[must_use]
     pub fn try_sclerp(&self, other: &Self, t: T, epsilon: T) -> Option<Self>

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -285,7 +285,7 @@ macro_rules! look_at_isometry_construction_impl(
         ///   * eye - The observer position.
         ///   * target - The target position.
         ///   * up - Vertical direction. The only requirement of this parameter is to not be collinear
-        ///   to `eye - at`. Non-collinearity is not checked.
+        ///     to `eye - at`. Non-collinearity is not checked.
         ///
         /// # Example
         ///
@@ -336,7 +336,7 @@ macro_rules! look_at_isometry_construction_impl(
         ///   * eye - The eye position.
         ///   * target - The target position.
         ///   * up - A vector approximately aligned with required the vertical axis. The only
-        ///   requirement of this parameter is to not be collinear to `target - eye`.
+        ///     requirement of this parameter is to not be collinear to `target - eye`.
         ///
         /// # Example
         ///
@@ -379,7 +379,7 @@ macro_rules! look_at_isometry_construction_impl(
         ///   * eye - The eye position.
         ///   * target - The target position.
         ///   * up - A vector approximately aligned with required the vertical axis. The only
-        ///   requirement of this parameter is to not be collinear to `target - eye`.
+        ///     requirement of this parameter is to not be collinear to `target - eye`.
         ///
         /// # Example
         ///

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1227,7 +1227,7 @@ where
     /// * `other`: the second quaternion to interpolate toward.
     /// * `t`: the interpolation parameter. Should be between 0 and 1.
     /// * `epsilon`: the value below which the sinus of the angle separating both quaternion
-    /// must be to return `None`.
+    ///    must be to return `None`.
     #[inline]
     #[must_use]
     pub fn try_slerp(&self, other: &Self, t: T, epsilon: T) -> Option<Self>

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -582,8 +582,8 @@ where
     /// # Arguments
     ///   * dir - The look direction. It does not need to be normalized.
     ///   * up - The vertical direction. It does not need to be normalized.
-    ///   The only requirement of this parameter is to not be collinear to `dir`. Non-collinearity
-    ///   is not checked.
+    ///     The only requirement of this parameter is to not be collinear to `dir`. Non-collinearity
+    ///     is not checked.
     ///
     /// # Example
     /// ```
@@ -624,7 +624,7 @@ where
     /// # Arguments
     ///   * dir − The view direction. It does not need to be normalized.
     ///   * up - A vector approximately aligned with required the vertical axis. It does not need
-    ///   to be normalized. The only requirement of this parameter is to not be collinear to `dir`.
+    ///     to be normalized. The only requirement of this parameter is to not be collinear to `dir`.
     ///
     /// # Example
     /// ```
@@ -655,7 +655,7 @@ where
     /// # Arguments
     ///   * dir − The view direction. It does not need to be normalized.
     ///   * up - A vector approximately aligned with required the vertical axis. The only
-    ///   requirement of this parameter is to not be collinear to `dir`.
+    ///     requirement of this parameter is to not be collinear to `dir`.
     ///
     /// # Example
     /// ```

--- a/src/geometry/rotation_interpolation.rs
+++ b/src/geometry/rotation_interpolation.rs
@@ -67,7 +67,7 @@ impl<T: SimdRealField> Rotation3<T> {
     /// * `other`: the second rotation to interpolate toward.
     /// * `t`: the interpolation parameter. Should be between 0 and 1.
     /// * `epsilon`: the value below which the sinus of the angle separating both rotations
-    /// must be to return `None`.
+    ///   must be to return `None`.
     #[inline]
     #[must_use]
     pub fn try_slerp(&self, other: &Self, t: T, epsilon: T) -> Option<Self>

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -310,7 +310,7 @@ where
     ///
     /// # Arguments
     ///   * `axisangle` - A vector representing the rotation. Its magnitude is the amount of rotation
-    ///   in radian. Its direction is the axis of rotation.
+    ///     in radian. Its direction is the axis of rotation.
     ///
     /// # Example
     /// ```
@@ -459,7 +459,7 @@ where
     /// # Arguments
     ///   * dir - The look direction, that is, direction the matrix `z` axis will be aligned with.
     ///   * up - The vertical direction. The only requirement of this parameter is to not be
-    ///   collinear to `dir`. Non-collinearity is not checked.
+    ///     collinear to `dir`. Non-collinearity is not checked.
     ///
     /// # Example
     /// ```
@@ -515,7 +515,7 @@ where
     /// # Arguments
     ///   * dir - The direction toward which the camera looks.
     ///   * up - A vector approximately aligned with required the vertical axis. The only
-    ///   requirement of this parameter is to not be collinear to `dir`.
+    ///     requirement of this parameter is to not be collinear to `dir`.
     ///
     /// # Example
     /// ```
@@ -546,7 +546,7 @@ where
     /// # Arguments
     ///   * dir - The direction toward which the camera looks.
     ///   * up - A vector approximately aligned with required the vertical axis. The only
-    ///   requirement of this parameter is to not be collinear to `dir`.
+    ///     requirement of this parameter is to not be collinear to `dir`.
     ///
     /// # Example
     /// ```

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -280,7 +280,7 @@ macro_rules! similarity_construction_impl(
             ///   * eye - The observer position.
             ///   * target - The target position.
             ///   * up - Vertical direction. The only requirement of this parameter is to not be collinear
-            ///   to `eye - at`. Non-collinearity is not checked.
+            ///     to `eye - at`. Non-collinearity is not checked.
             ///
             /// # Example
             /// ```
@@ -329,7 +329,7 @@ macro_rules! similarity_construction_impl(
             ///   * eye - The eye position.
             ///   * target - The target position.
             ///   * up - A vector approximately aligned with required the vertical axis. The only
-            ///   requirement of this parameter is to not be collinear to `target - eye`.
+            ///     requirement of this parameter is to not be collinear to `target - eye`.
             ///
             /// # Example
             /// ```
@@ -366,7 +366,7 @@ macro_rules! similarity_construction_impl(
             ///   * eye - The eye position.
             ///   * target - The target position.
             ///   * up - A vector approximately aligned with required the vertical axis. The only
-            ///   requirement of this parameter is to not be collinear to `target - eye`.
+            ///     requirement of this parameter is to not be collinear to `target - eye`.
             ///
             /// # Example
             /// ```

--- a/src/linalg/decomposition.rs
+++ b/src/linalg/decomposition.rs
@@ -120,8 +120,8 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// * `compute_v` − set this to `true` to enable the computation of right-singular vectors.
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_svd(
         self,
         compute_u: bool,
@@ -153,8 +153,8 @@ impl<T: ComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
     /// * `compute_v` − set this to `true` to enable the computation of right-singular vectors.
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_svd_unordered(
         self,
         compute_u: bool,
@@ -302,8 +302,8 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     ///
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_schur(self, eps: T::RealField, max_niter: usize) -> Option<Schur<T, D>>
     where
         D: DimSub<U1>, // For Hessenberg.
@@ -336,8 +336,8 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> Matrix<T, D, D, S> {
     ///
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_symmetric_eigen(
         self,
         eps: T::RealField,

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -69,8 +69,8 @@ where
     ///
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_new(m: OMatrix<T, D, D>, eps: T::RealField, max_niter: usize) -> Option<Self> {
         let mut work = Matrix::zeros_generic(m.shape_generic().0, Const::<1>);
 

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -110,8 +110,8 @@ where
     /// * `compute_v` − set this to `true` to enable the computation of right-singular vectors.
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_new_unordered(
         mut matrix: OMatrix<T, R, C>,
         compute_u: bool,
@@ -695,8 +695,8 @@ where
     /// * `compute_v` − set this to `true` to enable the computation of right-singular vectors.
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_new(
         matrix: OMatrix<T, R, C>,
         compute_u: bool,

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -73,8 +73,8 @@ where
     ///
     /// * `eps`       − tolerance used to determine when a value converged to 0.
     /// * `max_niter` − maximum total number of iterations performed by the algorithm. If this
-    /// number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
-    /// continues indefinitely until convergence.
+    ///   number of iteration is exceeded, `None` is returned. If `niter == 0`, then the algorithm
+    ///   continues indefinitely until convergence.
     pub fn try_new(m: OMatrix<T, D, D>, eps: T::RealField, max_niter: usize) -> Option<Self>
     where
         D: DimSub<U1>,


### PR DESCRIPTION
This is a new warning in Rust 1.80's clippy that will be released this week.