### PR TITLE
Derive defmt::Format for Matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ glam028 = { package = "glam", version = "0.28", optional = true }
 glam029 = { package = "glam", version = "0.29", optional = true }
 glam030 = { package = "glam", version = "0.30", optional = true }
 rayon = { version = "1.6", optional = true }
+defmt = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -42,6 +42,7 @@ use std::mem;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ArrayStorage<T, const R: usize, const C: usize>(pub [[T; R]; C]);
 
 impl<T, const R: usize, const C: usize> ArrayStorage<T, R, C> {

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -219,6 +219,7 @@ dim_ops!(
     archive(as = "Self")
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Const<const R: usize>;
 
 /// Trait implemented exclusively by type-level integers.

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -171,6 +171,7 @@ pub type MatrixCross<T, R1, C1, R2, C2> =
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Matrix<T, R, C, S> {
     /// The data storage that contains all the matrix components. Disappointed?
     ///

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -35,6 +35,7 @@ use rkyv::bytecheck;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Unit<T> {
     pub(crate) value: T,
 }

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -55,6 +55,7 @@ use simba::scalar::{ClosedNeg, RealField};
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DualQuaternion<T> {
     /// The real component of the quaternion
     pub real: Quaternion<T>,

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -85,6 +85,7 @@ use rkyv::bytecheck;
     ")
     )
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Isometry<T, R, const D: usize> {
     /// The pure rotational part of this isometry.
     pub rotation: R,

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -35,6 +35,7 @@ use rkyv::bytecheck;
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Orthographic3<T> {
     matrix: Matrix4<T>,
 }

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -36,6 +36,7 @@ use rkyv::bytecheck;
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Perspective3<T> {
     matrix: Matrix4<T>,
 }

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -53,6 +53,7 @@ use std::mem::MaybeUninit;
     ")
     )
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OPoint<T: Scalar, D: DimName>
 where
     DefaultAllocator: Allocator<D>,

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -38,6 +38,7 @@ use rkyv::bytecheck;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Quaternion<T> {
     /// This quaternion as a 4D vector of coordinates in the `[ x, y, z, w ]` storage order.
     pub coords: Vector4<T>,

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -64,6 +64,7 @@ use rkyv::bytecheck;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Copy, Clone)]
 pub struct Rotation<T, const D: usize> {
     matrix: SMatrix<T, D, D>,

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -32,6 +32,7 @@ use rkyv::bytecheck;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Copy, Clone)]
 pub struct Scale<T, const D: usize> {
     /// The scale coordinates, i.e., how much is multiplied to a point's coordinates when it is

--- a/src/geometry/similarity.rs
+++ b/src/geometry/similarity.rs
@@ -49,6 +49,7 @@ use rkyv::bytecheck;
     ")
     )
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Similarity<T, R, const D: usize> {
     /// The part of this similarity that does not include the scaling factor.
     pub isometry: Isometry<T, R, D>,

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -32,6 +32,7 @@ use rkyv::bytecheck;
     )
 )]
 #[cfg_attr(feature = "rkyv-serialize", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Copy, Clone)]
 pub struct Translation<T, const D: usize> {
     /// The translation coordinates, i.e., how much is added to a point's coordinates when it is

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -33,6 +33,7 @@ use std::mem::MaybeUninit;
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>,
          OVector<T, DimDiff<DimMinimum<R, C>, U1>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct Bidiagonal<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -23,6 +23,7 @@ use crate::storage::{Storage, StorageMut};
     serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct Cholesky<T: SimdComplexField, D: Dim>
 where

--- a/src/linalg/col_piv_qr.rs
+++ b/src/linalg/col_piv_qr.rs
@@ -31,6 +31,7 @@ use std::mem::MaybeUninit;
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct ColPivQR<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/eigen.rs
+++ b/src/linalg/eigen.rs
@@ -33,6 +33,7 @@ use crate::linalg::Schur;
          OVector<T, D>: Serialize,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct Eigen<T: ComplexField, D: Dim>
 where

--- a/src/linalg/full_piv_lu.rs
+++ b/src/linalg/full_piv_lu.rs
@@ -27,6 +27,7 @@ use crate::linalg::PermutationSequence;
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct FullPivLU<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -26,6 +26,7 @@ use std::mem::MaybeUninit;
          OMatrix<T, D, D>: Deserialize<'de>,
          OVector<T, DimDiff<D, U1>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct Hessenberg<T: ComplexField, D: DimSub<U1>>
 where

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -27,6 +27,7 @@ use crate::linalg::PermutationSequence;
          OMatrix<T, R, C>: Deserialize<'de>,
          PermutationSequence<DimMinimum<R, C>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct LU<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -23,6 +23,7 @@ use crate::storage::StorageMut;
     serde(bound(deserialize = "DefaultAllocator: Allocator<D>,
          OVector<(usize, usize), D>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct PermutationSequence<D: Dim>
 where

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -29,6 +29,7 @@ use std::mem::MaybeUninit;
          OMatrix<T, R, C>: Deserialize<'de>,
          OVector<T, DimMinimum<R, C>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct QR<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -33,6 +33,7 @@ use std::mem::MaybeUninit;
     serde(bound(deserialize = "DefaultAllocator: Allocator<D, D>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct Schur<T: ComplexField, D: Dim>
 where

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -37,6 +37,7 @@ use crate::linalg::Bidiagonal;
          OMatrix<T, DimMinimum<R, C>, C>: Deserialize<'de>,
          OVector<T::RealField, DimMinimum<R, C>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct SVD<T: ComplexField, R: DimMin<C>, C: Dim>
 where

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -29,6 +29,7 @@ use crate::linalg::SymmetricTridiagonal;
          OVector<T::RealField, D>: Deserialize<'de>,
          OMatrix<T, D, D>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct SymmetricEigen<T: ComplexField, D: Dim>
 where

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -26,6 +26,7 @@ use std::mem::MaybeUninit;
          OMatrix<T, D, D>: Deserialize<'de>,
          OVector<T, DimDiff<D, U1>>: Deserialize<'de>"))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct SymmetricTridiagonal<T: ComplexField, D: DimSub<U1>>
 where

--- a/src/linalg/udu.rs
+++ b/src/linalg/udu.rs
@@ -18,6 +18,7 @@ use simba::scalar::RealField;
         deserialize = "OVector<T, D>: Deserialize<'de>, OMatrix<T, D, D>: Deserialize<'de>"
     ))
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
 pub struct UDU<T: RealField, D: Dim>
 where


### PR DESCRIPTION
[`defmt`](https://defmt.ferrous-systems.com/) is the de facto logging standard in the Rust embedded space. `nalgebra` works in `#[no_std]` environments so it would be very convenient if `defmt` could be used with `nalgebra` types. For this to work with `nalgebra` types they need to implement/derive the `Format` trait.

Since there's already precedent for implement foreign traits in in this library I figured it made sense to optionally derive `Format` for the public types. `defmt` recently hit 1.0 so this should should add much maintenance burden.

For now I limited the derive to public types in the main `nalgebra` crate. I _think_ I got all of them but if I missed any please let me know.

Thanks!