### PR TITLE
Add Matrix::apply_with_location public function

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -994,6 +994,25 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
         }
     }
 
+    /// Applies a closure `f` to modify each component of `self`. Unlike `apply`,
+    /// `f` also gets passed the row and column index, i.e. `f(row, col, value)`.
+    #[inline]
+    pub fn apply_with_location<F: FnMut(usize, usize, &mut T)>(&mut self, mut f: F)
+    where
+        S: RawStorageMut<T, R, C>,
+    {
+        let (nrows, ncols) = self.shape();
+
+        for j in 0..ncols {
+            for i in 0..nrows {
+                unsafe {
+                    let e = self.data.get_unchecked_mut(i, j);
+                    f(i, j, e)
+                }
+            }
+        }
+    }
+
     /// Replaces each component of `self` by the result of a closure `f` applied on its components
     /// joined with the components from `rhs`.
     #[inline]

--- a/tests/core/matrix.rs
+++ b/tests/core/matrix.rs
@@ -499,6 +499,17 @@ fn apply() {
 }
 
 #[test]
+fn apply_with_location() {
+    let mut a = Matrix3::new(1.1f32, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9);
+
+    let expected = Matrix3::new(1.1, 3.2, 5.3, 5.4, 7.5, 9.6, 9.7, 11.8, 13.9);
+
+    a.apply_with_location(|i, j, e| *e += i as f32 + j as f32);
+
+    assert_eq!(a, expected);
+}
+
+#[test]
 fn map() {
     let a = Matrix4::new(
         1.1f64, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 8.8, 7.7, 6.6, 5.5, 4.4, 3.3, 2.2,


### PR DESCRIPTION
Matrix::apply_with_location works similar `Matrix::map_with_location`, but in-place, like `apply`.

It works like apply, but passes row and column to the callback function.