### PR TITLE
Fix simd_try_normalize mask logic

### DIFF
--- a/src/base/norm.rs
+++ b/src/base/norm.rs
@@ -328,9 +328,9 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         DefaultAllocator: Allocator<R, C>,
     {
         let n = self.norm();
-        let le = n.clone().simd_le(min_norm);
+        let valid = n.clone().simd_gt(min_norm);
         let val = self.unscale(n);
-        SimdOption::new(val, le)
+        SimdOption::new(val, valid)
     }
 
     /// Sets the magnitude of this vector unless it is smaller than `min_magnitude`.


### PR DESCRIPTION
Similar to `try_normalize`, `simd_try_normalize` compares the norm `n` against `min_norm`. The former properly allows a value if it is greater than the minimum:

https://github.com/dimforge/nalgebra/blob/a3c261051ba7c8201ef8c49640ae24c1f53360f7/src/base/norm.rs#L397-L401

The simd version uses this comparison boolean as a lanewise mask, but the logic is currently inverted, such that a valid value greater than `min_norm` results in a `false` mask.