### PR TITLE
Make SymmetricEigenScalar usable but not implementable

### DIFF
--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -103,7 +103,7 @@ pub use self::qr::QR;
 pub use self::qz::QZ;
 pub use self::schur::Schur;
 pub use self::svd::SVD;
-pub use self::symmetric_eigen::SymmetricEigen;
+pub use self::symmetric_eigen::{SymmetricEigen, SymmetricEigenScalar};
 
 trait ComplexHelper {
     type RealPart;

--- a/nalgebra-lapack/src/symmetric_eigen.rs
+++ b/nalgebra-lapack/src/symmetric_eigen.rs
@@ -161,6 +161,10 @@ where
     }
 }
 
+pub trait Sealed {}
+impl Sealed for f32 {}
+impl Sealed for f64 {}
+
 /*
  *
  * Lapack functions dispatch.
@@ -168,7 +172,7 @@ where
  */
 /// Trait implemented by scalars for which Lapack implements the eigendecomposition of symmetric
 /// real matrices.
-pub trait SymmetricEigenScalar: Scalar {
+pub trait SymmetricEigenScalar: Scalar + Sealed {
     #[allow(missing_docs)]
     fn xsyev(
         jobz: u8,


### PR DESCRIPTION
The Trait `SymmetricEigenScalar` is required to do the symmetric eigendecomposition, but because it is not exported, there is no way to use this in generic code.

This PR exports this trait, but still does not allow it to be implemented outside the crate