### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Changelog
 
 All notable changes to `nalgebra`, starting with the version 0.6.0 will be
 documented here.
@@ -445,28 +445,28 @@ but it will be deprecated soon in favor of the `nalgebra-sparse` crate.
 
 ### Added
 
-* Add `UnitDualQuaternion`, a dual-quaternion with unit magnitude which can be used as an isometry transformation.
-* Add `UDU::new()` and `matrix.udu()` to compute the UDU factorization of a matrix.
-* Add `ColPivQR::new()` and `matrix.col_piv_qr()` to compute the QR decomposition with column pivoting of a matrix.
-* Add `from_basis_unchecked` to all the rotation types. This builds a rotation from a set of basis vectors (representing
+- Add `UnitDualQuaternion`, a dual-quaternion with unit magnitude which can be used as an isometry transformation.
+- Add `UDU::new()` and `matrix.udu()` to compute the UDU factorization of a matrix.
+- Add `ColPivQR::new()` and `matrix.col_piv_qr()` to compute the QR decomposition with column pivoting of a matrix.
+- Add `from_basis_unchecked` to all the rotation types. This builds a rotation from a set of basis vectors (representing
   the columns of the corresponding rotation matrix).
-* Add `Matrix::cap_magnitude` to cap the magnitude of a vector.
-* Add `UnitQuaternion::append_axisangle_linearized` to approximately append a rotation represented as an axis-angle to a
+- Add `Matrix::cap_magnitude` to cap the magnitude of a vector.
+- Add `UnitQuaternion::append_axisangle_linearized` to approximately append a rotation represented as an axis-angle to a
   rotation represented as an unit quaternion.
-* Mark the iterators on matrix components as `DoubleEndedIter`.
-* Re-export `simba::simd::SimdValue` at the root of the `nalgebra` crate.
+- Mark the iterators on matrix components as `DoubleEndedIter`.
+- Re-export `simba::simd::SimdValue` at the root of the `nalgebra` crate.
 
 ## [0.24.0]
 
 ### Added
 
-* The `DualQuaternion` type. It is still work-in-progress, but the basics are here:
+- The `DualQuaternion` type. It is still work-in-progress, but the basics are here:
   creation from its real and dual part, multiplication of two dual quaternions,
   and normalization.
 
 ### Removed
 
-* There is no blanket `impl<T> PartialEq for Unit<T>` anymore. Instead, it is
+- There is no blanket `impl<T> PartialEq for Unit<T>` anymore. Instead, it is
   implemented specifically for `UnitComplex`, `UnitQuaternion` and `Unit<Vector>`.
 
 ## [0.23.2]
@@ -476,7 +476,7 @@ by applying changes similar to what we did in the version 0.23.1 for matrices.
 
 ### Added
 
-* The `Isometry::inv_mul` method which is a more efficient way of doing
+- The `Isometry::inv_mul` method which is a more efficient way of doing
   `isometry1.inverse() * isometry2`.
 
 ## [0.23.1]
@@ -492,20 +492,20 @@ In this release we improved the documentation of the matrix and vector types by:
 
 ### Added
 
-* The `.inverse_transform_unit_vector(v)` was added to `Rotation2/3`, `Isometry2/3`, `UnitQuaternion`,
+- The `.inverse_transform_unit_vector(v)` was added to `Rotation2/3`, `Isometry2/3`, `UnitQuaternion`,
   and `UnitComplex`.
   It applies the corresponding rotation to a unit vector `Unit<Vector2/3>`.
-* The `Point.map(f)` and `Point.apply(f)` to apply a function to each component of the point, similarly
+- The `Point.map(f)` and `Point.apply(f)` to apply a function to each component of the point, similarly
   to `Vector.map(f)`
   and `Vector.apply(f)`.
-* The `Quaternion::from([N; 4])` conversion to build a quaternion from an array of four elements.
-* The `Isometry::from(Translation)` conversion to build an isometry from a translation.
-* The `Vector::ith_axis(i)` which build a unit vector, e.g., `Unit<Vector3<f32>>` with its i-th component set to 1.0,
+- The `Quaternion::from([N; 4])` conversion to build a quaternion from an array of four elements.
+- The `Isometry::from(Translation)` conversion to build an isometry from a translation.
+- The `Vector::ith_axis(i)` which build a unit vector, e.g., `Unit<Vector3<f32>>` with its i-th component set to 1.0,
   and the
   others set to zero.
-* The `Isometry.lerp_slerp` and `Isometry.try_lerp_slerp` methods to interpolate between two isometries using linear
+- The `Isometry.lerp_slerp` and `Isometry.try_lerp_slerp` methods to interpolate between two isometries using linear
   interpolation for the translational part, and spherical interpolation for the rotational part.
-* The `Rotation2.slerp`, `Rotation3.slerp`, and `UnitQuaternion.slerp` method for
+- The `Rotation2.slerp`, `Rotation3.slerp`, and `UnitQuaternion.slerp` method for
   spherical interpolation.
 
 ## [0.22.0]
@@ -517,14 +517,14 @@ of nalgebra for your code to compile again.
 
 ### Added
 
-* The `libm` feature that enables `libm` when building for `no-std` environment.
-* The `libm-force` feature that enables `libm` even when building for a not `no-std` environment.
-* `Cholesky::new_unchecked` which build a Cholesky decomposition without checking that its input is
+- The `libm` feature that enables `libm` when building for `no-std` environment.
+- The `libm-force` feature that enables `libm` even when building for a not `no-std` environment.
+- `Cholesky::new_unchecked` which build a Cholesky decomposition without checking that its input is
   positive-definite. It can be used with SIMD types.
-* The `Default` trait is now implemented for matrices, and quaternions. They are all filled with zeros,
+- The `Default` trait is now implemented for matrices, and quaternions. They are all filled with zeros,
   except for `UnitQuaternion` which is initialized with the identity.
-* Matrix exponential `matrix.exp()`.
-* The `Vector::ith(i, x)` that builds a vector filled with zeros except for the `i`-th component set to `x`.
+- Matrix exponential `matrix.exp()`.
+- The `Vector::ith(i, x)` that builds a vector filled with zeros except for the `i`-th component set to `x`.
 
 ## [0.21.0]
 
@@ -537,53 +537,53 @@ for details about this switch and its benefits.
 
 ### Added
 
-* It is now possible to use SIMD types like `simba::f32x4` as scalar types for nalgebra's matrices and
+- It is now possible to use SIMD types like `simba::f32x4` as scalar types for nalgebra's matrices and
   geometric types.
 
 ### Modified
 
-* Use of traits like `alga::general::{RealField, ComplexField}` have now been replaced by
+- Use of traits like `alga::general::{RealField, ComplexField}` have now been replaced by
   `simba::scalar::{RealField, ComplexField}`.
-* The implementation of traits from the __alga__ crate (and well as the dependency to _alga__) are now
+- The implementation of traits from the __alga__ crate (and well as the dependency to _alga__) are now
   omitted unless the `alga` cargo feature is activated.
 
 ### Removed
 
-* The `Neg` unary operator is no longer implemented for `UnitComplex` and `UnitQuaternion`. This caused
+- The `Neg` unary operator is no longer implemented for `UnitComplex` and `UnitQuaternion`. This caused
   hard-to-track errors when we mistakenly write, e.g., `-q * v` instead of `-(q * v)`.
-* The `na::convert_unchecked` is no longer marked as unsafe.
+- The `na::convert_unchecked` is no longer marked as unsafe.
 
 ## [0.20.0]
 
 ### Added
 
-* `cholesky.rank_one_update(...)` which performs a rank-one update on the cholesky decomposition of a matrix.
-* `From<&Matrix>` is now implemented for matrix slices.
-* `.try_set_magnitude(...)` which sets the magnitude of a vector, while keeping its direction.
-* Implementations of `From` and `Into` for the conversion between matrix slices and standard (`&[N]` `&mut [N]`) slices.
+- `cholesky.rank_one_update(...)` which performs a rank-one update on the cholesky decomposition of a matrix.
+- `From<&Matrix>` is now implemented for matrix slices.
+- `.try_set_magnitude(...)` which sets the magnitude of a vector, while keeping its direction.
+- Implementations of `From` and `Into` for the conversion between matrix slices and standard (`&[N]` `&mut [N]`) slices.
 
 ### Modified
 
-* We started some major changes in order to allow non-Copy types to be used as scalar types inside of matrices/vectors.
+- We started some major changes in order to allow non-Copy types to be used as scalar types inside of matrices/vectors.
 
 ## [0.19.0]
 
 ### Added
 
-* `.remove_rows_at` and `remove_columns_at` which removes a set of rows or columns (specified by indices) from a matrix.
-* Several formatting traits have been implemented for all matrices/vectors: `LowerExp`, `UpperExp`, `Octal`, `LowerHex`,
+- `.remove_rows_at` and `remove_columns_at` which removes a set of rows or columns (specified by indices) from a matrix.
+- Several formatting traits have been implemented for all matrices/vectors: `LowerExp`, `UpperExp`, `Octal`, `LowerHex`,
   `UpperHex`, `Binary`, `Pointer`.
-* `UnitQuaternion::quaternions_mean(...)` which computes the mean rotation of a set of unit quaternions. This implements
+- `UnitQuaternion::quaternions_mean(...)` which computes the mean rotation of a set of unit quaternions. This implements
   the algorithm from _Oshman, Yaakov, and Avishy Carmi, "Attitude estimation from vector observations using a
   genetic-algorithm-embedded quaternion particle filter."
 
 ### Modified
 
-* It is now possible to get the `min/max` element of unsigned integer matrices.
+- It is now possible to get the `min/max` element of unsigned integer matrices.
 
 ### Added to nalgebra-glm
 
-* Some infinite and reversed perspectives: `::infinite_perspective_rh_no`, `::infinite_perspective_rh_zo`,
+- Some infinite and reversed perspectives: `::infinite_perspective_rh_no`, `::infinite_perspective_rh_zo`,
   `::reversed_perspective_rh_zo`, and `::reversed_infinite_perspective_rh_zo`.
 
 ## [0.18.0]
@@ -596,99 +596,99 @@ as matrix decomposition. This excludes geometric type (like `Isometry`, `Rotatio
 
 #### Quaternion and geometric operations
 
-* Add trigonometric functions for
+- Add trigonometric functions for
   quaternions: `.cos, .sin, .tan, .acos, .asin, .atan, .cosh, .sinh, .tanh, .acosh, .asinh, .atanh`.
-* Add geometric algebra operations for quaternions: `.inner, .outer, .project, .rejection`
-* Add `.left_div, .right_div` for quaternions.
-* Add `.renormalize` to `Unit<...>` and `Rotation3` to correct potential drift due to repeated operations.
+- Add geometric algebra operations for quaternions: `.inner, .outer, .project, .rejection`
+- Add `.left_div, .right_div` for quaternions.
+- Add `.renormalize` to `Unit<...>` and `Rotation3` to correct potential drift due to repeated operations.
   Those drifts could cause them not to be pure rotations anymore.
 
 #### Convolution
 
-* `.convolve_full(kernel)` returns the convolution of `self` by `kernel`.
-* `.convolve_valid(kernel)` returns the convolution of `self` by `kernel` after removal of all the elements relying on
+- `.convolve_full(kernel)` returns the convolution of `self` by `kernel`.
+- `.convolve_valid(kernel)` returns the convolution of `self` by `kernel` after removal of all the elements relying on
   zero-padding.
-* `.convolve_same(kernel)` returns the convolution of `self` by `kernel` with a result of the same size as `self`.
+- `.convolve_same(kernel)` returns the convolution of `self` by `kernel` with a result of the same size as `self`.
 
 #### Complex number support
 
-* Add the `::from_matrix` constructor too all rotation types to extract a rotation from a raw matrix.
-* Add the `::from_matrix_eps` constructor too all rotation types to extract a rotation from a raw matrix. This takes
+- Add the `::from_matrix` constructor too all rotation types to extract a rotation from a raw matrix.
+- Add the `::from_matrix_eps` constructor too all rotation types to extract a rotation from a raw matrix. This takes
   more argument than `::from_matrix` to control the convergence of the underlying optimization algorithm.
-* Add `.camax()` which returns the matrix component with the greatest L1-norm.
-* Add `.camin()` which returns the matrix component with the smallest L1-norm.
-* Add `.ad_mul(b)` for matrix-multiplication of `self.adjoint() * b`.
-* Add `.ad_mul_to(b)` which is the same as `.ad_mul` but with a provided matrix to be filled with the result of the
+- Add `.camax()` which returns the matrix component with the greatest L1-norm.
+- Add `.camin()` which returns the matrix component with the smallest L1-norm.
+- Add `.ad_mul(b)` for matrix-multiplication of `self.adjoint() * b`.
+- Add `.ad_mul_to(b)` which is the same as `.ad_mul` but with a provided matrix to be filled with the result of the
   multiplication.
-* Add BLAS operations involving complex conjugation (following similar names as the original BLAS spec):
-    * `.dotc(rhs)` equal to  `self.adjoint() * rhs`.
-    * `.gerc(alpha, x, y, beta)` equivalent to `self = alpha * x * y.adjoint() + beta * self`
-    * `.hegerc` which is like `gerc` but for Hermitian matrices.
-    * `.syger` which is the new name of `.ger_symm` which is equivalent
+- Add BLAS operations involving complex conjugation (following similar names as the original BLAS spec):
+  - `.dotc(rhs)` equal to  `self.adjoint() * rhs`.
+  - `.gerc(alpha, x, y, beta)` equivalent to `self = alpha * x * y.adjoint() + beta * self`
+  - `.hegerc` which is like `gerc` but for Hermitian matrices.
+  - `.syger` which is the new name of `.ger_symm` which is equivalent
       to `self = alpha * x * y.transpose() + beta * self`.
-    * `.sygemv` which is the new name of `.gemv_symm` which is equivalent to `self = alpha * a * x + beta * self`
+  - `.sygemv` which is the new name of `.gemv_symm` which is equivalent to `self = alpha * a * x + beta * self`
       with `a` symmetric.
-    * `.hegemv(alpha, a, x, beta)` which is like `.sygemv` but with `a` Hermitian.
-    * `.gemv_ad(alpha, a, x, beta)` which is equivalent to `self = alpha * a.adjoint() * x + beta * self`.
-    * `.gemm_ad(alpha, a, b, beta)` which is equivalent to `self = alpha * a.adjoint() * b + beta * self`.
-    * `.icamax()` which returns the index of the complex vector component with the greatest L1-norm.
+  - `.hegemv(alpha, a, x, beta)` which is like `.sygemv` but with `a` Hermitian.
+  - `.gemv_ad(alpha, a, x, beta)` which is equivalent to `self = alpha * a.adjoint() * x + beta * self`.
+  - `.gemm_ad(alpha, a, b, beta)` which is equivalent to `self = alpha * a.adjoint() * b + beta * self`.
+  - `.icamax()` which returns the index of the complex vector component with the greatest L1-norm.
 
 Note that all the other BLAS operation will continue to work for all fields, including floats and complex numbers.
 
 ### Renamed
 
-* `RealSchur` has been renamed `Schur` because it can now work with complex matrices.
+- `RealSchur` has been renamed `Schur` because it can now work with complex matrices.
 
 ## [0.17.0]
 
 ### Added
 
-* Add swizzling up to dimension 3 for vectors. For example, you can do `v.zxy()` as an equivalent
+- Add swizzling up to dimension 3 for vectors. For example, you can do `v.zxy()` as an equivalent
   to `Vector3::new(v.z, v.x, v.y)`.
-* Add swizzling up to dimension 3 for points. For example, you can do `p.zxy()` as an equivalent
+- Add swizzling up to dimension 3 for points. For example, you can do `p.zxy()` as an equivalent
   to `Point3::new(p.z, p.x, p.y)`.
-* Add `.copy_from_slice` to copy matrix components from a slice in column-major order.
-* Add `.dot` to quaternions.
-* Add `.zip_zip_map` for iterating on three matrices simultaneously, and applying a closure to them.
-* Add `.slerp` and `.try_slerp` to unit vectors.
-* Add `.lerp` to vectors.
-* Add `.to_projective` and `.as_projective` to `Perspective3` and `Orthographic3` in order to
+- Add `.copy_from_slice` to copy matrix components from a slice in column-major order.
+- Add `.dot` to quaternions.
+- Add `.zip_zip_map` for iterating on three matrices simultaneously, and applying a closure to them.
+- Add `.slerp` and `.try_slerp` to unit vectors.
+- Add `.lerp` to vectors.
+- Add `.to_projective` and `.as_projective` to `Perspective3` and `Orthographic3` in order to
   use them as `Projective3` structures.
-* Add `From/Into` impls to allow the conversion of any transformation type to a matrix.
-* Add `Into` impls to convert a matrix slice into an owned matrix.
-* Add `Point*::from_slice` to create a point from a slice.
-* Add `.map_with_location` to matrices to apply a map which passes the component indices to the user-defined closure
+- Add `From/Into` impls to allow the conversion of any transformation type to a matrix.
+- Add `Into` impls to convert a matrix slice into an owned matrix.
+- Add `Point*::from_slice` to create a point from a slice.
+- Add `.map_with_location` to matrices to apply a map which passes the component indices to the user-defined closure
   alongside
   the component itself.
-* Add impl `From<Vector>` for `Point`.
-* Add impl `From<Vector4>` for `Quaternion`.
-* Add impl `From<Vector>` for `Translation`.
-* Add the `::from_vec` constructor to construct a matrix from a `Vec` (a `DMatrix` will reuse the original `Vec`
+- Add impl `From<Vector>` for `Point`.
+- Add impl `From<Vector4>` for `Quaternion`.
+- Add impl `From<Vector>` for `Translation`.
+- Add the `::from_vec` constructor to construct a matrix from a `Vec` (a `DMatrix` will reuse the original `Vec`
   as-is for its storage).
-* Add `.to_homogeneous` to square matrices (and with dimensions higher than 1x1). This will increase their number of row
+- Add `.to_homogeneous` to square matrices (and with dimensions higher than 1x1). This will increase their number of row
   and columns by 1. The new column and row are filled with 0, except for the diagonal element which is set to 1.
-* Implement `Extend<Vec>` for matrices with a dynamic storage. The provided `Vec` is assumed to represent a column-major
+- Implement `Extend<Vec>` for matrices with a dynamic storage. The provided `Vec` is assumed to represent a column-major
   matrix with the same number of rows as the one being extended. This will effectively append new columns on the right
   of
   the matrix being extended.
-* Implement `Extend<Vec>` for vectors with a dynamic storage. This will concatenate the vector with the given `Vec`.
-* Implement `Extend<Matrix<...>>` for matrices with dynamic storage. This will concatenate the columns of both matrices.
-* Implement `Into<Vec>` for the `MatrixVec` storage.
-* Implement `Hash` for all matrices.
-* Add a `.len()` method to retrieve the size of a `MatrixVec`.
+- Implement `Extend<Vec>` for vectors with a dynamic storage. This will concatenate the vector with the given `Vec`.
+- Implement `Extend<Matrix<...>>` for matrices with dynamic storage. This will concatenate the columns of both matrices.
+- Implement `Into<Vec>` for the `MatrixVec` storage.
+- Implement `Hash` for all matrices.
+- Add a `.len()` method to retrieve the size of a `MatrixVec`.
 
 ### Modified
 
-* The orthographic projection no longer require that `bottom < top`, that `left < right`, and that `znear < zfar`. The
+- The orthographic projection no longer require that `bottom < top`, that `left < right`, and that `znear < zfar`. The
   only restriction now ith that they must not be equal (in which case the projection would be singular).
-* The `Point::from_coordinates` methods is deprecated. Use `Point::from` instead.
-* The `.transform_point` and `.transform_vector` methods are now inherent methods for matrices so that the user does not
+- The `Point::from_coordinates` methods is deprecated. Use `Point::from` instead.
+- The `.transform_point` and `.transform_vector` methods are now inherent methods for matrices so that the user does not
   have to
   explicitly import the `Transform` trait from the alga crate.
-* Renamed the matrix storage types: `MatrixArray` -> `ArrayStorage` and `MatrixVec` -> `VecStorage`.
-* Renamed `.unwrap()` to `.into_inner()` for geometric types that wrap another type.
+- Renamed the matrix storage types: `MatrixArray` -> `ArrayStorage` and `MatrixVec` -> `VecStorage`.
+- Renamed `.unwrap()` to `.into_inner()` for geometric types that wrap another type.
   This is for the case of `Unit`, `Transform`, `Orthographic3`, `Perspective3`, `Rotation`.
-* Deprecate several functions at the root of the crate (replaced by methods).
+- Deprecate several functions at the root of the crate (replaced by methods).
 
 ### Removed
 
@@ -696,8 +696,8 @@ Note that all the other BLAS operation will continue to work for all fields, inc
 
 ### nalgebra-glm
 
-* Add several alternative projection computations, e.g., `ortho_lh`, `ortho_lh_no`, `perspective_lh`, etc.
-* Add features matching those of nalgebra, in particular:`serde-serialize`, `abmonation-serialize`, std` (enabled by
+- Add several alternative projection computations, e.g., `ortho_lh`, `ortho_lh_no`, `perspective_lh`, etc.
+- Add features matching those of nalgebra, in particular:`serde-serialize`, `abmonation-serialize`, std` (enabled by
   default).
 
 ## [0.16.0]
@@ -706,15 +706,15 @@ All dependencies have been updated to their latest versions.
 
 ## Modified
 
-* Adjust `UnitQuaternion`s, `Rotation3`s, and `Rotation2`s generated from the `Standard` distribution to be uniformly
+- Adjust `UnitQuaternion`s, `Rotation3`s, and `Rotation2`s generated from the `Standard` distribution to be uniformly
   distributed.
 
 ### Added
 
-* Add a feature `stdweb` to activate the dependency feature `rand/stdweb`.
-* Add blas-like methods `.imin()` and `.imax()` that return the index of the minimum and maximum entry of a vector.
-* Add construction of a `Point` from an array by implementing the `From` trait.
-* Add support for generating uniformly distributed random unit column vectors using the `Standard` distribution.
+- Add a feature `stdweb` to activate the dependency feature `rand/stdweb`.
+- Add blas-like methods `.imin()` and `.imax()` that return the index of the minimum and maximum entry of a vector.
+- Add construction of a `Point` from an array by implementing the `From` trait.
+- Add support for generating uniformly distributed random unit column vectors using the `Standard` distribution.
 
 ## [0.15.0]
 
@@ -724,61 +724,61 @@ corresponding [documentation](https://nalgebra.org/wasm_and_embedded_programming
 
 ### Modified
 
-* Rename the `core` module to `base` to avoid conflicts with the `core` crate implicitly imported when
+- Rename the `core` module to `base` to avoid conflicts with the `core` crate implicitly imported when
   `#![no_std]` is enabled.
-* Constructors of the `MatrixSlice*` types have been renamed from `new_*` to `from_slice_*`. This was
+- Constructors of the `MatrixSlice*` types have been renamed from `new_*` to `from_slice_*`. This was
   necessary to avoid the `incoherent_fundamental_impls` lint that is going to become a hard error.
 
 ### Added
 
-* Add `UnitQuaternion` constructor `::new_eps(...)` and `::from_scaled_axis_eps(...)` that return the
+- Add `UnitQuaternion` constructor `::new_eps(...)` and `::from_scaled_axis_eps(...)` that return the
   identity if the magnitude of the input axisangle is smaller than the epsilon provided.
-* Add methods `.rotation_between_axis(...)` and `.scaled_rotation_between_axis(...)` to `UnitComplex`
-  to compute the rotation matrix between two 2D **unit** vectors.
-* Add methods `.axis_angle()` to `UnitComplex` and `UnitQuaternion` in order to retrieve both the
+- Add methods `.rotation_between_axis(...)` and `.scaled_rotation_between_axis(...)` to `UnitComplex`
+  to compute the rotation matrix between two 2D __unit__ vectors.
+- Add methods `.axis_angle()` to `UnitComplex` and `UnitQuaternion` in order to retrieve both the
   unit rotation axis, and the rotation angle simultaneously.
-* Add functions to construct a random matrix with a user-defined distribution: `::from_distribution(...)`.
+- Add functions to construct a random matrix with a user-defined distribution: `::from_distribution(...)`.
 
 ## [0.14.0]
 
 ### Modified
 
-* Allow the `Isometry * Unit<Vector>` multiplication.
+- Allow the `Isometry * Unit<Vector>` multiplication.
 
 ### Added
 
-* Add blas-like operations: `.quadform(...)` and `.quadform_tr(...)` to compute respectively
+- Add blas-like operations: `.quadform(...)` and `.quadform_tr(...)` to compute respectively
   the quadratic forms `self = alpha * A.transpose() * B * A + beta * self` and
   `alpha * A * B * A.transpose() + beta * self`. Here, `A, B` are matrices with
   `B` square, and `alpha, beta` are reals.
-* Add blas-like operations: `.gemv_tr(...)` that behaves like `.gemv` except that the
+- Add blas-like operations: `.gemv_tr(...)` that behaves like `.gemv` except that the
   provided matrix is assumed to be transposed.
-* Add blas-like operations: `cmpy, cdpy` for component-wise multiplications and
+- Add blas-like operations: `cmpy, cdpy` for component-wise multiplications and
   division with scalar factors:
-    - `self <- alpha * self + beta * a * b`
-    - `self <- alpha * self + beta * a / b`
-* `.cross_matrix()` returns the cross-product matrix of a given 3D vector, i.e.,
+  - `self <- alpha * self + beta * a * b`
+  - `self <- alpha * self + beta * a / b`
+- `.cross_matrix()` returns the cross-product matrix of a given 3D vector, i.e.,
   the matrix `M` such that for all vector `v` we have
   `M * v == self.cross(&v)`.
-* `.iamin()` that returns the index of the vector entry with
+- `.iamin()` that returns the index of the vector entry with
   the smallest absolute value.
-* The `mint` feature that can be enabled in order to allow conversions from
+- The `mint` feature that can be enabled in order to allow conversions from
   and to types of the [mint](https://crates.io/crates/mint) crate.
-* Aliases for matrix and vector slices. Their are named by adding `Slice`
+- Aliases for matrix and vector slices. Their are named by adding `Slice`
   before the dimension numbers, i.e., a 3x5 matrix slice with dimensions known
   at compile-time is called `MatrixSlice3x5`. A vector slice with dimensions
   unknown at compile-time is called `DVectorSlice`.
-* Add functions for constructing matrix slices from a slice `&[N]`, e.g.,
+- Add functions for constructing matrix slices from a slice `&[N]`, e.g.,
   `MatrixSlice2::new(...)` and `MatrixSlice2::new_with_strides(...)`.
-* The `::repeat(...)` constructor that is an alternative name to
+- The `::repeat(...)` constructor that is an alternative name to
   `::from_element(...)`.
-* `UnitQuaternion::scaled_rotation_between_axis(...)` and
+- `UnitQuaternion::scaled_rotation_between_axis(...)` and
   `UnitQuaternion::rotation_between_axis(...)` that take Unit vectors instead of
   Vector as arguments.
 
 ## [0.13.0]
 
-The **nalgebra-lapack** crate has been updated. This now includes a broad range
+The __nalgebra-lapack__ crate has been updated. This now includes a broad range
 matrix decompositions using LAPACK bindings.
 
 This adds support for serialization using the
@@ -786,7 +786,7 @@ This adds support for serialization using the
 
 ### Breaking semantic change
 
-* The implementation of slicing with steps now matches the documentation.
+- The implementation of slicing with steps now matches the documentation.
   Before, step identified the number to add to pass from one column/row index
   to the next one. This made 0 step invalid. Now (and on the documentation so
   far), the step is the number of ignored row/columns between each
@@ -795,103 +795,103 @@ This adds support for serialization using the
 
 ### Modified
 
-* The trait `Axpy` has been replaced by a method `.axpy`.
-* The alias `MatrixNM` is now deprecated. Use `MatrixMN` instead (we
+- The trait `Axpy` has been replaced by a method `.axpy`.
+- The alias `MatrixNM` is now deprecated. Use `MatrixMN` instead (we
   reordered M and N to be in alphabetical order).
-* In-place componentwise multiplication and division
+- In-place componentwise multiplication and division
   `.component_mul_mut(...)` and `.component_div_mut(...)` have been deprecated
   for a future renaming. Use `.component_mul_assign(...)` and
   `.component_div_assign(...)` instead.
 
 ### Added
 
-* `alga::general::Real` is now re-exported by nalgebra.
+- `alga::general::Real` is now re-exported by nalgebra.
   elements.)
-* `::zeros(...)` that creates a matrix filled with zeroes.
-* `::from_partial_diagonal(...)` that creates a matrix from diagonal elements.
+- `::zeros(...)` that creates a matrix filled with zeroes.
+- `::from_partial_diagonal(...)` that creates a matrix from diagonal elements.
   The matrix can be rectangular. If not enough elements are provided, the rest
   of the diagonal is set to 0.
-* `.conjugate_transpose()` computes the transposed conjugate of a
+- `.conjugate_transpose()` computes the transposed conjugate of a
   complex matrix.
-* `.conjugate_transpose_to(...)` computes the transposed conjugate of a
+- `.conjugate_transpose_to(...)` computes the transposed conjugate of a
   complex matrix. The result written into a user-provided matrix.
-* `.transpose_to(...)` is the same as `.transpose()` but stores the result in
+- `.transpose_to(...)` is the same as `.transpose()` but stores the result in
   the provided matrix.
-* `.conjugate_transpose_to(...)` is the same as `.conjugate_transpose()` but
+- `.conjugate_transpose_to(...)` is the same as `.conjugate_transpose()` but
   stores the result in the provided matrix.
-* Implements `IntoIterator` for `&Matrix`, `&mut Matrix` and `Matrix`.
-* `.mul_to(...)` multiplies two matrices and stores the result to the given buffer.
-* `.tr_mul_to(...)` left-multiplies `self.transpose()` to another matrix and stores the result to the given buffer.
-* `.add_scalar(...)` that adds a scalar to each component of a matrix.
-* `.add_scalar_mut(...)` that adds in-place a scalar to each component of a matrix.
-* `.kronecker(a, b)` computes the kronecker product (i.e. matrix tensor
+- Implements `IntoIterator` for `&Matrix`, `&mut Matrix` and `Matrix`.
+- `.mul_to(...)` multiplies two matrices and stores the result to the given buffer.
+- `.tr_mul_to(...)` left-multiplies `self.transpose()` to another matrix and stores the result to the given buffer.
+- `.add_scalar(...)` that adds a scalar to each component of a matrix.
+- `.add_scalar_mut(...)` that adds in-place a scalar to each component of a matrix.
+- `.kronecker(a, b)` computes the kronecker product (i.e. matrix tensor
   product) of two matrices.
-* `.apply(f)` replaces each component of a matrix with the results of the
+- `.apply(f)` replaces each component of a matrix with the results of the
   closure `f` called on each of them.
 
 Pure Rust implementation of some Blas operations:
 
-* `.iamax()` returns the index of the maximum value of a vector.
-* `.axpy(...)` computes `self = a * x + b * self`.
-* `.gemv(...)` computes `self = alpha * a * x + beta * self` with a matrix and vector `a` and `x`.
-* `.ger(...)` computes `self = alpha * x^t * y + beta * self` where `x` and `y` are vectors.
-* `.gemm(...)` computes `self = alpha * a * b + beta * self` where `a` and `b` are matrices.
-* `.gemv_symm(...)` is the same as `.gemv` except that `self` is assumed symmetric.
-* `.ger_symm(...)` is the same as `.ger` except that `self` is assumed symmetric.
+- `.iamax()` returns the index of the maximum value of a vector.
+- `.axpy(...)` computes `self = a * x + b * self`.
+- `.gemv(...)` computes `self = alpha * a * x + beta * self` with a matrix and vector `a` and `x`.
+- `.ger(...)` computes `self = alpha * x^t * y + beta * self` where `x` and `y` are vectors.
+- `.gemm(...)` computes `self = alpha * a * b + beta * self` where `a` and `b` are matrices.
+- `.gemv_symm(...)` is the same as `.gemv` except that `self` is assumed symmetric.
+- `.ger_symm(...)` is the same as `.ger` except that `self` is assumed symmetric.
 
 New slicing methods:
 
-* `.rows_range(...)` that retrieves a reference to a range of rows.
-* `.rows_range_mut(...)` that retrieves a mutable reference to a range of rows.
-* `.columns_range(...)` that retrieves a reference to a range of columns.
-* `.columns_range_mut(...)` that retrieves a mutable reference to a range of columns.
+- `.rows_range(...)` that retrieves a reference to a range of rows.
+- `.rows_range_mut(...)` that retrieves a mutable reference to a range of rows.
+- `.columns_range(...)` that retrieves a reference to a range of columns.
+- `.columns_range_mut(...)` that retrieves a mutable reference to a range of columns.
 
 Matrix decompositions implemented in pure Rust:
 
-* Cholesky, SVD, LU, QR, Hessenberg, Schur, Symmetric eigendecompositions,
+- Cholesky, SVD, LU, QR, Hessenberg, Schur, Symmetric eigendecompositions,
   Bidiagonal, Symmetric tridiagonal
-* Computation of householder reflectors and givens rotations.
+- Computation of householder reflectors and givens rotations.
 
 Matrix edition:
 
-* `.upper_triangle()` extracts the upper triangle of a matrix, including the diagonal.
-* `.lower_triangle()` extracts the lower triangle of a matrix, including the diagonal.
-* `.fill(...)` fills the matrix with a single value.
-* `.fill_with_identity(...)` fills the matrix with the identity.
-* `.fill_diagonal(...)` fills the matrix diagonal with a single value.
-* `.fill_row(...)` fills a selected matrix row with a single value.
-* `.fill_column(...)` fills a selected matrix column with a single value.
-* `.set_diagonal(...)` sets the matrix diagonal.
-* `.set_row(...)` sets a selected row.
-* `.set_column(...)` sets a selected column.
-* `.fill_lower_triangle(...)` fills some sub-diagonals below the main diagonal with a value.
-* `.fill_upper_triangle(...)` fills some sub-diagonals above the main diagonal with a value.
-* `.swap_rows(...)` swaps two rows.
-* `.swap_columns(...)` swaps two columns.
+- `.upper_triangle()` extracts the upper triangle of a matrix, including the diagonal.
+- `.lower_triangle()` extracts the lower triangle of a matrix, including the diagonal.
+- `.fill(...)` fills the matrix with a single value.
+- `.fill_with_identity(...)` fills the matrix with the identity.
+- `.fill_diagonal(...)` fills the matrix diagonal with a single value.
+- `.fill_row(...)` fills a selected matrix row with a single value.
+- `.fill_column(...)` fills a selected matrix column with a single value.
+- `.set_diagonal(...)` sets the matrix diagonal.
+- `.set_row(...)` sets a selected row.
+- `.set_column(...)` sets a selected column.
+- `.fill_lower_triangle(...)` fills some sub-diagonals below the main diagonal with a value.
+- `.fill_upper_triangle(...)` fills some sub-diagonals above the main diagonal with a value.
+- `.swap_rows(...)` swaps two rows.
+- `.swap_columns(...)` swaps two columns.
 
 Column removal:
 
-* `.remove_column(...)` removes one column.
-* `.remove_fixed_columns<D>(...)` removes `D` columns.
-* `.remove_columns(...)` removes a number of columns known at run-time.
+- `.remove_column(...)` removes one column.
+- `.remove_fixed_columns<D>(...)` removes `D` columns.
+- `.remove_columns(...)` removes a number of columns known at run-time.
 
 Row removal:
 
-* `.remove_row(...)` removes one row.
-* `.remove_fixed_rows<D>(...)` removes `D` rows.
-* `.remove_rows(...)` removes a number of rows known at run-time.
+- `.remove_row(...)` removes one row.
+- `.remove_fixed_rows<D>(...)` removes `D` rows.
+- `.remove_rows(...)` removes a number of rows known at run-time.
 
 Column insertion:
 
-* `.insert_column(...)` adds one column at the given position.
-* `.insert_fixed_columns<D>(...)` adds `D` columns at the given position.
-* `.insert_columns(...)` adds at the given position a number of columns known at run-time.
+- `.insert_column(...)` adds one column at the given position.
+- `.insert_fixed_columns<D>(...)` adds `D` columns at the given position.
+- `.insert_columns(...)` adds at the given position a number of columns known at run-time.
 
 Row insertion:
 
-* `.insert_row(...)` adds one row at the given position.
-* `.insert_fixed_rows<D>(...)` adds `D` rows at the given position.
-* `.insert_rows(...)` adds at the given position a number of rows known at run-time.
+- `.insert_row(...)` adds one row at the given position.
+- `.insert_fixed_rows<D>(...)` adds `D` rows at the given position.
+- `.insert_rows(...)` adds at the given position a number of rows known at run-time.
 
 ## [0.12.0]
 
@@ -899,7 +899,7 @@ The main change of this release is the update of the dependency serde to 1.0.
 
 ### Added
 
-* `.trace()` that computes the trace of a matrix (the sum of its diagonal
+- `.trace()` that computes the trace of a matrix (the sum of its diagonal
   elements.)
 
 ## [0.11.0]
@@ -909,21 +909,21 @@ overview of all the added/modified features.
 
 This version is a major rewrite of the library. Major changes are:
 
-* Algebraic traits are now defined by the [alga](https://crates.io/crates/alga) crate.
+- Algebraic traits are now defined by the [alga](https://crates.io/crates/alga) crate.
   All other mathematical traits, except `Axpy` have been removed from
-  **nalgebra**.
-* Methods are now preferred to free functions because they do not require any
+  __nalgebra__.
+- Methods are now preferred to free functions because they do not require any
   trait to be used anymore.
-* Most algebraic entities can be parametrized by type-level integers
+- Most algebraic entities can be parametrized by type-level integers
   to specify their dimensions. Using `Dynamic` instead of a type-level
   integer indicates that the dimension known at run-time only.
-* Statically-sized **rectangular** matrices.
-* More transformation types have been added: unit-sized complex numbers (for
+- Statically-sized __rectangular__ matrices.
+- More transformation types have been added: unit-sized complex numbers (for
   2D rotations), affine/projective/general transformations with `Affine2/3`,
   `Projective2/3`, and `Transform2/3`.
-* Serde serialization is now supported instead of `rustc_serialize`. Enable
+- Serde serialization is now supported instead of `rustc_serialize`. Enable
   it with the `serde-serialize` feature.
-* Matrix **slices** are now implemented.
+- Matrix __slices__ are now implemented.
 
 ### Added
 
@@ -931,29 +931,29 @@ Lots of features including rectangular matrices, slices, and Serde
 serialization. Refer to the brand new [website](https://nalgebra.org) for more
 details. The following free-functions have been added as well:
 
-* `::id()` that returns the universal [identity element](https://nalgebra.org/performance_tricks/#the-id-type)
+- `::id()` that returns the universal [identity element](https://nalgebra.org/performance_tricks/#the-id-type)
   of type `Id`.
-* `::inf_sup()` that returns both the infimum and supremum of a value at the
+- `::inf_sup()` that returns both the infimum and supremum of a value at the
   same time.
-* `::partial_sort2()` that attempts to sort two values in increasing order.
-* `::wrap()` that moves a value to the given interval by adding or removing
+- `::partial_sort2()` that attempts to sort two values in increasing order.
+- `::wrap()` that moves a value to the given interval by adding or removing
   the interval width to it.
 
 ### Modified
 
-* `::cast`            -> `::convert`
-* `point.as_vector()` -> `point.coords`
-* `na::origin`        -> `P::origin()`
-* `na::is_zero`       -> `.is_zero()` (from num::Zero)
-* `.transform`        -> `.transform_point`/`.transform_vector`
-* `.translate`        -> `.translate_point`
-* `::dimension::<P>`  -> `::dimension::<P::Vector>`
-* `::angle_between`   -> `::angle`
+- `::cast`            -> `::convert`
+- `point.as_vector()` -> `point.coords`
+- `na::origin`        -> `P::origin()`
+- `na::is_zero`       -> `.is_zero()` (from num::Zero)
+- `.transform`        -> `.transform_point`/`.transform_vector`
+- `.translate`        -> `.translate_point`
+- `::dimension::<P>`  -> `::dimension::<P::Vector>`
+- `::angle_between`   -> `::angle`
 
 Componentwise multiplication and division has been replaced by methods:
 
-* multiplication -> `.componentwise_mul`, `.componentwise_mul_mut`.
-* division -> `.componentwise_div`, `.componentwise_div_mut`.
+- multiplication -> `.componentwise_mul`, `.componentwise_mul_mut`.
+- division -> `.componentwise_div`, `.componentwise_div_mut`.
 
 The following free-functions are now replaced by methods (with the same names)
 only:
@@ -963,51 +963,51 @@ only:
 
 The following free-functions are now replaced by static methods only:
 
-* `::householder_matrix` under the name `::new_householder_generic`
-* `::identity`
-* `::new_identity` under the name `::identity`
-* `::from_homogeneous`
-* `::repeat` under the name `::from_element`
+- `::householder_matrix` under the name `::new_householder_generic`
+- `::identity`
+- `::new_identity` under the name `::identity`
+- `::from_homogeneous`
+- `::repeat` under the name `::from_element`
 
 The following free-function are now replaced methods accessible through traits
 only:
 
-* `::transform` -> methods `.transform_point` and `.transform_vector` of the `alga::linear::Transformation` trait.
-* `::inverse_transform` -> methods `.inverse_transform_point` and
+- `::transform` -> methods `.transform_point` and `.transform_vector` of the `alga::linear::Transformation` trait.
+- `::inverse_transform` -> methods `.inverse_transform_point` and
   `.inverse_transform_vector` of the `alga::linear::ProjectiveTransformation`
   trait.
-* `::translate`, `::inverse_translate`, `::rotate`, `::inverse_rotate` ->
+- `::translate`, `::inverse_translate`, `::rotate`, `::inverse_rotate` ->
   methods from the `alga::linear::Similarity` trait instead. Those have the
   same names but end with `_point` or `_vector`, e.g., `.translate_point` and
   `.translate_vector`.
-* `::orthonormal_subspace_basis` -> method with the same name from
+- `::orthonormal_subspace_basis` -> method with the same name from
   `alga::linear::FiniteDimInnerSpace`.
-* `::canonical_basis_element` and `::canonical_basis` -> methods with the
+- `::canonical_basis_element` and `::canonical_basis` -> methods with the
   same names from `alga::linear::FiniteDimVectorSpace`.
-* `::rotation_between` -> method with the same name from the
+- `::rotation_between` -> method with the same name from the
   `alga::linear::Rotation` trait.
-* `::is_zero` -> method with the same name from `num::Zero`.
+- `::is_zero` -> method with the same name from `num::Zero`.
 
 ### Removed
 
-* The free functions `::prepend_rotation`, `::append_rotation`,
+- The free functions `::prepend_rotation`, `::append_rotation`,
   `::append_rotation_wrt_center`, `::append_rotation_wrt_point`,
-  `::append_transformation`, and `::append_translation ` have been removed.
+  `::append_transformation`, and `::append_translation` have been removed.
   Instead, create the rotation or translation object explicitly and use
   multiplication to compose it with anything else.
 
-* The free function `::outer` has been removed. Use column-vector ×
+- The free function `::outer` has been removed. Use column-vector ×
   row-vector multiplication instead.
 
-* `::approx_eq`, `::approx_eq_eps` have been removed. Use the `relative_eq!`
+- `::approx_eq`, `::approx_eq_eps` have been removed. Use the `relative_eq!`
   macro from the [approx](https://crates.io/crates/approx) crate instead.
 
-* `::covariance` has been removed. There is no replacement for now.
-* `::mean` has been removed. There is no replacement for now.
-* `::sample_sphere` has been removed. There is no replacement for now.
-* `::cross_matrix` has been removed. There is no replacement for now.
-* `::absolute_rotate` has been removed. There is no replacement for now.
-* `::rotation`, `::transformation`, `::translation`, `::inverse_rotation`,
+- `::covariance` has been removed. There is no replacement for now.
+- `::mean` has been removed. There is no replacement for now.
+- `::sample_sphere` has been removed. There is no replacement for now.
+- `::cross_matrix` has been removed. There is no replacement for now.
+- `::absolute_rotate` has been removed. There is no replacement for now.
+- `::rotation`, `::transformation`, `::translation`, `::inverse_rotation`,
   `::inverse_transformation`, `::inverse_translation` have been removed. Use
   the appropriate methods/field of each transformation type, e.g.,
   `rotation.angle()` and `rotation.axis()`.
@@ -1031,15 +1031,15 @@ since it now allowed to write for a type `T` that implements `ApproxEq`:
 
 ### Modified
 
-* Renamed:
-    - `::from_col_vector` -> `::from_column_vector`
-    - `::from_col_iter` -> `::from_column_iter`
-    - `.col_slice` -> `.column_slice`
-    - `.set_col` -> `.set_column`
-    - `::canonical_basis_with_dim` -> `::canonical_basis_with_dimension`
-    - `::from_elem` -> `::from_element`
-    - `DiagMut` -> `DiagonalMut`
-    - `UnitQuaternion::new` becomes `UnitQuaternion::from_scaled_axis` or
+- Renamed:
+  - `::from_col_vector` -> `::from_column_vector`
+  - `::from_col_iter` -> `::from_column_iter`
+  - `.col_slice` -> `.column_slice`
+  - `.set_col` -> `.set_column`
+  - `::canonical_basis_with_dim` -> `::canonical_basis_with_dimension`
+  - `::from_elem` -> `::from_element`
+  - `DiagMut` -> `DiagonalMut`
+  - `UnitQuaternion::new` becomes `UnitQuaternion::from_scaled_axis` or
       `UnitQuaternion::from_axisangle`. The new `::new` method now requires a
       not-normalized quaternion.
 
@@ -1053,9 +1053,9 @@ Other similar trait changes are to be expected in the future, e.g., for the
 Methods marked `unsafe` for reasons unrelated to memory safety are no
 longer unsafe. Instead, their name end with `_unchecked`. In particular:
 
-* `Rotation3::new_with_matrix` -> `Rotation3::from_matrix_unchecked`
-* `PerspectiveMatrix3::new_with_matrix` -> `PerspectiveMatrix3::from_matrix_unchecked`
-* `OrthographicMatrix3::new_with_matrix` -> `OrthographicMatrix3::from_matrix_unchecked`
+- `Rotation3::new_with_matrix` -> `Rotation3::from_matrix_unchecked`
+- `PerspectiveMatrix3::new_with_matrix` -> `PerspectiveMatrix3::from_matrix_unchecked`
+- `OrthographicMatrix3::new_with_matrix` -> `OrthographicMatrix3::from_matrix_unchecked`
 
 ### Added
 
@@ -1078,58 +1078,58 @@ crate for vectors, rotations and points. To enable them, activate the
 
 ### Modified
 
-* Almost everything (types, methods, and traits) now use fulls names instead
+- Almost everything (types, methods, and traits) now use fulls names instead
   of abbreviations (e.g. `Vec3` becomes `Vector3`). Most changes are obvious.
   Note however that:
-    - `::sqnorm` becomes `::norm_squared`.
-    - `::sqdist` becomes `::distance_squared`.
-    - `::abs`, `::min`, etc. did not change as this is a common name for
+  - `::sqnorm` becomes `::norm_squared`.
+  - `::sqdist` becomes `::distance_squared`.
+  - `::abs`, `::min`, etc. did not change as this is a common name for
       absolute values on, e.g., the libc.
-    - Dynamically sized structures keep the `D` prefix, e.g., `DMat` becomes
+  - Dynamically sized structures keep the `D` prefix, e.g., `DMat` becomes
       `DMatrix`.
-* All files with abbreviated names have been renamed to their full version,
+- All files with abbreviated names have been renamed to their full version,
   e.g., `vec.rs` becomes `vector.rs`.
 
 ## [0.7.0]
 
 ### Added
 
-* Added implementation of assignment operators (+=, -=, etc.) for
+- Added implementation of assignment operators (+=, -=, etc.) for
   everything.
 
 ### Modified
 
-* Points and vectors are now linked to each other with associated types
+- Points and vectors are now linked to each other with associated types
   (on the PointAsVector trait).
 
 ## [0.6.0]
 
-**Announcement:** a users forum has been created for `nalgebra`, `ncollide`, and `nphysics`. See
+__Announcement:__ a users forum has been created for `nalgebra`, `ncollide`, and `nphysics`. See
 you [there](https://users.nphysics.org)!
 
 ### Added
 
-* Added a dependency to [generic-array](https://crates.io/crates/generic-array). Feature-gated:
+- Added a dependency to [generic-array](https://crates.io/crates/generic-array). Feature-gated:
   requires `features="generic_sizes"`.
-* Added statically sized vectors with user-defined sizes: `VectorN`. Feature-gated: requires
+- Added statically sized vectors with user-defined sizes: `VectorN`. Feature-gated: requires
   `features="generic_sizes"`.
-* Added similarity transformations (an uniform scale followed by a rotation followed by a
+- Added similarity transformations (an uniform scale followed by a rotation followed by a
   translation): `Similarity2`, `Similarity3`.
 
 ### Removed
 
-* Removed zero-sized elements `Vector0`, `Point0`.
-* Removed 4-dimensional transformations `Rotation4` and `Isometry4` (which had an implementation too incomplete to be
+- Removed zero-sized elements `Vector0`, `Point0`.
+- Removed 4-dimensional transformations `Rotation4` and `Isometry4` (which had an implementation too incomplete to be
   useful).
 
 ### Modified
 
-* Vectors are now multipliable with isometries. This will result into a pure rotation (this is how
+- Vectors are now multipliable with isometries. This will result into a pure rotation (this is how
   vectors differ from point semantically: they design directions, so they are not translatable).
-* `{Isometry3, Rotation3}::look_at` reimplemented and renamed to `::look_at_rh` and `::look_at_lh` to agree
+- `{Isometry3, Rotation3}::look_at` reimplemented and renamed to `::look_at_rh` and `::look_at_lh` to agree
   with the computer graphics community (in particular, the GLM library). Use the `::look_at_rh`
   variant to build a view matrix that
   may be successfully used with `Persp` and `Ortho`.
-* The old `{Isometry3, Rotation3}::look_at` implementations are now called `::new_observer_frame`.
-* Rename every `fov` on `Persp` to `fovy`.
-* Fixed the perspective and orthographic projection matrices.
+- The old `{Isometry3, Rotation3}::look_at` implementations are now called `::new_observer_frame`.
+- Rename every `fov` on `Persp` to `fovy`.
+- Fixed the perspective and orthographic projection matrices.

--- a/nalgebra-glm/src/ext/matrix_clip_space.rs
+++ b/nalgebra-glm/src/ext/matrix_clip_space.rs
@@ -754,7 +754,7 @@ pub fn infinite_perspective_rh_no<T: RealNumber>(aspect: T, fovy: T, near: T) ->
     mat
 }
 
-/// Build infinite right-handed perspective projection matrix with [0,1] depth range.
+/// Build infinite right-handed perspective projection matrix with \[0,1\] depth range.
 ///
 /// # Parameters
 ///

--- a/nalgebra-glm/src/lib.rs
+++ b/nalgebra-glm/src/lib.rs
@@ -77,7 +77,7 @@
    * Using function with the form `type1_to_type2` in order to convert an instance of `type1` into an instance of `type2`.
    For example [`glm::mat3_to_mat4(m)`](crate::mat3_to_mat4) will convert the 3x3 matrix `m` to a 4x4 matrix by appending one column on the right
    and one row on the left. Those now row and columns are filled with 0 except for the diagonal element which is set to 1.
-   * Using one of the [`convert`](crate::convert), [`try_convert`](crate::try_convert), or [`convert_unchecked`](crate::convert_unchecked) functions.
+   * Using one of the [`convert`], [`try_convert`], or [`convert_unchecked`] functions.
    These functions are directly re-exported from nalgebra and are extremely versatile:
        1. The `convert` function can convert any type (especially geometric types from nalgebra like `Isometry3`) into another algebraic type which is equivalent but more general. For example,
    `let sim: Similarity3<_> = na::convert(isometry)` will convert an `Isometry3` into a `Similarity3`.

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -19,12 +19,15 @@
 //! - Sparsity patterns in CSR and CSC matrices are explicitly represented by the
 //!   [SparsityPattern](pattern::SparsityPattern) type, which encodes the invariants of the
 //!   associated index data structures.
-//! - [Matrix market format support](`io`) when the `io` feature is enabled.
-//! - [proptest strategies](`proptest`) for sparse matrices when the feature
+//! - [Matrix market format support] when the `io` feature is enabled.
+//! - [proptest strategies] for sparse matrices when the feature
 //!   `proptest-support` is enabled.
 //! - [matrixcompare support](https://crates.io/crates/matrixcompare) for effortless
 //!   (approximate) comparison of matrices in test code (requires the `compare` feature).
 //!
+//! [Matrix market format support]: io/
+//! [proptest strategies]: proptest/
+//! 
 //! ## Current state
 //!
 //! The library is in an early, but usable state. The API has been designed to be extensible,

--- a/nalgebra-sparse/src/ops/impl_std_ops.rs
+++ b/nalgebra-sparse/src/ops/impl_std_ops.rs
@@ -117,7 +117,7 @@ impl_spmm!(CsrMatrix, spmm_csr_pattern, spmm_csr_prealloc_unchecked);
 impl_spmm!(CscMatrix, spmm_csc_pattern, spmm_csc_prealloc_unchecked);
 
 /// Implements Scalar * Matrix operations for *concrete* scalar types. The reason this is necessary
-/// is that we are not able to implement Mul<Matrix<T>> for all T generically due to orphan rules.
+/// is that we are not able to implement `Mul<Matrix<T>>` for all T generically due to orphan rules.
 macro_rules! impl_concrete_scalar_matrix_mul {
     ($matrix_type:ident, $($scalar_type:ty),*) => {
         // For each concrete scalar type, forward the implementation of scalar * matrix

--- a/src/base/alias.rs
+++ b/src/base/alias.rs
@@ -18,7 +18,7 @@ use std::mem::MaybeUninit;
 
 /// An owned matrix column-major matrix with `R` rows and `C` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type OMatrix<T, R, C> = Matrix<T, R, C, Owned<T, R, C>>;
 
 /// An owned matrix with uninitialized data.
@@ -26,7 +26,7 @@ pub type UninitMatrix<T, R, C> = Matrix<MaybeUninit<T>, R, C, OwnedUninit<T, R, 
 
 /// An owned matrix column-major matrix with `R` rows and `C` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated(
     note = "use SMatrix for a statically-sized matrix using integer dimensions, or OMatrix for an owned matrix using types as dimensions."
 )]
@@ -34,237 +34,237 @@ pub type MatrixMN<T, R, C> = Matrix<T, R, C, Owned<T, R, C>>;
 
 /// An owned matrix column-major matrix with `D` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated(note = "use OMatrix<T, D, D> or SMatrix<T, D, D> instead.")]
 pub type MatrixN<T, D> = Matrix<T, D, D, Owned<T, D, D>>;
 
 /// A statically sized column-major matrix with `R` rows and `C` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type SMatrix<T, const R: usize, const C: usize> =
     Matrix<T, Const<R>, Const<C>, ArrayStorage<T, R, C>>;
 
 /// A dynamically sized column-major matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type DMatrix<T> = Matrix<T, Dyn, Dyn, VecStorage<T, Dyn, Dyn>>;
 
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 1 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx1<T> = Matrix<T, Dyn, U1, VecStorage<T, Dyn, U1>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 2 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx2<T> = Matrix<T, Dyn, U2, VecStorage<T, Dyn, U2>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 3 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx3<T> = Matrix<T, Dyn, U3, VecStorage<T, Dyn, U3>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 4 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx4<T> = Matrix<T, Dyn, U4, VecStorage<T, Dyn, U4>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 5 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx5<T> = Matrix<T, Dyn, U5, VecStorage<T, Dyn, U5>>;
 /// A heap-allocated, column-major, matrix with a dynamic number of rows and 6 columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type MatrixXx6<T> = Matrix<T, Dyn, U6, VecStorage<T, Dyn, U6>>;
 
 /// A heap-allocated, column-major, matrix with 1 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix1xX<T> = Matrix<T, U1, Dyn, VecStorage<T, U1, Dyn>>;
 /// A heap-allocated, column-major, matrix with 2 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix2xX<T> = Matrix<T, U2, Dyn, VecStorage<T, U2, Dyn>>;
 /// A heap-allocated, column-major, matrix with 3 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix3xX<T> = Matrix<T, U3, Dyn, VecStorage<T, U3, Dyn>>;
 /// A heap-allocated, column-major, matrix with 4 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix4xX<T> = Matrix<T, U4, Dyn, VecStorage<T, U4, Dyn>>;
 /// A heap-allocated, column-major, matrix with 5 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix5xX<T> = Matrix<T, U5, Dyn, VecStorage<T, U5, Dyn>>;
 /// A heap-allocated, column-major, matrix with 6 rows and a dynamic number of columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub type Matrix6xX<T> = Matrix<T, U6, Dyn, VecStorage<T, U6, Dyn>>;
 
 /// A stack-allocated, column-major, 1x1 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1<T> = Matrix<T, U1, U1, ArrayStorage<T, 1, 1>>;
 /// A stack-allocated, column-major, 2x2 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2<T> = Matrix<T, U2, U2, ArrayStorage<T, 2, 2>>;
 /// A stack-allocated, column-major, 3x3 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3<T> = Matrix<T, U3, U3, ArrayStorage<T, 3, 3>>;
 /// A stack-allocated, column-major, 4x4 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4<T> = Matrix<T, U4, U4, ArrayStorage<T, 4, 4>>;
 /// A stack-allocated, column-major, 5x5 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5<T> = Matrix<T, U5, U5, ArrayStorage<T, 5, 5>>;
 /// A stack-allocated, column-major, 6x6 square matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6<T> = Matrix<T, U6, U6, ArrayStorage<T, 6, 6>>;
 
 /// A stack-allocated, column-major, 1x2 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1x2<T> = Matrix<T, U1, U2, ArrayStorage<T, 1, 2>>;
 /// A stack-allocated, column-major, 1x3 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1x3<T> = Matrix<T, U1, U3, ArrayStorage<T, 1, 3>>;
 /// A stack-allocated, column-major, 1x4 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1x4<T> = Matrix<T, U1, U4, ArrayStorage<T, 1, 4>>;
 /// A stack-allocated, column-major, 1x5 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1x5<T> = Matrix<T, U1, U5, ArrayStorage<T, 1, 5>>;
 /// A stack-allocated, column-major, 1x6 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix1x6<T> = Matrix<T, U1, U6, ArrayStorage<T, 1, 6>>;
 
 /// A stack-allocated, column-major, 2x3 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2x3<T> = Matrix<T, U2, U3, ArrayStorage<T, 2, 3>>;
 /// A stack-allocated, column-major, 2x4 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2x4<T> = Matrix<T, U2, U4, ArrayStorage<T, 2, 4>>;
 /// A stack-allocated, column-major, 2x5 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2x5<T> = Matrix<T, U2, U5, ArrayStorage<T, 2, 5>>;
 /// A stack-allocated, column-major, 2x6 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2x6<T> = Matrix<T, U2, U6, ArrayStorage<T, 2, 6>>;
 
 /// A stack-allocated, column-major, 3x4 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3x4<T> = Matrix<T, U3, U4, ArrayStorage<T, 3, 4>>;
 /// A stack-allocated, column-major, 3x5 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3x5<T> = Matrix<T, U3, U5, ArrayStorage<T, 3, 5>>;
 /// A stack-allocated, column-major, 3x6 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3x6<T> = Matrix<T, U3, U6, ArrayStorage<T, 3, 6>>;
 
 /// A stack-allocated, column-major, 4x5 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4x5<T> = Matrix<T, U4, U5, ArrayStorage<T, 4, 5>>;
 /// A stack-allocated, column-major, 4x6 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4x6<T> = Matrix<T, U4, U6, ArrayStorage<T, 4, 6>>;
 
 /// A stack-allocated, column-major, 5x6 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5x6<T> = Matrix<T, U5, U6, ArrayStorage<T, 5, 6>>;
 
 /// A stack-allocated, column-major, 2x1 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix2x1<T> = Matrix<T, U2, U1, ArrayStorage<T, 2, 1>>;
 /// A stack-allocated, column-major, 3x1 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3x1<T> = Matrix<T, U3, U1, ArrayStorage<T, 3, 1>>;
 /// A stack-allocated, column-major, 4x1 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4x1<T> = Matrix<T, U4, U1, ArrayStorage<T, 4, 1>>;
 /// A stack-allocated, column-major, 5x1 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5x1<T> = Matrix<T, U5, U1, ArrayStorage<T, 5, 1>>;
 /// A stack-allocated, column-major, 6x1 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6x1<T> = Matrix<T, U6, U1, ArrayStorage<T, 6, 1>>;
 
 /// A stack-allocated, column-major, 3x2 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix3x2<T> = Matrix<T, U3, U2, ArrayStorage<T, 3, 2>>;
 /// A stack-allocated, column-major, 4x2 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4x2<T> = Matrix<T, U4, U2, ArrayStorage<T, 4, 2>>;
 /// A stack-allocated, column-major, 5x2 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5x2<T> = Matrix<T, U5, U2, ArrayStorage<T, 5, 2>>;
 /// A stack-allocated, column-major, 6x2 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6x2<T> = Matrix<T, U6, U2, ArrayStorage<T, 6, 2>>;
 
 /// A stack-allocated, column-major, 4x3 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix4x3<T> = Matrix<T, U4, U3, ArrayStorage<T, 4, 3>>;
 /// A stack-allocated, column-major, 5x3 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5x3<T> = Matrix<T, U5, U3, ArrayStorage<T, 5, 3>>;
 /// A stack-allocated, column-major, 6x3 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6x3<T> = Matrix<T, U6, U3, ArrayStorage<T, 6, 3>>;
 
 /// A stack-allocated, column-major, 5x4 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix5x4<T> = Matrix<T, U5, U4, ArrayStorage<T, 5, 4>>;
 /// A stack-allocated, column-major, 6x4 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6x4<T> = Matrix<T, U6, U4, ArrayStorage<T, 6, 4>>;
 
 /// A stack-allocated, column-major, 6x5 matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type Matrix6x5<T> = Matrix<T, U6, U5, ArrayStorage<T, 6, 5>>;
 
 /*
@@ -288,7 +288,7 @@ pub type UninitVector<T, D> = Matrix<MaybeUninit<T>, D, U1, OwnedUninit<T, D, U1
 
 /// An owned matrix column-major matrix with `R` rows and `C` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated(
     note = "use SVector for a statically-sized matrix using integer dimensions, or OVector for an owned matrix using types as dimensions."
 )]

--- a/src/base/alias_slice.rs
+++ b/src/base/alias_slice.rs
@@ -13,237 +13,237 @@ use crate::slice_deprecation_note;
 // NOTE: we can't provide defaults for the strides because it's not supported yet by min_const_generics.
 /// A column-major matrix slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(SMatrixView)]
 pub type SMatrixSlice<'a, T, const R: usize, const C: usize> =
     Matrix<T, Const<R>, Const<C>, ViewStorage<'a, T, Const<R>, Const<C>, Const<1>, Const<R>>>;
 
 /// A column-major matrix slice dynamic numbers of rows and columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(DMatrixView)]
 pub type DMatrixSlice<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, Dyn, ViewStorage<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1)]
 pub type MatrixSlice1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorage<'a, T, U1, U1, RStride, CStride>>;
 /// A column-major 2x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2)]
 pub type MatrixSlice2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U2, ViewStorage<'a, T, U2, U2, RStride, CStride>>;
 /// A column-major 3x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3)]
 pub type MatrixSlice3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U3, ViewStorage<'a, T, U3, U3, RStride, CStride>>;
 /// A column-major 4x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4)]
 pub type MatrixSlice4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U4, ViewStorage<'a, T, U4, U4, RStride, CStride>>;
 /// A column-major 5x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5)]
 pub type MatrixSlice5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U5, ViewStorage<'a, T, U5, U5, RStride, CStride>>;
 /// A column-major 6x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6)]
 pub type MatrixSlice6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U6, ViewStorage<'a, T, U6, U6, RStride, CStride>>;
 
 /// A column-major 1x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1x2)]
 pub type MatrixSlice1x2<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U2, ViewStorage<'a, T, U1, U2, RStride, CStride>>;
 /// A column-major 1x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1x3)]
 pub type MatrixSlice1x3<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U3, ViewStorage<'a, T, U1, U3, RStride, CStride>>;
 /// A column-major 1x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1x4)]
 pub type MatrixSlice1x4<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U4, ViewStorage<'a, T, U1, U4, RStride, CStride>>;
 /// A column-major 1x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1x5)]
 pub type MatrixSlice1x5<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U5, ViewStorage<'a, T, U1, U5, RStride, CStride>>;
 /// A column-major 1x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView1x6)]
 pub type MatrixSlice1x6<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U6, ViewStorage<'a, T, U1, U6, RStride, CStride>>;
 
 /// A column-major 2x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2x1)]
 pub type MatrixSlice2x1<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorage<'a, T, U2, U1, RStride, CStride>>;
 /// A column-major 2x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2x3)]
 pub type MatrixSlice2x3<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U3, ViewStorage<'a, T, U2, U3, RStride, CStride>>;
 /// A column-major 2x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2x4)]
 pub type MatrixSlice2x4<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U4, ViewStorage<'a, T, U2, U4, RStride, CStride>>;
 /// A column-major 2x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2x5)]
 pub type MatrixSlice2x5<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U5, ViewStorage<'a, T, U2, U5, RStride, CStride>>;
 /// A column-major 2x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView2x6)]
 pub type MatrixSlice2x6<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U6, ViewStorage<'a, T, U2, U6, RStride, CStride>>;
 
 /// A column-major 3x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3x1)]
 pub type MatrixSlice3x1<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorage<'a, T, U3, U1, RStride, CStride>>;
 /// A column-major 3x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3x2)]
 pub type MatrixSlice3x2<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U2, ViewStorage<'a, T, U3, U2, RStride, CStride>>;
 /// A column-major 3x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3x4)]
 pub type MatrixSlice3x4<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U4, ViewStorage<'a, T, U3, U4, RStride, CStride>>;
 /// A column-major 3x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3x5)]
 pub type MatrixSlice3x5<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U5, ViewStorage<'a, T, U3, U5, RStride, CStride>>;
 /// A column-major 3x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView3x6)]
 pub type MatrixSlice3x6<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U6, ViewStorage<'a, T, U3, U6, RStride, CStride>>;
 
 /// A column-major 4x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4x1)]
 pub type MatrixSlice4x1<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorage<'a, T, U4, U1, RStride, CStride>>;
 /// A column-major 4x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4x2)]
 pub type MatrixSlice4x2<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U2, ViewStorage<'a, T, U4, U2, RStride, CStride>>;
 /// A column-major 4x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4x3)]
 pub type MatrixSlice4x3<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U3, ViewStorage<'a, T, U4, U3, RStride, CStride>>;
 /// A column-major 4x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4x5)]
 pub type MatrixSlice4x5<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U5, ViewStorage<'a, T, U4, U5, RStride, CStride>>;
 /// A column-major 4x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView4x6)]
 pub type MatrixSlice4x6<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U6, ViewStorage<'a, T, U4, U6, RStride, CStride>>;
 
 /// A column-major 5x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5x1)]
 pub type MatrixSlice5x1<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorage<'a, T, U5, U1, RStride, CStride>>;
 /// A column-major 5x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5x2)]
 pub type MatrixSlice5x2<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U2, ViewStorage<'a, T, U5, U2, RStride, CStride>>;
 /// A column-major 5x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5x3)]
 pub type MatrixSlice5x3<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U3, ViewStorage<'a, T, U5, U3, RStride, CStride>>;
 /// A column-major 5x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5x4)]
 pub type MatrixSlice5x4<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U4, ViewStorage<'a, T, U5, U4, RStride, CStride>>;
 /// A column-major 5x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView5x6)]
 pub type MatrixSlice5x6<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U6, ViewStorage<'a, T, U5, U6, RStride, CStride>>;
 
 /// A column-major 6x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6x1)]
 pub type MatrixSlice6x1<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorage<'a, T, U6, U1, RStride, CStride>>;
 /// A column-major 6x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6x2)]
 pub type MatrixSlice6x2<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U2, ViewStorage<'a, T, U6, U2, RStride, CStride>>;
 /// A column-major 6x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6x3)]
 pub type MatrixSlice6x3<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U3, ViewStorage<'a, T, U6, U3, RStride, CStride>>;
 /// A column-major 6x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6x4)]
 pub type MatrixSlice6x4<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U4, ViewStorage<'a, T, U6, U4, RStride, CStride>>;
 /// A column-major 6x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixView6x5)]
 pub type MatrixSlice6x5<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U5, ViewStorage<'a, T, U6, U5, RStride, CStride>>;
@@ -300,14 +300,14 @@ pub type MatrixSliceXx6<'a, T, RStride = U1, CStride = Dyn> =
 
 /// A column vector slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView)]
 pub type VectorSlice<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, U1, ViewStorage<'a, T, D, U1, RStride, CStride>>;
 
 /// A column vector slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(SVectorView)]
 pub type SVectorSlice<'a, T, const D: usize> =
     Matrix<T, Const<D>, Const<1>, ViewStorage<'a, T, Const<D>, Const<1>, Const<1>, Const<D>>>;
@@ -319,37 +319,37 @@ pub type DVectorSlice<'a, T, RStride = U1, CStride = Dyn> =
 
 /// A 1D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView1)]
 pub type VectorSlice1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorage<'a, T, U1, U1, RStride, CStride>>;
 /// A 2D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView2)]
 pub type VectorSlice2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorage<'a, T, U2, U1, RStride, CStride>>;
 /// A 3D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView3)]
 pub type VectorSlice3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorage<'a, T, U3, U1, RStride, CStride>>;
 /// A 4D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView4)]
 pub type VectorSlice4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorage<'a, T, U4, U1, RStride, CStride>>;
 /// A 5D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView5)]
 pub type VectorSlice5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorage<'a, T, U5, U1, RStride, CStride>>;
 /// A 6D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorView6)]
 pub type VectorSlice6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorage<'a, T, U6, U1, RStride, CStride>>;
@@ -363,251 +363,251 @@ pub type VectorSlice6<'a, T, RStride = U1, CStride = U6> =
  */
 /// A column-major matrix slice with `R` rows and `C` columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = "Use MatrixViewMut instead, which has an identical definition."]
 pub type MatrixSliceMutMN<'a, T, R, C, RStride = U1, CStride = R> =
     Matrix<T, R, C, ViewStorageMut<'a, T, R, C, RStride, CStride>>;
 
 /// A column-major matrix slice with `D` rows and columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = "Use MatrixViewMut instead."]
 pub type MatrixSliceMutN<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, D, ViewStorageMut<'a, T, D, D, RStride, CStride>>;
 
 /// A column-major matrix slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(SMatrixViewMut)]
 pub type SMatrixSliceMut<'a, T, const R: usize, const C: usize> =
     Matrix<T, Const<R>, Const<C>, ViewStorageMut<'a, T, Const<R>, Const<C>, Const<1>, Const<R>>>;
 
 /// A column-major matrix slice dynamic numbers of rows and columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(DMatrixViewMut)]
 pub type DMatrixSliceMut<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, Dyn, ViewStorageMut<'a, T, Dyn, Dyn, RStride, CStride>>;
 
 /// A column-major 1x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1)]
 pub type MatrixSliceMut1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorageMut<'a, T, U1, U1, RStride, CStride>>;
 /// A column-major 2x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2)]
 pub type MatrixSliceMut2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U2, ViewStorageMut<'a, T, U2, U2, RStride, CStride>>;
 /// A column-major 3x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3)]
 pub type MatrixSliceMut3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U3, ViewStorageMut<'a, T, U3, U3, RStride, CStride>>;
 /// A column-major 4x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4)]
 pub type MatrixSliceMut4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U4, ViewStorageMut<'a, T, U4, U4, RStride, CStride>>;
 /// A column-major 5x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5)]
 pub type MatrixSliceMut5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U5, ViewStorageMut<'a, T, U5, U5, RStride, CStride>>;
 /// A column-major 6x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6)]
 pub type MatrixSliceMut6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U6, ViewStorageMut<'a, T, U6, U6, RStride, CStride>>;
 
 /// A column-major 1x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1x2)]
 pub type MatrixSliceMut1x2<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U2, ViewStorageMut<'a, T, U1, U2, RStride, CStride>>;
 /// A column-major 1x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1x3)]
 pub type MatrixSliceMut1x3<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U3, ViewStorageMut<'a, T, U1, U3, RStride, CStride>>;
 /// A column-major 1x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1x4)]
 pub type MatrixSliceMut1x4<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U4, ViewStorageMut<'a, T, U1, U4, RStride, CStride>>;
 /// A column-major 1x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1x5)]
 pub type MatrixSliceMut1x5<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U5, ViewStorageMut<'a, T, U1, U5, RStride, CStride>>;
 /// A column-major 1x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut1x6)]
 pub type MatrixSliceMut1x6<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U6, ViewStorageMut<'a, T, U1, U6, RStride, CStride>>;
 
 /// A column-major 2x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2x1)]
 pub type MatrixSliceMut2x1<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorageMut<'a, T, U2, U1, RStride, CStride>>;
 /// A column-major 2x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2x3)]
 pub type MatrixSliceMut2x3<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U3, ViewStorageMut<'a, T, U2, U3, RStride, CStride>>;
 /// A column-major 2x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2x4)]
 pub type MatrixSliceMut2x4<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U4, ViewStorageMut<'a, T, U2, U4, RStride, CStride>>;
 /// A column-major 2x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2x5)]
 pub type MatrixSliceMut2x5<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U5, ViewStorageMut<'a, T, U2, U5, RStride, CStride>>;
 /// A column-major 2x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut2x6)]
 pub type MatrixSliceMut2x6<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U6, ViewStorageMut<'a, T, U2, U6, RStride, CStride>>;
 
 /// A column-major 3x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3x1)]
 pub type MatrixSliceMut3x1<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorageMut<'a, T, U3, U1, RStride, CStride>>;
 /// A column-major 3x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3x2)]
 pub type MatrixSliceMut3x2<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U2, ViewStorageMut<'a, T, U3, U2, RStride, CStride>>;
 /// A column-major 3x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3x4)]
 pub type MatrixSliceMut3x4<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U4, ViewStorageMut<'a, T, U3, U4, RStride, CStride>>;
 /// A column-major 3x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3x5)]
 pub type MatrixSliceMut3x5<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U5, ViewStorageMut<'a, T, U3, U5, RStride, CStride>>;
 /// A column-major 3x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut3x6)]
 pub type MatrixSliceMut3x6<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U6, ViewStorageMut<'a, T, U3, U6, RStride, CStride>>;
 
 /// A column-major 4x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4x1)]
 pub type MatrixSliceMut4x1<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorageMut<'a, T, U4, U1, RStride, CStride>>;
 /// A column-major 4x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4x2)]
 pub type MatrixSliceMut4x2<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U2, ViewStorageMut<'a, T, U4, U2, RStride, CStride>>;
 /// A column-major 4x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4x3)]
 pub type MatrixSliceMut4x3<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U3, ViewStorageMut<'a, T, U4, U3, RStride, CStride>>;
 /// A column-major 4x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4x5)]
 pub type MatrixSliceMut4x5<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U5, ViewStorageMut<'a, T, U4, U5, RStride, CStride>>;
 /// A column-major 4x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut4x6)]
 pub type MatrixSliceMut4x6<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U6, ViewStorageMut<'a, T, U4, U6, RStride, CStride>>;
 
 /// A column-major 5x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5x1)]
 pub type MatrixSliceMut5x1<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorageMut<'a, T, U5, U1, RStride, CStride>>;
 /// A column-major 5x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5x2)]
 pub type MatrixSliceMut5x2<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U2, ViewStorageMut<'a, T, U5, U2, RStride, CStride>>;
 /// A column-major 5x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5x3)]
 pub type MatrixSliceMut5x3<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U3, ViewStorageMut<'a, T, U5, U3, RStride, CStride>>;
 /// A column-major 5x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5x4)]
 pub type MatrixSliceMut5x4<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U4, ViewStorageMut<'a, T, U5, U4, RStride, CStride>>;
 /// A column-major 5x6 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut5x6)]
 pub type MatrixSliceMut5x6<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U6, ViewStorageMut<'a, T, U5, U6, RStride, CStride>>;
 
 /// A column-major 6x1 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6x1)]
 pub type MatrixSliceMut6x1<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorageMut<'a, T, U6, U1, RStride, CStride>>;
 /// A column-major 6x2 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6x2)]
 pub type MatrixSliceMut6x2<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U2, ViewStorageMut<'a, T, U6, U2, RStride, CStride>>;
 /// A column-major 6x3 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6x3)]
 pub type MatrixSliceMut6x3<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U3, ViewStorageMut<'a, T, U6, U3, RStride, CStride>>;
 /// A column-major 6x4 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6x4)]
 pub type MatrixSliceMut6x4<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U4, ViewStorageMut<'a, T, U6, U4, RStride, CStride>>;
 /// A column-major 6x5 matrix slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(MatrixViewMut6x5)]
 pub type MatrixSliceMut6x5<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U5, ViewStorageMut<'a, T, U6, U5, RStride, CStride>>;
@@ -664,58 +664,58 @@ pub type MatrixSliceMutXx6<'a, T, RStride = U1, CStride = Dyn> =
 
 /// A column vector slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut)]
 pub type VectorSliceMut<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, U1, ViewStorageMut<'a, T, D, U1, RStride, CStride>>;
 
 /// A column vector slice with dimensions known at compile-time.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(SVectorViewMut)]
 pub type SVectorSliceMut<'a, T, const D: usize> =
     Matrix<T, Const<D>, Const<1>, ViewStorageMut<'a, T, Const<D>, Const<1>, Const<1>, Const<D>>>;
 
 /// A column vector slice dynamic numbers of rows and columns.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(DVectorViewMut)]
 pub type DVectorSliceMut<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 
 /// A 1D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut1)]
 pub type VectorSliceMut1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorageMut<'a, T, U1, U1, RStride, CStride>>;
 /// A 2D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut2)]
 pub type VectorSliceMut2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorageMut<'a, T, U2, U1, RStride, CStride>>;
 /// A 3D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut3)]
 pub type VectorSliceMut3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorageMut<'a, T, U3, U1, RStride, CStride>>;
 /// A 4D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut4)]
 pub type VectorSliceMut4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorageMut<'a, T, U4, U1, RStride, CStride>>;
 /// A 5D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut5)]
 pub type VectorSliceMut5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorageMut<'a, T, U5, U1, RStride, CStride>>;
 /// A 6D column vector slice.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 #[deprecated = slice_deprecation_note!(VectorViewMut6)]
 pub type VectorSliceMut6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorageMut<'a, T, U6, U1, RStride, CStride>>;

--- a/src/base/alias_view.rs
+++ b/src/base/alias_view.rs
@@ -14,7 +14,7 @@ use crate::base::{Const, Matrix};
 ///
 /// See [`SMatrixViewMut`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type SMatrixView<'a, T, const R: usize, const C: usize> =
     Matrix<T, Const<R>, Const<C>, ViewStorage<'a, T, Const<R>, Const<C>, Const<1>, Const<R>>>;
 
@@ -22,7 +22,7 @@ pub type SMatrixView<'a, T, const R: usize, const C: usize> =
 ///
 /// See [`DMatrixViewMut`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type DMatrixView<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, Dyn, ViewStorage<'a, T, Dyn, Dyn, RStride, CStride>>;
 
@@ -30,42 +30,42 @@ pub type DMatrixView<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`MatrixViewMut1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorage<'a, T, U1, U1, RStride, CStride>>;
 /// An immutable column-major 2x2 matrix view.
 ///
 /// See [`MatrixViewMut2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U2, ViewStorage<'a, T, U2, U2, RStride, CStride>>;
 /// An immutable column-major 3x3 matrix view.
 ///
 /// See [`MatrixViewMut3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U3, ViewStorage<'a, T, U3, U3, RStride, CStride>>;
 /// An immutable column-major 4x4 matrix view.
 ///
 /// See [`MatrixViewMut4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U4, ViewStorage<'a, T, U4, U4, RStride, CStride>>;
 /// An immutable column-major 5x5 matrix view.
 ///
 /// See [`MatrixViewMut5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U5, ViewStorage<'a, T, U5, U5, RStride, CStride>>;
 /// An immutable column-major 6x6 matrix view.
 ///
 /// See [`MatrixViewMut6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U6, ViewStorage<'a, T, U6, U6, RStride, CStride>>;
 
@@ -73,35 +73,35 @@ pub type MatrixView6<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixViewMut1x2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1x2<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U2, ViewStorage<'a, T, U1, U2, RStride, CStride>>;
 /// An immutable column-major 1x3 matrix view.
 ///
 /// See [`MatrixViewMut1x3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1x3<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U3, ViewStorage<'a, T, U1, U3, RStride, CStride>>;
 /// An immutable column-major 1x4 matrix view.
 ///
 /// See [`MatrixViewMut1x4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1x4<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U4, ViewStorage<'a, T, U1, U4, RStride, CStride>>;
 /// An immutable column-major 1x5 matrix view.
 ///
 /// See [`MatrixViewMut1x5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1x5<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U5, ViewStorage<'a, T, U1, U5, RStride, CStride>>;
 /// An immutable column-major 1x6 matrix view.
 ///
 /// See [`MatrixViewMut1x6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1x6<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U6, ViewStorage<'a, T, U1, U6, RStride, CStride>>;
 
@@ -109,35 +109,35 @@ pub type MatrixView1x6<'a, T, RStride = U1, CStride = U1> =
 ///
 /// See [`MatrixViewMut2x1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2x1<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorage<'a, T, U2, U1, RStride, CStride>>;
 /// An immutable column-major 2x3 matrix view.
 ///
 /// See [`MatrixViewMut2x3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2x3<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U3, ViewStorage<'a, T, U2, U3, RStride, CStride>>;
 /// An immutable column-major 2x4 matrix view.
 ///
 /// See [`MatrixViewMut2x4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2x4<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U4, ViewStorage<'a, T, U2, U4, RStride, CStride>>;
 /// An immutable column-major 2x5 matrix view.
 ///
 /// See [`MatrixViewMut2x5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2x5<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U5, ViewStorage<'a, T, U2, U5, RStride, CStride>>;
 /// An immutable column-major 2x6 matrix view.
 ///
 /// See [`MatrixViewMut2x6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2x6<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U6, ViewStorage<'a, T, U2, U6, RStride, CStride>>;
 
@@ -145,35 +145,35 @@ pub type MatrixView2x6<'a, T, RStride = U1, CStride = U2> =
 ///
 /// See [`MatrixViewMut3x1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3x1<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorage<'a, T, U3, U1, RStride, CStride>>;
 /// An immutable column-major 3x2 matrix view.
 ///
 /// See [`MatrixViewMut3x2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3x2<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U2, ViewStorage<'a, T, U3, U2, RStride, CStride>>;
 /// An immutable column-major 3x4 matrix view.
 ///
 /// See [`MatrixViewMut3x4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3x4<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U4, ViewStorage<'a, T, U3, U4, RStride, CStride>>;
 /// An immutable column-major 3x5 matrix view.
 ///
 /// See [`MatrixViewMut3x5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3x5<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U5, ViewStorage<'a, T, U3, U5, RStride, CStride>>;
 /// An immutable column-major 3x6 matrix view.
 ///
 /// See [`MatrixViewMut3x6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3x6<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U6, ViewStorage<'a, T, U3, U6, RStride, CStride>>;
 
@@ -181,35 +181,35 @@ pub type MatrixView3x6<'a, T, RStride = U1, CStride = U3> =
 ///
 /// See [`MatrixViewMut4x1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4x1<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorage<'a, T, U4, U1, RStride, CStride>>;
 /// An immutable column-major 4x2 matrix view.
 ///
 /// See [`MatrixViewMut4x2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4x2<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U2, ViewStorage<'a, T, U4, U2, RStride, CStride>>;
 /// An immutable column-major 4x3 matrix view.
 ///
 /// See [`MatrixViewMut4x3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4x3<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U3, ViewStorage<'a, T, U4, U3, RStride, CStride>>;
 /// An immutable column-major 4x5 matrix view.
 ///
 /// See [`MatrixViewMut4x5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4x5<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U5, ViewStorage<'a, T, U4, U5, RStride, CStride>>;
 /// An immutable column-major 4x6 matrix view.
 ///
 /// See [`MatrixViewMut4x6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4x6<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U6, ViewStorage<'a, T, U4, U6, RStride, CStride>>;
 
@@ -217,35 +217,35 @@ pub type MatrixView4x6<'a, T, RStride = U1, CStride = U4> =
 ///
 /// See [`MatrixViewMut5x1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5x1<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorage<'a, T, U5, U1, RStride, CStride>>;
 /// An immutable column-major 5x2 matrix view.
 ///
 /// See [`MatrixViewMut5x2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5x2<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U2, ViewStorage<'a, T, U5, U2, RStride, CStride>>;
 /// An immutable column-major 5x3 matrix view.
 ///
 /// See [`MatrixViewMut5x3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5x3<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U3, ViewStorage<'a, T, U5, U3, RStride, CStride>>;
 /// An immutable column-major 5x4 matrix view.
 ///
 /// See [`MatrixViewMut5x4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5x4<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U4, ViewStorage<'a, T, U5, U4, RStride, CStride>>;
 /// An immutable column-major 5x6 matrix view.
 ///
 /// See [`MatrixViewMut5x6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5x6<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U6, ViewStorage<'a, T, U5, U6, RStride, CStride>>;
 
@@ -253,35 +253,35 @@ pub type MatrixView5x6<'a, T, RStride = U1, CStride = U5> =
 ///
 /// See [`MatrixViewMut6x1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6x1<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorage<'a, T, U6, U1, RStride, CStride>>;
 /// An immutable column-major 6x2 matrix view.
 ///
 /// See [`MatrixViewMut6x2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6x2<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U2, ViewStorage<'a, T, U6, U2, RStride, CStride>>;
 /// An immutable column-major 6x3 matrix view.
 ///
 /// See [`MatrixViewMut6x3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6x3<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U3, ViewStorage<'a, T, U6, U3, RStride, CStride>>;
 /// An immutable column-major 6x4 matrix view.
 ///
 /// See [`MatrixViewMut6x4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6x4<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U4, ViewStorage<'a, T, U6, U4, RStride, CStride>>;
 /// An immutable column-major 6x5 matrix view.
 ///
 /// See [`MatrixViewMut6x5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6x5<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U5, ViewStorage<'a, T, U6, U5, RStride, CStride>>;
 
@@ -289,42 +289,42 @@ pub type MatrixView6x5<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixViewMut1xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView1xX<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, Dyn, ViewStorage<'a, T, U1, Dyn, RStride, CStride>>;
 /// An immutable column-major matrix view with 2 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixViewMut2xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView2xX<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, Dyn, ViewStorage<'a, T, U2, Dyn, RStride, CStride>>;
 /// An immutable column-major matrix view with 3 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixViewMut3xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView3xX<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, Dyn, ViewStorage<'a, T, U3, Dyn, RStride, CStride>>;
 /// An immutable column-major matrix view with 4 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixViewMut4xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView4xX<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, Dyn, ViewStorage<'a, T, U4, Dyn, RStride, CStride>>;
 /// An immutable column-major matrix view with 5 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixViewMut5xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView5xX<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, Dyn, ViewStorage<'a, T, U5, Dyn, RStride, CStride>>;
 /// An immutable column-major matrix view with 6 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixViewMut6xX`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixView6xX<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, Dyn, ViewStorage<'a, T, U6, Dyn, RStride, CStride>>;
 
@@ -332,42 +332,42 @@ pub type MatrixView6xX<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixViewMutXx1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx1<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 /// An immutable column-major matrix view with a number of rows chosen at runtime and 2 columns.
 ///
 /// See [`MatrixViewMutXx2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx2<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U2, ViewStorage<'a, T, Dyn, U2, RStride, CStride>>;
 /// An immutable column-major matrix view with a number of rows chosen at runtime and 3 columns.
 ///
 /// See [`MatrixViewMutXx3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx3<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U3, ViewStorage<'a, T, Dyn, U3, RStride, CStride>>;
 /// An immutable column-major matrix view with a number of rows chosen at runtime and 4 columns.
 ///
 /// See [`MatrixViewMutXx4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx4<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U4, ViewStorage<'a, T, Dyn, U4, RStride, CStride>>;
 /// An immutable column-major matrix view with a number of rows chosen at runtime and 5 columns.
 ///
 /// See [`MatrixViewMutXx5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx5<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U5, ViewStorage<'a, T, Dyn, U5, RStride, CStride>>;
 /// An immutable column-major matrix view with a number of rows chosen at runtime and 6 columns.
 ///
 /// See [`MatrixViewMutXx6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewXx6<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U6, ViewStorage<'a, T, Dyn, U6, RStride, CStride>>;
 
@@ -375,7 +375,7 @@ pub type MatrixViewXx6<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`VectorViewMut`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, U1, ViewStorage<'a, T, D, U1, RStride, CStride>>;
 
@@ -383,7 +383,7 @@ pub type VectorView<'a, T, D, RStride = U1, CStride = D> =
 ///
 /// See [`SVectorViewMut`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type SVectorView<'a, T, const D: usize> =
     Matrix<T, Const<D>, Const<1>, ViewStorage<'a, T, Const<D>, Const<1>, Const<1>, Const<D>>>;
 
@@ -391,7 +391,7 @@ pub type SVectorView<'a, T, const D: usize> =
 ///
 /// See [`DVectorViewMut`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type DVectorView<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U1, ViewStorage<'a, T, Dyn, U1, RStride, CStride>>;
 
@@ -399,42 +399,42 @@ pub type DVectorView<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`VectorViewMut1`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorage<'a, T, U1, U1, RStride, CStride>>;
 /// An immutable 2D column vector view.
 ///
 /// See [`VectorViewMut2`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorage<'a, T, U2, U1, RStride, CStride>>;
 /// An immutable 3D column vector view.
 ///
 /// See [`VectorViewMut3`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorage<'a, T, U3, U1, RStride, CStride>>;
 /// An immutable 4D column vector view.
 ///
 /// See [`VectorViewMut4`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorage<'a, T, U4, U1, RStride, CStride>>;
 /// An immutable 5D column vector view.
 ///
 /// See [`VectorViewMut5`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorage<'a, T, U5, U1, RStride, CStride>>;
 /// An immutable 6D column vector view.
 ///
 /// See [`VectorViewMut6`] for a mutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorView6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorage<'a, T, U6, U1, RStride, CStride>>;
 
@@ -450,7 +450,7 @@ pub type VectorView6<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`SMatrixView`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type SMatrixViewMut<'a, T, const R: usize, const C: usize> =
     Matrix<T, Const<R>, Const<C>, ViewStorageMut<'a, T, Const<R>, Const<C>, Const<1>, Const<R>>>;
 
@@ -458,7 +458,7 @@ pub type SMatrixViewMut<'a, T, const R: usize, const C: usize> =
 ///
 /// See [`DMatrixView`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type DMatrixViewMut<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, Dyn, ViewStorageMut<'a, T, Dyn, Dyn, RStride, CStride>>;
 
@@ -466,42 +466,42 @@ pub type DMatrixViewMut<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`MatrixView1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorageMut<'a, T, U1, U1, RStride, CStride>>;
 /// A mutable column-major 2x2 matrix view.
 ///
 /// See [`MatrixView2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U2, ViewStorageMut<'a, T, U2, U2, RStride, CStride>>;
 /// A mutable column-major 3x3 matrix view.
 ///
 /// See [`MatrixView3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U3, ViewStorageMut<'a, T, U3, U3, RStride, CStride>>;
 /// A mutable column-major 4x4 matrix view.
 ///
 /// See [`MatrixView4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U4, ViewStorageMut<'a, T, U4, U4, RStride, CStride>>;
 /// A mutable column-major 5x5 matrix view.
 ///
 /// See [`MatrixView5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U5, ViewStorageMut<'a, T, U5, U5, RStride, CStride>>;
 /// A mutable column-major 6x6 matrix view.
 ///
 /// See [`MatrixView6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U6, ViewStorageMut<'a, T, U6, U6, RStride, CStride>>;
 
@@ -509,35 +509,35 @@ pub type MatrixViewMut6<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixView1x2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1x2<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U2, ViewStorageMut<'a, T, U1, U2, RStride, CStride>>;
 /// A mutable column-major 1x3 matrix view.
 ///
 /// See [`MatrixView1x3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1x3<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U3, ViewStorageMut<'a, T, U1, U3, RStride, CStride>>;
 /// A mutable column-major 1x4 matrix view.
 ///
 /// See [`MatrixView1x4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1x4<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U4, ViewStorageMut<'a, T, U1, U4, RStride, CStride>>;
 /// A mutable column-major 1x5 matrix view.
 ///
 /// See [`MatrixView1x5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1x5<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U5, ViewStorageMut<'a, T, U1, U5, RStride, CStride>>;
 /// A mutable column-major 1x6 matrix view.
 ///
 /// See [`MatrixView1x6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1x6<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U6, ViewStorageMut<'a, T, U1, U6, RStride, CStride>>;
 
@@ -545,35 +545,35 @@ pub type MatrixViewMut1x6<'a, T, RStride = U1, CStride = U1> =
 ///
 /// See [`MatrixView2x1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2x1<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorageMut<'a, T, U2, U1, RStride, CStride>>;
 /// A mutable column-major 2x3 matrix view.
 ///
 /// See [`MatrixView2x3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2x3<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U3, ViewStorageMut<'a, T, U2, U3, RStride, CStride>>;
 /// A mutable column-major 2x4 matrix view.
 ///
 /// See [`MatrixView2x4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2x4<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U4, ViewStorageMut<'a, T, U2, U4, RStride, CStride>>;
 /// A mutable column-major 2x5 matrix view.
 ///
 /// See [`MatrixView2x5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2x5<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U5, ViewStorageMut<'a, T, U2, U5, RStride, CStride>>;
 /// A mutable column-major 2x6 matrix view.
 ///
 /// See [`MatrixView2x6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2x6<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U6, ViewStorageMut<'a, T, U2, U6, RStride, CStride>>;
 
@@ -581,35 +581,35 @@ pub type MatrixViewMut2x6<'a, T, RStride = U1, CStride = U2> =
 ///
 /// See [`MatrixView3x1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3x1<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorageMut<'a, T, U3, U1, RStride, CStride>>;
 /// A mutable column-major 3x2 matrix view.
 ///
 /// See [`MatrixView3x2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3x2<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U2, ViewStorageMut<'a, T, U3, U2, RStride, CStride>>;
 /// A mutable column-major 3x4 matrix view.
 ///
 /// See [`MatrixView3x4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3x4<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U4, ViewStorageMut<'a, T, U3, U4, RStride, CStride>>;
 /// A mutable column-major 3x5 matrix view.
 ///
 /// See [`MatrixView3x5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3x5<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U5, ViewStorageMut<'a, T, U3, U5, RStride, CStride>>;
 /// A mutable column-major 3x6 matrix view.
 ///
 /// See [`MatrixView3x6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3x6<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U6, ViewStorageMut<'a, T, U3, U6, RStride, CStride>>;
 
@@ -617,35 +617,35 @@ pub type MatrixViewMut3x6<'a, T, RStride = U1, CStride = U3> =
 ///
 /// See [`MatrixView4x1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4x1<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorageMut<'a, T, U4, U1, RStride, CStride>>;
 /// A mutable column-major 4x2 matrix view.
 ///
 /// See [`MatrixView4x2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4x2<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U2, ViewStorageMut<'a, T, U4, U2, RStride, CStride>>;
 /// A mutable column-major 4x3 matrix view.
 ///
 /// See [`MatrixView4x3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4x3<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U3, ViewStorageMut<'a, T, U4, U3, RStride, CStride>>;
 /// A mutable column-major 4x5 matrix view.
 ///
 /// See [`MatrixView4x5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4x5<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U5, ViewStorageMut<'a, T, U4, U5, RStride, CStride>>;
 /// A mutable column-major 4x6 matrix view.
 ///
 /// See [`MatrixView4x6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4x6<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U6, ViewStorageMut<'a, T, U4, U6, RStride, CStride>>;
 
@@ -653,35 +653,35 @@ pub type MatrixViewMut4x6<'a, T, RStride = U1, CStride = U4> =
 ///
 /// See [`MatrixView5x1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5x1<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorageMut<'a, T, U5, U1, RStride, CStride>>;
 /// A mutable column-major 5x2 matrix view.
 ///
 /// See [`MatrixView5x2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5x2<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U2, ViewStorageMut<'a, T, U5, U2, RStride, CStride>>;
 /// A mutable column-major 5x3 matrix view.
 ///
 /// See [`MatrixView5x3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5x3<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U3, ViewStorageMut<'a, T, U5, U3, RStride, CStride>>;
 /// A mutable column-major 5x4 matrix view.
 ///
 /// See [`MatrixView5x4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5x4<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U4, ViewStorageMut<'a, T, U5, U4, RStride, CStride>>;
 /// A mutable column-major 5x6 matrix view.
 ///
 /// See [`MatrixView5x6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5x6<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U6, ViewStorageMut<'a, T, U5, U6, RStride, CStride>>;
 
@@ -689,35 +689,35 @@ pub type MatrixViewMut5x6<'a, T, RStride = U1, CStride = U5> =
 ///
 /// See [`MatrixView6x1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6x1<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorageMut<'a, T, U6, U1, RStride, CStride>>;
 /// A mutable column-major 6x2 matrix view.
 ///
 /// See [`MatrixView6x2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6x2<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U2, ViewStorageMut<'a, T, U6, U2, RStride, CStride>>;
 /// A mutable column-major 6x3 matrix view.
 ///
 /// See [`MatrixView6x3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6x3<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U3, ViewStorageMut<'a, T, U6, U3, RStride, CStride>>;
 /// A mutable column-major 6x4 matrix view.
 ///
 /// See [`MatrixView6x4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6x4<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U4, ViewStorageMut<'a, T, U6, U4, RStride, CStride>>;
 /// A mutable column-major 6x5 matrix view.
 ///
 /// See [`MatrixView6x5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6x5<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U5, ViewStorageMut<'a, T, U6, U5, RStride, CStride>>;
 
@@ -725,42 +725,42 @@ pub type MatrixViewMut6x5<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixView1xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut1xX<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, Dyn, ViewStorageMut<'a, T, U1, Dyn, RStride, CStride>>;
 /// A mutable column-major matrix view with 2 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixView2xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut2xX<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, Dyn, ViewStorageMut<'a, T, U2, Dyn, RStride, CStride>>;
 /// A mutable column-major matrix view with 3 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixView3xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut3xX<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, Dyn, ViewStorageMut<'a, T, U3, Dyn, RStride, CStride>>;
 /// A mutable column-major matrix view with 4 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixView4xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut4xX<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, Dyn, ViewStorageMut<'a, T, U4, Dyn, RStride, CStride>>;
 /// A mutable column-major matrix view with 5 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixView5xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut5xX<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, Dyn, ViewStorageMut<'a, T, U5, Dyn, RStride, CStride>>;
 /// A mutable column-major matrix view with 6 rows and a number of columns chosen at runtime.
 ///
 /// See [`MatrixView6xX`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMut6xX<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, Dyn, ViewStorageMut<'a, T, U6, Dyn, RStride, CStride>>;
 
@@ -768,42 +768,42 @@ pub type MatrixViewMut6xX<'a, T, RStride = U1, CStride = U6> =
 ///
 /// See [`MatrixViewXx1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx1<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 /// A mutable column-major matrix view with a number of rows chosen at runtime and 2 columns.
 ///
 /// See [`MatrixViewXx2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx2<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U2, ViewStorageMut<'a, T, Dyn, U2, RStride, CStride>>;
 /// A mutable column-major matrix view with a number of rows chosen at runtime and 3 columns.
 ///
 /// See [`MatrixViewXx3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx3<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U3, ViewStorageMut<'a, T, Dyn, U3, RStride, CStride>>;
 /// A mutable column-major matrix view with a number of rows chosen at runtime and 4 columns.
 ///
 /// See [`MatrixViewXx4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx4<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U4, ViewStorageMut<'a, T, Dyn, U4, RStride, CStride>>;
 /// A mutable column-major matrix view with a number of rows chosen at runtime and 5 columns.
 ///
 /// See [`MatrixViewXx5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx5<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U5, ViewStorageMut<'a, T, Dyn, U5, RStride, CStride>>;
 /// A mutable column-major matrix view with a number of rows chosen at runtime and 6 columns.
 ///
 /// See [`MatrixViewXx6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type MatrixViewMutXx6<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U6, ViewStorageMut<'a, T, Dyn, U6, RStride, CStride>>;
 
@@ -811,7 +811,7 @@ pub type MatrixViewMutXx6<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`VectorView`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut<'a, T, D, RStride = U1, CStride = D> =
     Matrix<T, D, U1, ViewStorageMut<'a, T, D, U1, RStride, CStride>>;
 
@@ -819,7 +819,7 @@ pub type VectorViewMut<'a, T, D, RStride = U1, CStride = D> =
 ///
 /// See [`SVectorView`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type SVectorViewMut<'a, T, const D: usize> =
     Matrix<T, Const<D>, Const<1>, ViewStorageMut<'a, T, Const<D>, Const<1>, Const<1>, Const<D>>>;
 
@@ -827,7 +827,7 @@ pub type SVectorViewMut<'a, T, const D: usize> =
 ///
 /// See [`DVectorView`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type DVectorViewMut<'a, T, RStride = U1, CStride = Dyn> =
     Matrix<T, Dyn, U1, ViewStorageMut<'a, T, Dyn, U1, RStride, CStride>>;
 
@@ -835,41 +835,41 @@ pub type DVectorViewMut<'a, T, RStride = U1, CStride = Dyn> =
 ///
 /// See [`VectorView1`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut1<'a, T, RStride = U1, CStride = U1> =
     Matrix<T, U1, U1, ViewStorageMut<'a, T, U1, U1, RStride, CStride>>;
 /// A mutable 2D column vector view.
 ///
 /// See [`VectorView2`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut2<'a, T, RStride = U1, CStride = U2> =
     Matrix<T, U2, U1, ViewStorageMut<'a, T, U2, U1, RStride, CStride>>;
 /// A mutable 3D column vector view.
 ///
 /// See [`VectorView3`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut3<'a, T, RStride = U1, CStride = U3> =
     Matrix<T, U3, U1, ViewStorageMut<'a, T, U3, U1, RStride, CStride>>;
 /// A mutable 4D column vector view.
 ///
 /// See [`VectorView4`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut4<'a, T, RStride = U1, CStride = U4> =
     Matrix<T, U4, U1, ViewStorageMut<'a, T, U4, U1, RStride, CStride>>;
 /// A mutable 5D column vector view.
 ///
 /// See [`VectorView5`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut5<'a, T, RStride = U1, CStride = U5> =
     Matrix<T, U5, U1, ViewStorageMut<'a, T, U5, U1, RStride, CStride>>;
 /// A mutable 6D column vector view.
 ///
 /// See [`VectorView6`] for an immutable version of this type.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`](crate::base::Matrix) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Matrix`] type too.**
 pub type VectorViewMut6<'a, T, RStride = U1, CStride = U6> =
     Matrix<T, U6, U1, ViewStorageMut<'a, T, U6, U1, RStride, CStride>>;

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -32,8 +32,8 @@ use rkyv::bytecheck;
 /// - A translation part of type [`Translation3`](crate::Translation3)
 /// - A rotation part which can either be a [`UnitQuaternion`](crate::UnitQuaternion) or a [`Rotation3`](crate::Rotation3).
 ///
-/// Note that instead of using the [`Isometry`](crate::Isometry) type in your code directly, you should use one
-/// of its aliases: [`Isometry2`](crate::Isometry2), [`Isometry3`](crate::Isometry3),
+/// Note that instead of using the [`Isometry`] type in your code directly, you should use one
+/// of its aliases: [`Isometry2`](crate::Isometry2), [`Isometry3`],
 /// [`IsometryMatrix2`](crate::IsometryMatrix2), [`IsometryMatrix3`](crate::IsometryMatrix3). Though
 /// keep in mind that all the documentation of all the methods of these aliases will also appears on
 /// this page.

--- a/src/geometry/isometry_alias.rs
+++ b/src/geometry/isometry_alias.rs
@@ -2,28 +2,28 @@ use crate::geometry::{Isometry, Rotation2, Rotation3, UnitComplex, UnitQuaternio
 
 /// A 2-dimensional direct isometry using a unit complex number for its rotational part.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`](crate::Isometry) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`] type too.**
 ///
 /// Also known as a 2D rigid-body motion, or as an element of SE(2).
 pub type Isometry2<T> = Isometry<T, UnitComplex<T>, 2>;
 
 /// A 3-dimensional direct isometry using a unit quaternion for its rotational part.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`](crate::Isometry) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`] type too.**
 ///
 /// Also known as a rigid-body motion, or as an element of SE(3).
 pub type Isometry3<T> = Isometry<T, UnitQuaternion<T>, 3>;
 
 /// A 2-dimensional direct isometry using a rotation matrix for its rotational part.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`](crate::Isometry) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`] type too.**
 ///
 /// Also known as a rigid-body motion, or as an element of SE(2).
 pub type IsometryMatrix2<T> = Isometry<T, Rotation2<T>, 2>;
 
 /// A 3-dimensional direct isometry using a rotation matrix for its rotational part.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`](crate::Isometry) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Isometry`] type too.**
 ///
 /// Also known as a rigid-body motion, or as an element of SE(3).
 pub type IsometryMatrix3<T> = Isometry<T, Rotation3<T>, 3>;

--- a/src/geometry/point_alias.rs
+++ b/src/geometry/point_alias.rs
@@ -6,25 +6,25 @@ pub type Point<T, const D: usize> = OPoint<T, Const<D>>;
 
 /// A statically sized 1-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point1<T> = Point<T, 1>;
 /// A statically sized 2-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point2<T> = Point<T, 2>;
 /// A statically sized 3-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point3<T> = Point<T, 3>;
 /// A statically sized 4-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point4<T> = Point<T, 4>;
 /// A statically sized 5-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point5<T> = Point<T, 5>;
 /// A statically sized 6-dimensional column point.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Point`](crate::Point) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Point`] type too.**
 pub type Point6<T> = Point<T, 6>;

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -26,7 +26,7 @@ use rkyv::bytecheck;
 /// The `Rotation` type can either represent a 2D or 3D rotation, represented as a matrix.
 /// For a rotation based on quaternions, see [`UnitQuaternion`](crate::UnitQuaternion) instead.
 ///
-/// Note that instead of using the [`Rotation`](crate::Rotation) type in your code directly, you should use one
+/// Note that instead of using the [`Rotation`] type in your code directly, you should use one
 /// of its aliases: [`Rotation2`](crate::Rotation2), or [`Rotation3`](crate::Rotation3). Though
 /// keep in mind that all the documentation of all the methods of these aliases will also appears on
 /// this page.

--- a/src/geometry/rotation_alias.rs
+++ b/src/geometry/rotation_alias.rs
@@ -2,10 +2,10 @@ use crate::geometry::Rotation;
 
 /// A 2-dimensional rotation matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Rotation`](crate::Rotation) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Rotation`] type too.**
 pub type Rotation2<T> = Rotation<T, 2>;
 
 /// A 3-dimensional rotation matrix.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Rotation`](crate::Rotation) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Rotation`] type too.**
 pub type Rotation3<T> = Rotation<T, 3>;

--- a/src/geometry/unit_complex.rs
+++ b/src/geometry/unit_complex.rs
@@ -11,8 +11,8 @@ use std::cmp::{Eq, PartialEq};
 
 /// A 2D rotation represented as a complex number with magnitude 1.
 ///
-/// All the methods specific [`UnitComplex`](crate::UnitComplex) are listed here. You may also
-/// read the documentation of the [`Complex`](crate::Complex) type which
+/// All the methods specific [`UnitComplex`] are listed here. You may also
+/// read the documentation of the [`Complex`] type which
 /// is used internally and accessible with `unit_complex.complex()`.
 ///
 /// # Construction


### PR DESCRIPTION
Ran `cargo doc --workspace --no-deps --document-private-items` using 
```shell
❯ rustdoc --version
rustdoc 1.86.0 (05f9846f8 2025-03-31)
```
Plus, I applied suggestions from `markdownlint`.