### PR TITLE
Fix comment on Matrix::fill_upper_triangle

### DIFF
--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -249,7 +249,7 @@ impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> Matrix<T, R, C, S> {
         }
     }
 
-    /// Sets all the elements of the lower-triangular part of this matrix to `val`.
+    /// Sets all the elements of the upper-triangular part of this matrix to `val`.
     ///
     /// The parameter `shift` allows some superdiagonals to be left untouched:
     /// * If `shift = 0` then the diagonal is overwritten as well.


### PR DESCRIPTION
Matrix::fill_upper_triangle currently says that it "Sets all the elements of the _lower_-triangular part...", when it should say it fills the "_upper_-triangular part"