### PR TITLE
Unscrambled Quaternion Averaging Function Results

### DIFF
--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -928,30 +928,54 @@ mod tests {
         }
     }
 
-
-
-
-
-
-
+    /// A single input value into mean_of should give back the same value.
     #[test]
-    fn mean_of_simple() {
-        // assert!(false);
+    fn mean_of_single() {
+        use nalgebra::UnitQuaternion;
+        let q1 = UnitQuaternion::from_euler_angles(0.1, 0.2, 0.3);
 
+        let quat_vec = vec![q1];
+        let q_mean = UnitQuaternion::mean_of(quat_vec);
+
+        let euler_angles_mean = q_mean.euler_angles();
+        assert_relative_eq!(euler_angles_mean.0, 0.1, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.1, 0.2, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.2, 0.3, epsilon = 1.0e-7);
     }
 
+    /// Three input values, with the mean outputs to be compared against
+    /// [another implementation](https://stackoverflow.com/a/49690919/1758759)
+    /// of the averaging algorithm.
+    #[test]
+    fn mean_of_three_values_1() {
+        use nalgebra::UnitQuaternion;
+        let q1 = UnitQuaternion::from_euler_angles(0.2, 0.1, 0.2);
+        let q2 = UnitQuaternion::from_euler_angles(0.6, 0.0, 0.5);
+        let q3 = UnitQuaternion::from_euler_angles(0.2, 0.2, 1.2);
 
+        let quat_vec = vec![q1, q2, q3];
+        let q_mean = UnitQuaternion::mean_of(quat_vec);
 
+        let euler_angles_mean = q_mean.euler_angles();
+        assert_relative_eq!(euler_angles_mean.0, 0.32674402, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.1, 0.08907341, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.2, 0.63291054, epsilon = 1.0e-7);
+    }
 
+    /// Similar to `mean_of_three_values_1` but has some negative values thrown in for good measure.
+    #[test]
+    fn mean_of_three_values_2() {
+        use nalgebra::UnitQuaternion;
+        let q1 = UnitQuaternion::from_euler_angles(-1.4, 2.0, 0.4);
+        let q2 = UnitQuaternion::from_euler_angles(2.3, 2.0, -0.4);
+        let q3 = UnitQuaternion::from_euler_angles(-0.2, -7.0, 0.6);
 
+        let quat_vec = vec![q1, q2, q3];
+        let q_mean = UnitQuaternion::mean_of(quat_vec);
 
-
-
-
-
-
-
-
-
-
+        let euler_angles_mean = q_mean.euler_angles();
+        assert_relative_eq!(euler_angles_mean.0, -0.55177751, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.1, 0.96545842, epsilon = 1.0e-7);
+        assert_relative_eq!(euler_angles_mean.2, 1.93519699, epsilon = 1.0e-7);
+    }
 }

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -814,14 +814,16 @@ where
     /// # use std::f32;
     /// # use nalgebra::{UnitQuaternion};
     /// let q1 = UnitQuaternion::from_euler_angles(0.0, 0.0, 0.0);
-    /// let q2 = UnitQuaternion::from_euler_angles(-0.1, 0.0, 0.0);
-    /// let q3 = UnitQuaternion::from_euler_angles(0.1, 0.0, 0.0);
+    /// let q2 = UnitQuaternion::from_euler_angles(0.1, 0.0, 0.0);
+    /// let q3 = UnitQuaternion::from_euler_angles(0.2, 0.0, 0.0);
     ///
     /// let quat_vec = vec![q1, q2, q3];
     /// let q_mean = UnitQuaternion::mean_of(quat_vec);
     ///
     /// let euler_angles_mean = q_mean.euler_angles();
-    /// assert_relative_eq!(euler_angles_mean.0, 0.0, epsilon = 1.0e-7)
+    /// assert_relative_eq!(euler_angles_mean.0, 0.1, epsilon = 1.0e-7);
+    /// assert_relative_eq!(euler_angles_mean.1, 0.0, epsilon = 1.0e-7);
+    /// assert_relative_eq!(euler_angles_mean.2, 0.0, epsilon = 1.0e-7);
     /// ```
     #[inline]
     pub fn mean_of(unit_quaternions: impl IntoIterator<Item = Self>) -> Self
@@ -925,4 +927,31 @@ mod tests {
             assert!(relative_eq!(x.into_inner().norm(), 1.0))
         }
     }
+
+
+
+
+
+
+
+    #[test]
+    fn mean_of_simple() {
+        // assert!(false);
+
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -849,10 +849,10 @@ where
 
         let max_eigenvector = eigen_matrix.eigenvectors.column(max_eigenvalue_index);
         UnitQuaternion::from_quaternion(Quaternion::new(
+            max_eigenvector[3].clone(),
             max_eigenvector[0].clone(),
             max_eigenvector[1].clone(),
             max_eigenvector[2].clone(),
-            max_eigenvector[3].clone(),
         ))
     }
 }


### PR DESCRIPTION
# Issue

The ordering of the final output in the `geometry::quaternion_construction::UnitQuaternion<T>::mean_of` appears to be incorrect. Presumably this was due to the `w, i, j, k` ordering changing at some point from `i, j, k, w` + the original doctest checking against an expected zero value. Testing against an expected zero value doesn't check if the zero came from what should've been a zero, or some other zero elsewhere, it's better to use a non-zero value.

# Fix
The fix is swapping the output values around to follow the `w, i, j, k` ordering. Additionally, to avoid similar problems in the future, have added 3 tests which have values calculated using a python implementation of what appears to be the [same algorithm](https://stackoverflow.com/a/49690919/1758759).

# Current Workaround
What I have to do currently is to unscramble the outputs from the `mean_of` function (without this PR):

```rust
let q1 = UnitQuaternion::from_euler_angles(0.0_f64, 0.0, 0.4);
let q2 = UnitQuaternion::from_euler_angles(0.0, 0.0, 0.2);
let q3 = UnitQuaternion::from_euler_angles(0.0, 0.0, 0.3);

let quat_vec = vec![q1, q2, q3];
let q_mean_scrambled = UnitQuaternion::mean_of(quat_vec);
let q_mean_corrected =         
        UnitQuaternion::from_quaternion(Quaternion::from_vector(Vector4::new(
                q_mean_scrambled[3],
                q_mean_scrambled[0],
                q_mean_scrambled[1],
                q_mean_scrambled[2],
        )));
```


# Caveats

As a side note, for some reason the doctest on my machine doesn't want to run automatically when I click the "Run Doctest" code lens button. I have to invoke it manually by its name. It also doesn't seem to run under `cargo test`.

I'm not a quaternion expert, just a user. I don't have detailed knowledge about the actual averaging algorithm, I relied on the python implementation to provide me with the test values I was after. There's nothing inherently special about the values used in the tests.

# Referencing Potentially Wrong

The algorithm quoted in the [original PR](https://github.com/dimforge/nalgebra/pull/647) is Markley _et al_. 2007. However the actual code appears to reference a paper from 2006. The 2006 paper is behind a paywall and from looking at its abstract does not appear to contain an averaging algorithm.

The 2007 paper is widely available and is widely used per the [stackoverflow](https://stackoverflow.com/questions/12374087/average-of-multiple-quaternions) discussion. The python code used to generate the test values in this PR is also derived ultimately from Markley _et al_. 2007.

We'll need to ping the original author (@thibaultbarbie) for comment. If no response, then in the absence of better information, it may have to be assumed that Markley _et al_. 2007 was the intended reference all along and the doc string will have to be updated.



