### PR TITLE
Update errors for a more recent rust version

### DIFF
--- a/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `ShapeConstraint: SameNumberOfColumns<Const<2>, Co
    |            ^^^ the trait `SameNumberOfColumns<Const<2>, Const<3>>` is not implemented for `ShapeConstraint`
    |
    = help: the following other types implement trait `SameNumberOfColumns<D1, D2>`:
-             <ShapeConstraint as SameNumberOfColumns<D, D>>
-             <ShapeConstraint as SameNumberOfColumns<D, Dyn>>
-             <ShapeConstraint as SameNumberOfColumns<Dyn, D>>
+             `ShapeConstraint` implements `SameNumberOfColumns<D, D>`
+             `ShapeConstraint` implements `SameNumberOfColumns<D, Dyn>`
+             `ShapeConstraint` implements `SameNumberOfColumns<Dyn, D>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
@@ -17,21 +17,4 @@ error[E0282]: type annotations needed
 12 | |            a21, a22];
    | |____________________^ cannot infer type
    |
-   = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, Const<3>, _, _>` in the current scope
-  --> tests/macros/trybuild/stack_incompatible_block_dimensions.rs:11:5
-   |
-11 |       stack![a11, a12;
-   |  _____^
-12 | |            a21, a22];
-   | |____________________^ method not found in `Matrix<_, Const<3>, _, _>`
-   |
-  ::: src/base/matrix_view.rs
-   |
-   |        generic_slice_mut => generic_view_mut,
-   |                             ---------------- the method is available for `Matrix<_, Const<3>, _, _>` here
-   |
-   = note: the method was found for
-           - `Matrix<T, R, C, S>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `ShapeConstraint: SameNumberOfRows<Const<1>, Const
    |                 ^^^ the trait `SameNumberOfRows<Const<1>, Const<2>>` is not implemented for `ShapeConstraint`
    |
    = help: the following other types implement trait `SameNumberOfRows<D1, D2>`:
-             <ShapeConstraint as SameNumberOfRows<D, D>>
-             <ShapeConstraint as SameNumberOfRows<D, Dyn>>
-             <ShapeConstraint as SameNumberOfRows<Dyn, D>>
+             `ShapeConstraint` implements `SameNumberOfRows<D, D>`
+             `ShapeConstraint` implements `SameNumberOfRows<D, Dyn>`
+             `ShapeConstraint` implements `SameNumberOfRows<Dyn, D>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
@@ -17,21 +17,4 @@ error[E0282]: type annotations needed
 13 | |            a21, a22];
    | |____________________^ cannot infer type
    |
-   = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, _, Const<4>, _>` in the current scope
-  --> tests/macros/trybuild/stack_incompatible_block_dimensions2.rs:12:5
-   |
-12 |       stack![a11, a12;
-   |  _____^
-13 | |            a21, a22];
-   | |____________________^ method not found in `Matrix<_, _, Const<4>, _>`
-   |
-  ::: src/base/matrix_view.rs
-   |
-   |        generic_slice_mut => generic_view_mut,
-   |                             ---------------- the method is available for `Matrix<_, _, Const<4>, _>` here
-   |
-   = note: the method was found for
-           - `Matrix<T, R, C, S>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Current `main` branch targets rust 1.79 ; locally errors are different and are failing.

Ideally we wouldn't have local fails, should `trybuild` tests be made with a more recent rust version ?

Are these new error messages expected ? Are they better or worse ?