### PR TITLE
Release v0.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## [0.33.2] (29 October 2024)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra"
-version = "0.33.1"
+version = "0.33.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."


### PR DESCRIPTION
### Added

- Add the `convert-glam029` feature to enable conversion from/to types from `glam` v0.29.