### PR TITLE
Fix no-std CI build configuration

### DIFF
--- a/.github/Xargo.toml
+++ b/.github/Xargo.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-gnu.dependencies]
-alloc = {}
-
-[target.thumbv7em-none-eabihf.dependencies]
-alloc = {}

--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -106,27 +106,24 @@ jobs:
   build-no-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-          override: true
-          components: rustfmt
-      - name: install xargo
-        run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
-      - name: build x86_64-unknown-linux-gnu
-        run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
-      - name: build x86_64-unknown-linux-gnu --features rand-no-std
-        run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
-      - name: build x86_64-unknown-linux-gnu --features alloc
-        run: xargo build --verbose --no-default-features --features alloc --target=x86_64-unknown-linux-gnu;
+          toolchain: stable
+          targets: "x86_64-unknown-none,thumbv7em-none-eabihf"
+      - name: build x86_64-unknown-none
+        run: cargo build --verbose --no-default-features --target=x86_64-unknown-none
+      - name: build x86_64-unknown-none --features rand-no-std
+        run: cargo build --verbose --no-default-features --features rand-no-std --target=x86_64-unknown-none
+      - name: build x86_64-unknown-none --features alloc
+        run: cargo build --verbose --no-default-features --features alloc --target=x86_64-unknown-none
       - name: build thumbv7em-none-eabihf
-        run: xargo build --verbose --no-default-features --target=thumbv7em-none-eabihf;
-      - name: build x86_64-unknown-linux-gnu nalgebra-glm
-        run: xargo build --verbose --no-default-features -p nalgebra-glm --target=x86_64-unknown-linux-gnu;
+        run: cargo build --verbose --no-default-features --target=thumbv7em-none-eabihf
+      - name: build x86_64-unknown-none nalgebra-glm
+        run: cargo build --verbose --no-default-features -p nalgebra-glm --target=x86_64-unknown-none
       - name: build thumbv7em-none-eabihf nalgebra-glm
-        run: xargo build --verbose --no-default-features -p nalgebra-glm --target=thumbv7em-none-eabihf;
+        run: cargo build --verbose --no-default-features -p nalgebra-glm --target=thumbv7em-none-eabihf
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* Stop using `xargo` and just use a regular `cargo` build.
* Use `stable` rather than `nightly` as that works with `cargo`.
* Update from `actions-rs/toolchain` for this job to `dtolnay/rust-toolchain` as the `actions-rs` action is unmaintained.
* Switch from `x86_64-unknown-linux-gnu` to `x86_64-unknown-none` as that is a 64 bit target that has no `std` lib.
* Keep the 32 bit ARM target testing to keep that coverage.
* Fix the `rand-no-std` test to pass that feature to the build.