### PR TITLE
Fix CI: `half` requiring rust 1.81

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -2,9 +2,9 @@ name: nalgebra CI build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -52,6 +52,19 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo build --all-features;
       - run: cargo build -p nalgebra-glm --all-features;
+  check-nalgebra-msrv:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Select rustc  version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.79.0
+          override: true
+      - uses: actions/checkout@v4
+      - name: check
+        run: cargo check --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
   test-nalgebra:
     runs-on: ubuntu-latest
     #    env:
@@ -64,7 +77,7 @@ jobs:
       - name: Select rustc  version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           override: true
       - uses: actions/checkout@v4
       - name: test

--- a/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `ShapeConstraint: SameNumberOfColumns<Const<2>, Co
    |            ^^^ the trait `SameNumberOfColumns<Const<2>, Const<3>>` is not implemented for `ShapeConstraint`
    |
    = help: the following other types implement trait `SameNumberOfColumns<D1, D2>`:
-             <ShapeConstraint as SameNumberOfColumns<D, D>>
-             <ShapeConstraint as SameNumberOfColumns<D, Dyn>>
-             <ShapeConstraint as SameNumberOfColumns<Dyn, D>>
+             `ShapeConstraint` implements `SameNumberOfColumns<D, D>`
+             `ShapeConstraint` implements `SameNumberOfColumns<D, Dyn>`
+             `ShapeConstraint` implements `SameNumberOfColumns<Dyn, D>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
@@ -26,11 +26,6 @@ error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, Con
    |  _____^
 12 | |            a21, a22];
    | |____________________^ method not found in `Matrix<_, Const<3>, _, _>`
-   |
-  ::: src/base/matrix_view.rs
-   |
-   |        generic_slice_mut => generic_view_mut,
-   |                             ---------------- the method is available for `Matrix<_, Const<3>, _, _>` here
    |
    = note: the method was found for
            - `Matrix<T, R, C, S>`

--- a/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `ShapeConstraint: SameNumberOfRows<Const<1>, Const
    |                 ^^^ the trait `SameNumberOfRows<Const<1>, Const<2>>` is not implemented for `ShapeConstraint`
    |
    = help: the following other types implement trait `SameNumberOfRows<D1, D2>`:
-             <ShapeConstraint as SameNumberOfRows<D, D>>
-             <ShapeConstraint as SameNumberOfRows<D, Dyn>>
-             <ShapeConstraint as SameNumberOfRows<Dyn, D>>
+             `ShapeConstraint` implements `SameNumberOfRows<D, D>`
+             `ShapeConstraint` implements `SameNumberOfRows<D, Dyn>`
+             `ShapeConstraint` implements `SameNumberOfRows<Dyn, D>`
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed
@@ -26,11 +26,6 @@ error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, _, 
    |  _____^
 13 | |            a21, a22];
    | |____________________^ method not found in `Matrix<_, _, Const<4>, _>`
-   |
-  ::: src/base/matrix_view.rs
-   |
-   |        generic_slice_mut => generic_view_mut,
-   |                             ---------------- the method is available for `Matrix<_, _, Const<4>, _>` here
    |
    = note: the method was found for
            - `Matrix<T, R, C, S>`


### PR DESCRIPTION
Criterion brings `half` crate which Minimum Supported Rust Version is 1.81, so CI is failing, let's discuss how to fix:

- I bumped rust version and kept a check on MSRV.
- I updated the expected error message for rust 1.81 ; https://github.com/dimforge/nalgebra/pull/1504 may be relevant

I removed the warning to errors, let's see how it goes.