### PR TITLE
Upgrade `rand` to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rkyv-serialize = ["rkyv-serialize-no-std", "rkyv/std", "rkyv/validation"]
 ## To use rand in a #[no-std] environment, enable the
 ## `rand-no-std` feature instead of `rand`.
 rand-no-std = ["rand-package"]
-rand = ["rand-no-std", "rand-package/std", "rand-package/std_rng", "rand_distr"]
+rand = ["rand-no-std", "rand-package/std", "rand-package/std_rng", "rand-package/thread_rng", "rand_distr"]
 
 # Tests
 arbitrary = ["quickcheck"]
@@ -77,14 +77,14 @@ rkyv-safe-deser = ["rkyv-serialize", "rkyv/validation"]
 [dependencies]
 nalgebra-macros = { version = "0.2.2", path = "nalgebra-macros", optional = true }
 typenum = "1.12"
-rand-package = { package = "rand", version = "0.8", optional = true, default-features = false }
+rand-package = { package = "rand", version = "0.9", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", default-features = false }
 num-rational = { version = "0.4", default-features = false }
 approx = { version = "0.5", default-features = false }
 simba = { version = "0.9", default-features = false }
 alga = { version = "0.9", default-features = false, optional = true }
-rand_distr = { version = "0.4", default-features = false, optional = true }
+rand_distr = { version = "0.5", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 rkyv = { version = "0.7.41", default-features = false, optional = true }
@@ -114,7 +114,7 @@ rayon = { version = "1.6", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-rand_xorshift = "0.3"
+rand_xorshift = "0.4"
 rand_isaac = "0.3"
 criterion = { version = "0.4", features = ["html_reports"] }
 nalgebra = { path = ".", features = ["debug", "compare", "rand", "macros"] }

--- a/src/base/helper.rs
+++ b/src/base/helper.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -24,8 +24,8 @@ pub fn reject<F: FnMut(&T) -> bool, T: Arbitrary>(g: &mut Gen, f: F) -> T {
 #[cfg(feature = "rand-no-std")]
 pub fn reject_rand<G: Rng + ?Sized, F: FnMut(&T) -> bool, T>(g: &mut G, f: F) -> T
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     use std::iter;
-    iter::repeat(()).map(|_| g.gen()).find(f).unwrap()
+    iter::repeat(()).map(|_| g.random()).find(f).unwrap()
 }

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -89,14 +89,14 @@ where
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: crate::RealField, R, const D: usize> Distribution<Isometry<T, R, D>> for Standard
+impl<T: crate::RealField, R, const D: usize> Distribution<Isometry<T, R, D>> for StandardUniform
 where
     R: AbstractRotation<T, D>,
-    Standard: Distribution<T> + Distribution<R>,
+    StandardUniform: Distribution<T> + Distribution<R>,
 {
     #[inline]
     fn sample<G: Rng + ?Sized>(&self, rng: &mut G) -> Isometry<T, R, D> {
-        Isometry::from_parts(rng.gen(), rng.gen())
+        Isometry::from_parts(rng.random(), rng.random())
     }
 }
 

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -2,7 +2,7 @@
 use quickcheck::{Arbitrary, Gen};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 #[cfg(feature = "serde-serialize-no-std")]
@@ -741,18 +741,18 @@ impl<T: RealField> Orthographic3<T> {
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: RealField> Distribution<Orthographic3<T>> for Standard
+impl<T: RealField> Distribution<Orthographic3<T>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     /// Generate an arbitrary random variate for testing purposes.
     fn sample<R: Rng + ?Sized>(&self, r: &mut R) -> Orthographic3<T> {
         use crate::base::helper;
-        let left = r.gen();
+        let left = r.random();
         let right = helper::reject_rand(r, |x: &T| *x > left);
-        let bottom = r.gen();
+        let bottom = r.random();
         let top = helper::reject_rand(r, |x: &T| *x > bottom);
-        let znear = r.gen();
+        let znear = r.random();
         let zfar = helper::reject_rand(r, |x: &T| *x > znear);
 
         Orthographic3::new(left, right, bottom, top, znear, zfar)

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -2,7 +2,7 @@
 use quickcheck::{Arbitrary, Gen};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -313,18 +313,18 @@ impl<T: RealField> Perspective3<T> {
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: RealField> Distribution<Perspective3<T>> for Standard
+impl<T: RealField> Distribution<Perspective3<T>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     /// Generate an arbitrary random variate for testing purposes.
     fn sample<R: Rng + ?Sized>(&self, r: &mut R) -> Perspective3<T> {
         use crate::base::helper;
-        let znear = r.gen();
+        let znear = r.random();
         let zfar = helper::reject_rand(r, |x: &T| !(x.clone() - znear.clone()).is_zero());
         let aspect = helper::reject_rand(r, |x: &T| !x.is_zero());
 
-        Perspective3::new(aspect, r.gen(), znear, zfar)
+        Perspective3::new(aspect, r.random(), znear, zfar)
     }
 }
 

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -4,7 +4,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::{Bounded, One, Zero};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -159,15 +159,15 @@ where
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: Scalar, D: DimName> Distribution<OPoint<T, D>> for Standard
+impl<T: Scalar, D: DimName> Distribution<OPoint<T, D>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
     DefaultAllocator: Allocator<D>,
 {
     /// Generate a `Point` where each coordinate is an independent variate from `[0, 1)`.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> OPoint<T, D> {
-        OPoint::from(rng.gen::<OVector<T, D>>())
+        OPoint::from(rng.random::<OVector<T, D>>())
     }
 }
 

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -7,7 +7,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{uniform::SampleUniform, Distribution, OpenClosed01, Standard, Uniform},
+    distr::{uniform::SampleUniform, Distribution, OpenClosed01, StandardUniform, Uniform},
     Rng,
 };
 
@@ -171,13 +171,13 @@ where
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: SimdRealField> Distribution<Quaternion<T>> for Standard
+impl<T: SimdRealField> Distribution<Quaternion<T>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Quaternion<T> {
-        Quaternion::new(rng.gen(), rng.gen(), rng.gen(), rng.gen())
+        Quaternion::new(rng.random(), rng.random(), rng.random(), rng.random())
     }
 }
 
@@ -866,7 +866,7 @@ where
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: SimdRealField> Distribution<UnitQuaternion<T>> for Standard
+impl<T: SimdRealField> Distribution<UnitQuaternion<T>> for StandardUniform
 where
     T::Element: SimdRealField,
     OpenClosed01: Distribution<T>,
@@ -879,7 +879,8 @@ where
         // Uniform random rotations.
         // In D. Kirk, editor, Graphics Gems III, pages 124-132. Academic, New York, 1992.
         let x0 = rng.sample(OpenClosed01);
-        let twopi = Uniform::new(T::zero(), T::simd_two_pi());
+        let twopi = Uniform::new(T::zero(), T::simd_two_pi())
+            .expect("Failed to costruct `Uniform`, should be unreachable");
         let theta1 = rng.sample(&twopi);
         let theta2 = rng.sample(&twopi);
         let s1 = theta1.clone().simd_sin();
@@ -921,7 +922,7 @@ mod tests {
     fn random_unit_quats_are_unit() {
         let mut rng = rand_xorshift::XorShiftRng::from_seed([0xAB; 16]);
         for _ in 0..1000 {
-            let x = rng.gen::<UnitQuaternion<f32>>();
+            let x = rng.random::<UnitQuaternion<f32>>();
             assert!(relative_eq!(x.into_inner().norm(), 1.0))
         }
     }

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -7,7 +7,7 @@ use num::Zero;
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{uniform::SampleUniform, Distribution, OpenClosed01, Standard, Uniform},
+    distr::{uniform::SampleUniform, Distribution, OpenClosed01, StandardUniform, Uniform},
     Rng,
 };
 
@@ -271,7 +271,7 @@ impl<T: SimdRealField> Rotation2<T> {
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: SimdRealField> Distribution<Rotation2<T>> for Standard
+impl<T: SimdRealField> Distribution<Rotation2<T>> for StandardUniform
 where
     T::Element: SimdRealField,
     T: SampleUniform,
@@ -279,7 +279,9 @@ where
     /// Generate a uniformly distributed random rotation.
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Rotation2<T> {
-        let twopi = Uniform::new(T::zero(), T::simd_two_pi());
+        let twopi = Uniform::new(T::zero(), T::simd_two_pi())
+            .expect("Failed to costruct `Uniform`, should be unreachable");
+
         Rotation2::new(rng.sample(twopi))
     }
 }
@@ -1153,7 +1155,7 @@ impl<T: SimdRealField> Rotation3<T> {
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: SimdRealField> Distribution<Rotation3<T>> for Standard
+impl<T: SimdRealField> Distribution<Rotation3<T>> for StandardUniform
 where
     T::Element: SimdRealField,
     OpenClosed01: Distribution<T>,
@@ -1167,7 +1169,8 @@ where
         // In D. Kirk, editor, Graphics Gems III, pages 117-120. Academic, New York, 1992.
 
         // Compute a random rotation around Z
-        let twopi = Uniform::new(T::zero(), T::simd_two_pi());
+        let twopi = Uniform::new(T::zero(), T::simd_two_pi())
+            .expect("Failed to costruct `Uniform`, should be unreachable");
         let theta = rng.sample(&twopi);
         let (ts, tc) = theta.simd_sin_cos();
         let a = SMatrix::<T, 3, 3>::new(

--- a/src/geometry/scale_construction.rs
+++ b/src/geometry/scale_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -63,14 +63,14 @@ impl<T: Scalar + One + ClosedMulAssign, const D: usize> One for Scale<T, D> {
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: Scalar, const D: usize> Distribution<Scale<T, D>> for Standard
+impl<T: Scalar, const D: usize> Distribution<Scale<T, D>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<G: Rng + ?Sized>(&self, rng: &mut G) -> Scale<T, D> {
-        Scale::from(rng.gen::<SVector<T, D>>())
+        Scale::from(rng.random::<SVector<T, D>>())
     }
 }
 

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -68,20 +68,20 @@ where
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: crate::RealField, R, const D: usize> Distribution<Similarity<T, R, D>> for Standard
+impl<T: crate::RealField, R, const D: usize> Distribution<Similarity<T, R, D>> for StandardUniform
 where
     R: AbstractRotation<T, D>,
-    Standard: Distribution<T> + Distribution<R>,
+    StandardUniform: Distribution<T> + Distribution<R>,
 {
     /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &mut G) -> Similarity<T, R, D> {
-        let mut s = rng.gen();
+        let mut s = rng.random();
         while relative_eq!(s, T::zero()) {
-            s = rng.gen()
+            s = rng.random()
         }
 
-        Similarity::from_isometry(rng.gen(), s)
+        Similarity::from_isometry(rng.random(), s)
     }
 }
 

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::{One, Zero};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -69,14 +69,14 @@ impl<T: Scalar + Zero + ClosedAddAssign, const D: usize> One for Translation<T, 
 }
 
 #[cfg(feature = "rand-no-std")]
-impl<T: Scalar, const D: usize> Distribution<Translation<T, D>> for Standard
+impl<T: Scalar, const D: usize> Distribution<Translation<T, D>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     /// Generate an arbitrary random variate for testing purposes.
     #[inline]
     fn sample<G: Rng + ?Sized>(&self, rng: &mut G) -> Translation<T, D> {
-        Translation::from(rng.gen::<SVector<T, D>>())
+        Translation::from(rng.random::<SVector<T, D>>())
     }
 }
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 
@@ -411,7 +411,7 @@ where
 }
 
 #[cfg(feature = "rand")]
-impl<T: SimdRealField> Distribution<UnitComplex<T>> for Standard
+impl<T: SimdRealField> Distribution<UnitComplex<T>> for StandardUniform
 where
     T::Element: SimdRealField,
     rand_distr::UnitCircle: Distribution<[T; 2]>,

--- a/tests/core/helper.rs
+++ b/tests/core/helper.rs
@@ -4,7 +4,7 @@
 use na::RealField;
 use num_complex::Complex;
 use quickcheck::{Arbitrary, Gen};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use rand::Rng;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -19,14 +19,14 @@ impl<T: Arbitrary + RealField> Arbitrary for RandComplex<T> {
     }
 }
 
-impl<T: RealField> Distribution<RandComplex<T>> for Standard
+impl<T: RealField> Distribution<RandComplex<T>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> RandComplex<T> {
-        let re = rng.gen();
-        let im = rng.gen();
+        let re = rng.random();
+        let im = rng.random();
         RandComplex(Complex::new(re, im))
     }
 }
@@ -45,9 +45,9 @@ impl<T: Arbitrary> Arbitrary for RandScalar<T> {
     }
 }
 
-impl<T: RealField> Distribution<RandScalar<T>> for Standard
+impl<T: RealField> Distribution<RandScalar<T>> for StandardUniform
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> RandScalar<T> {

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -17,13 +17,18 @@ macro_rules! gen_tests(
             use na::debug::RandomSDP;
             use na::dimension::{Const, Dyn};
             use na::{DMatrix, DVector, Matrix4x3, Vector4};
-            use rand::random;
+            use rand::{random, distr::uniform::{UniformUsize, UniformSampler}};
             use simba::scalar::ComplexField;
             #[allow(unused_imports)]
             use crate::core::helper::{RandScalar, RandComplex};
 
             use crate::proptest::*;
             use proptest::{prop_assert, proptest};
+
+            fn random_usize() -> usize {
+                let sampler = UniformUsize::new(usize::MIN, usize::MAX).unwrap();
+                sampler.sample(&mut rand::rng())
+            }
 
             proptest! {
                 #[test]
@@ -136,7 +141,8 @@ macro_rules! gen_tests(
                 #[test]
                 fn cholesky_insert_column(n in PROPTEST_MATRIX_DIM) {
                     let n = n.max(1).min(10);
-                    let j = random::<usize>() % n;
+
+                    let j = random_usize() % n;
                     let m_updated = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
 
                     // build m and col from m_updated
@@ -153,7 +159,7 @@ macro_rules! gen_tests(
                 #[test]
                 fn cholesky_remove_column(n in PROPTEST_MATRIX_DIM) {
                     let n = n.max(1).min(10);
-                    let j = random::<usize>() % n;
+                    let j = random_usize() % n;
                     let m = RandomSDP::new(Dyn(n), || random::<$scalar>().0).unwrap();
 
                     // remove column from cholesky decomposition and rebuild m

--- a/tests/linalg/exp.rs
+++ b/tests/linalg/exp.rs
@@ -45,11 +45,12 @@ mod tests {
         {
             // https://mathworld.wolfram.com/MatrixExponential.html
             use rand::{
-                distributions::{Distribution, Uniform},
-                thread_rng,
+                distr::{Distribution, Uniform},
+                rng,
             };
-            let mut rng = thread_rng();
-            let dist = Uniform::new(-10.0, 10.0);
+            let mut rng = rng();
+            let dist = Uniform::new(-10.0, 10.0)
+                .expect("Failed to costruct `Uniform`, should be unreachable");
             loop {
                 let a: f64 = dist.sample(&mut rng);
                 let b: f64 = dist.sample(&mut rng);


### PR DESCRIPTION
Bumps the `rand` version.

Things of note:

- `new_random_generic` in `base::construction` used `thread_rng`.  This function is now locked under a `thread_rng` feature, so I added it to nalgebra's `rand`.