### PR TITLE
Implement From<Point<T>> for Vector<T>

### DIFF
--- a/src/geometry/point_conversion.rs
+++ b/src/geometry/point_conversion.rs
@@ -6,8 +6,8 @@ use crate::base::allocator::Allocator;
 use crate::base::dimension::{DimNameAdd, DimNameSum, U1};
 use crate::base::{Const, DefaultAllocator, Matrix, OVector, Scalar};
 
-use crate::geometry::Point;
-use crate::{DimName, OPoint};
+use crate::geometry::{Point, Point2, Point3};
+use crate::{DimName, OPoint, Vector3, Vector4};
 
 /*
  * This file provides the following conversions:
@@ -70,14 +70,27 @@ where
     }
 }
 
-impl<T: Scalar + Zero + One, D: DimName> From<OPoint<T, D>> for OVector<T, DimNameSum<D, U1>>
+impl<T: Scalar + Zero + One> From<Point2<T>> for Vector3<T> {
+    #[inline]
+    fn from(p: Point2<T>) -> Self {
+        p.to_homogeneous()
+    }
+}
+
+impl<T: Scalar + Zero + One> From<Point3<T>> for Vector4<T> {
+    #[inline]
+    fn from(p: Point3<T>) -> Self {
+        p.to_homogeneous()
+    }
+}
+
+impl<T: Scalar, D: DimName> From<OPoint<T, D>> for OVector<T, D>
 where
-    D: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<DimNameSum<D, U1>> + Allocator<D>,
+    DefaultAllocator: Allocator<D>,
 {
     #[inline]
-    fn from(t: OPoint<T, D>) -> Self {
-        t.to_homogeneous()
+    fn from(p: OPoint<T, D>) -> Self {
+        p.coords
     }
 }
 

--- a/tests/geometry/point.rs
+++ b/tests/geometry/point.rs
@@ -1,4 +1,4 @@
-use na::{Point3, Vector3, Vector4};
+use na::{Point2, Point3, Point4, Vector2, Vector3, Vector4};
 use num::Zero;
 
 #[test]
@@ -99,4 +99,40 @@ fn display_fmt_respects_modifiers() {
     assert_eq!(&format!("{p}"), "{1.23, 3.45, 5.67}");
     assert_eq!(&format!("{p:.1}"), "{1.2, 3.5, 5.7}");
     assert_eq!(&format!("{p:.0}"), "{1, 3, 6}");
+}
+
+#[test]
+fn homogeneous_conversions() {
+    // 2D -> 3D homogeneous conversion
+    let p = Point2::new(1.0, 2.0);
+    let expected = Vector3::new(1.0, 2.0, 1.0);
+    let v1: Vector3<f64> = p.into();
+    assert_eq!(v1, expected);
+
+    // 3D -> 4D homogeneous conversion
+    let p = Point3::new(1.0, 2.0, 3.0);
+    let expected = Vector4::new(1.0, 2.0, 3.0, 1.0);
+    let v1: Vector4<f64> = p.into();
+    assert_eq!(v1, expected);
+}
+
+#[test]
+fn dimension_preserving_conversions() {
+    // 2D point -> 2D vector
+    let p = Point2::new(1.0, 2.0);
+    let expected = Vector2::new(1.0, 2.0);
+    let v1: Vector2<f64> = p.into();
+    assert_eq!(v1, expected);
+
+    // 3D point -> 3D vector
+    let p = Point3::new(1.0, 2.0, 3.0);
+    let expected = Vector3::new(1.0, 2.0, 3.0);
+    let v1: Vector3<f64> = p.into();
+    assert_eq!(v1, expected);
+
+    // 4D point -> 4D vector
+    let p = Point4::new(1.0, 2.0, 3.0, 4.0);
+    let expected = Vector4::new(1.0, 2.0, 3.0, 4.0);
+    let v1: Vector4<f64> = p.into();
+    assert_eq!(v1, expected);
 }


### PR DESCRIPTION
This PR addresses issue #1450

Changes made:
1. Restricted the existing homogeneous conversion to specific 2D/3D cases
   - Point2 -> Vector3 (homogeneous)
   - Point3 -> Vector4 (homogeneous)

2. Added generic dimension-preserving conversion

3. Added tests for both conversion types