### PR TITLE
feat: implement bytemuck traits for isometries and similarities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.33.1] (16 October 2024)
+
+### Added
+
+- Add implementations of `bytemuck` traits for isometries and similarities.
+- Implement `AsRef<[T]>` for matrices with contiguous storage.
+- Enable the `num-complex/bytemuck` feature when the `convert-bytemuck` feature is enabled.
+
 ## [0.33.0] (23 June 2024)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ macros = ["nalgebra-macros"]
 
 # Conversion
 convert-mint = ["mint"]
-convert-bytemuck = ["bytemuck"]
+convert-bytemuck = ["bytemuck", "num-complex/bytemuck"]
 convert-glam014 = ["glam014"]
 convert-glam015 = ["glam015"]
 convert-glam016 = ["glam016"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra"
-version = "0.33.0"
+version = "0.33.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1341,6 +1341,14 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> Matrix<T, R, C, S
     }
 }
 
+impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> AsRef<[T]> for Matrix<T, R, C, S> {
+    /// Extracts a slice containing the entire matrix entries ordered column-by-columns.
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
 impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C> + IsContiguous> Matrix<T, R, C, S> {
     /// Extracts a mutable slice containing the entire matrix entries ordered column-by-columns.
     #[inline]

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -14,6 +14,8 @@ use crate::base::storage::Owned;
 use crate::base::{Const, DefaultAllocator, OMatrix, SVector, Scalar, Unit};
 use crate::geometry::{AbstractRotation, Point, Translation};
 
+use crate::{Isometry3, Quaternion, Vector3, Vector4};
+
 #[cfg(feature = "rkyv-serialize")]
 use rkyv::bytecheck;
 
@@ -97,6 +99,23 @@ where
         self.translation.hash(state);
         self.rotation.hash(state);
     }
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Scalar, R, const D: usize> bytemuck::Zeroable for Isometry<T, R, D>
+where
+    SVector<T, D>: bytemuck::Zeroable,
+    R: bytemuck::Zeroable,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Scalar, R, const D: usize> bytemuck::Pod for Isometry<T, R, D>
+where
+    SVector<T, D>: bytemuck::Pod,
+    R: bytemuck::Pod,
+    T: Copy,
+{
 }
 
 /// # From the translation and rotation parts

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -65,6 +65,21 @@ where
     }
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Scalar, R, const D: usize> bytemuck::Zeroable for Similarity<T, R, D> where
+    Isometry<T, R, D>: bytemuck::Zeroable
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Scalar, R, const D: usize> bytemuck::Pod for Similarity<T, R, D>
+where
+    Isometry<T, R, D>: bytemuck::Pod,
+    R: Copy,
+    T: Copy,
+{
+}
+
 impl<T: Scalar + Zero, R, const D: usize> Similarity<T, R, D>
 where
     R: AbstractRotation<T, D>,

--- a/tests/core/conversion.rs
+++ b/tests/core/conversion.rs
@@ -177,9 +177,9 @@ macro_rules! array_row_vector_conversion(
     ($($array_vector_conversion_i: ident, $Vector: ident, $SZ: expr);* $(;)*) => {$(
         #[test]
         fn $array_vector_conversion_i() {
-            let v       = $Vector::from_fn(|_, i| i);
+            let v: $Vector<_>       = $Vector::from_fn(|_, i| i);
             let arr: [usize; $SZ] = v.into();
-            let arr_ref = v.as_ref();
+            let arr_ref: &[_] = v.as_ref();
             let v2      = $Vector::from(arr);
 
             for i in 0 .. $SZ {
@@ -207,13 +207,13 @@ macro_rules! array_matrix_conversion(
         fn $array_matrix_conversion_i_j() {
             let m       = $Matrix::from_fn(|i, j| i * 10 + j);
             let arr: [[usize; $NRows]; $NCols] = m.into();
-            let arr_ref = m.as_ref();
+            let arr_ref: &[_] = m.as_ref();
             let m2      = $Matrix::from(arr);
 
             for i in 0 .. $NRows {
                 for j in 0 .. $NCols {
                     assert_eq!(arr[j][i], i * 10 + j);
-                    assert_eq!(arr_ref[j][i], i * 10 + j);
+                    assert_eq!(arr_ref[j * $NRows + i], i * 10 + j);
                 }
             }
 


### PR DESCRIPTION
- Add implementations of bytemuck traits for isometries and similarities.
- Implement `AsRef<[T]>` for matrices with contiguous storage.
- Enable the `num-complex/bytemuck` feature when the `convert-bytemuck` feature is enabled.