### PR TITLE
Add Default impl for CooMatrix

### DIFF
--- a/nalgebra-sparse/src/coo.rs
+++ b/nalgebra-sparse/src/coo.rs
@@ -312,3 +312,15 @@ impl<T> CooMatrix<T> {
         (self.row_indices, self.col_indices, self.values)
     }
 }
+
+impl<T> Default for CooMatrix<T> {
+    fn default() -> Self {
+        Self {
+            nrows: 0,
+            ncols: 0,
+            row_indices: Default::default(),
+            col_indices: Default::default(),
+            values: Default::default(),
+        }
+    }
+}


### PR DESCRIPTION
Hello,

Just a small PR to make `CooMatrix` implement the `Default` trait. 

I don't know whether `Default` was not implemented on purpose, but since `CscMatrix` implements it I figured this would be helpful too.