### PR TITLE
Added function for user to access PermutationSequence indices

### DIFF
--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -161,4 +161,10 @@ where
             -T::one()
         }
     }
+
+    /// Returns the permutation indices as a vector of tuples to the user.
+    #[inline]
+    pub fn permutation_indices(&self) -> Vec<(usize, usize)> {
+        self.ipiv.rows_range(..self.len).iter().cloned().collect()
+    }
 }


### PR DESCRIPTION
As mentioned in issue #1464, 
For a PermutationSequence returned from a QR decomposition with column pivoting (`col_piv_qr`) we can't access the internal permutation sequence, so this function just allows the user to do so.

