### PR TITLE
Improve compile-time usability

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Select rustc  version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.87.0
           override: true
       - uses: actions/checkout@v4
       - name: check
@@ -77,7 +77,7 @@ jobs:
       - name: Select rustc  version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.87.0
           override: true
       - uses: actions/checkout@v4
       - name: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Bumped MSRV to 1.87.0.
 - Renamed associated const `DimName::USIZE` to `DimName::DIM`.
 - Moved to Rust 2024 edition.
 - Several methods are now `const` whenever possible. See details in [#1522](https://github.com/dimforge/nalgebra/pull/1522).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Renamed associated const `DimName::USIZE` to `DimName::DIM`.
 - Moved to Rust 2024 edition.
+- Several methods are now `const` whenever possible. See details in [#1522](https://github.com/dimforge/nalgebra/pull/1522).
 
 ## [0.33.2] (29 October 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "mathematics", "wasm", "no-std"]
 keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 exclude = ["/ci/*", "/.travis.yml", "/Makefile"]
 
 [badges]

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -59,11 +59,8 @@ where
         SB: Storage<T, DimNameDiff<D, U1>>,
     {
         let mut res = Self::identity();
-        res.generic_view_mut(
-            (0, D::DIM - 1),
-            (DimNameDiff::<D, U1>::name(), Const::<1>),
-        )
-        .copy_from(translation);
+        res.generic_view_mut((0, D::DIM - 1), (DimNameDiff::<D, U1>::name(), Const::<1>))
+            .copy_from(translation);
 
         res
     }
@@ -382,10 +379,7 @@ impl<T: Scalar + Zero + One + ClosedMulAssign + ClosedAddAssign, D: DimName, S: 
         DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
     {
         let scale = self
-            .generic_view(
-                (D::DIM - 1, 0),
-                (Const::<1>, DimNameDiff::<D, U1>::name()),
-            )
+            .generic_view((D::DIM - 1, 0), (Const::<1>, DimNameDiff::<D, U1>::name()))
             .tr_dot(shift);
         let post_translation = self.generic_view(
             (0, 0),
@@ -394,10 +388,8 @@ impl<T: Scalar + Zero + One + ClosedMulAssign + ClosedAddAssign, D: DimName, S: 
 
         self[(D::DIM - 1, D::DIM - 1)] += scale;
 
-        let mut translation = self.generic_view_mut(
-            (0, D::DIM - 1),
-            (DimNameDiff::<D, U1>::name(), Const::<1>),
-        );
+        let mut translation =
+            self.generic_view_mut((0, D::DIM - 1), (DimNameDiff::<D, U1>::name(), Const::<1>));
         translation += post_translation;
     }
 }
@@ -419,10 +411,8 @@ where
             (0, 0),
             (DimNameDiff::<D, U1>::name(), DimNameDiff::<D, U1>::name()),
         );
-        let normalizer = self.generic_view(
-            (D::DIM - 1, 0),
-            (Const::<1>, DimNameDiff::<D, U1>::name()),
-        );
+        let normalizer =
+            self.generic_view((D::DIM - 1, 0), (Const::<1>, DimNameDiff::<D, U1>::name()));
         let n = normalizer.tr_dot(v);
 
         if !n.is_zero() {

--- a/src/base/cg.rs
+++ b/src/base/cg.rs
@@ -31,7 +31,7 @@ where
     #[inline]
     pub fn new_scaling(scaling: T) -> Self {
         let mut res = Self::from_diagonal_element(scaling);
-        res[(D::dim() - 1, D::dim() - 1)] = T::one();
+        res[(D::DIM - 1, D::DIM - 1)] = T::one();
 
         res
     }
@@ -60,7 +60,7 @@ where
     {
         let mut res = Self::identity();
         res.generic_view_mut(
-            (0, D::dim() - 1),
+            (0, D::DIM - 1),
             (DimNameDiff::<D, U1>::name(), Const::<1>),
         )
         .copy_from(translation);
@@ -364,9 +364,9 @@ impl<T: Scalar + Zero + One + ClosedMulAssign + ClosedAddAssign, D: DimName, S: 
         D: DimNameSub<U1>,
         SB: Storage<T, DimNameDiff<D, U1>>,
     {
-        for i in 0..D::dim() {
-            for j in 0..D::dim() - 1 {
-                let add = shift[j].clone() * self[(D::dim() - 1, i)].clone();
+        for i in 0..D::DIM {
+            for j in 0..D::DIM - 1 {
+                let add = shift[j].clone() * self[(D::DIM - 1, i)].clone();
                 self[(j, i)] += add;
             }
         }
@@ -383,7 +383,7 @@ impl<T: Scalar + Zero + One + ClosedMulAssign + ClosedAddAssign, D: DimName, S: 
     {
         let scale = self
             .generic_view(
-                (D::dim() - 1, 0),
+                (D::DIM - 1, 0),
                 (Const::<1>, DimNameDiff::<D, U1>::name()),
             )
             .tr_dot(shift);
@@ -392,10 +392,10 @@ impl<T: Scalar + Zero + One + ClosedMulAssign + ClosedAddAssign, D: DimName, S: 
             (DimNameDiff::<D, U1>::name(), DimNameDiff::<D, U1>::name()),
         ) * shift;
 
-        self[(D::dim() - 1, D::dim() - 1)] += scale;
+        self[(D::DIM - 1, D::DIM - 1)] += scale;
 
         let mut translation = self.generic_view_mut(
-            (0, D::dim() - 1),
+            (0, D::DIM - 1),
             (DimNameDiff::<D, U1>::name(), Const::<1>),
         );
         translation += post_translation;
@@ -420,7 +420,7 @@ where
             (DimNameDiff::<D, U1>::name(), DimNameDiff::<D, U1>::name()),
         );
         let normalizer = self.generic_view(
-            (D::dim() - 1, 0),
+            (D::DIM - 1, 0),
             (Const::<1>, DimNameDiff::<D, U1>::name()),
         );
         let n = normalizer.tr_dot(v);

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -792,12 +792,12 @@ R::name(), C::name();         // Arguments for `_generic` constructors.
 
 impl_constructors_from_data!(data; R, Dyn;
 => R: DimName;
-R::name(), Dyn(data.len() / R::dim());
+R::name(), Dyn(data.len() / R::DIM);
 );
 
 impl_constructors_from_data!(data; Dyn, C;
 => C: DimName;
-Dyn(data.len() / C::dim()), C::name();
+Dyn(data.len() / C::DIM), C::name();
 );
 
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/base/construction_view.rs
+++ b/src/base/construction_view.rs
@@ -14,7 +14,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     /// This method is unsafe because the input data array is not checked to contain enough elements.
     /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
-    pub unsafe fn from_slice_with_strides_generic_unchecked(
+    pub const unsafe fn from_slice_with_strides_generic_unchecked(
         data: &'a [T],
         start: usize,
         nrows: R,
@@ -163,7 +163,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
     /// This method is unsafe because the input data array is not checked to contain enough elements.
     /// The generic types `R`, `C`, `RStride`, `CStride` can either be type-level integers or integers wrapped with `Dyn()`.
     #[inline]
-    pub unsafe fn from_slice_with_strides_generic_unchecked(
+    pub const unsafe fn from_slice_with_strides_generic_unchecked(
         data: &'a mut [T],
         start: usize,
         nrows: R,

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -223,7 +223,7 @@ pub struct Const<const R: usize>;
 
 /// Trait implemented exclusively by type-level integers.
 pub trait DimName: Dim {
-    const USIZE: usize;
+    const DIM: usize;
 
     /// The name of this dimension, i.e., the singleton `Self`.
     fn name() -> Self;
@@ -280,7 +280,7 @@ unsafe impl<const T: usize> Dim for Const<T> {
 }
 
 impl<const T: usize> DimName for Const<T> {
-    const USIZE: usize = T;
+    const DIM: usize = T;
 
     #[inline]
     fn name() -> Self {

--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -279,7 +279,7 @@ pub struct RowIter<'a, T, R: Dim, C: Dim, S: RawStorage<T, R, C>> {
 }
 
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorage<T, R, C>> RowIter<'a, T, R, C, S> {
-    pub(crate) fn new(mat: &'a Matrix<T, R, C, S>) -> Self {
+    pub(crate) const fn new(mat: &'a Matrix<T, R, C, S>) -> Self {
         RowIter { mat, curr: 0 }
     }
 }
@@ -330,7 +330,7 @@ pub struct RowIterMut<'a, T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> {
 }
 
 impl<'a, T, R: Dim, C: Dim, S: 'a + RawStorageMut<T, R, C>> RowIterMut<'a, T, R, C, S> {
-    pub(crate) fn new(mat: &'a mut Matrix<T, R, C, S>) -> Self {
+    pub(crate) const fn new(mat: &'a mut Matrix<T, R, C, S>) -> Self {
         RowIterMut {
             mat,
             curr: 0,

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -32,7 +32,7 @@ use crate::base::iter::{
 };
 use crate::base::storage::{Owned, RawStorage, RawStorageMut, SameShapeStorage};
 use crate::base::{Const, DefaultAllocator, OMatrix, OVector, Scalar, Unit};
-use crate::{ArrayStorage, DimName, SMatrix, SimdComplexField, Storage, UninitMatrix};
+use crate::{ArrayStorage, SMatrix, SimdComplexField, Storage, UninitMatrix};
 
 use crate::storage::IsContiguous;
 use crate::uninit::{Init, InitStatus, Uninit};

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -405,27 +405,6 @@ where
     }
 }
 
-impl<T, const R: usize, const C: usize, MR: DimName, MC: DimName> Matrix<T, MR, MC, ArrayStorage<T, R, C>> {
-    /// The shape of this matrix returned as the tuple (number of rows, number of columns).
-    ///
-    /// # Example
-    /// ```
-    /// # use nalgebra::Matrix3x4;
-    /// const MAT: Matrix3x4<f32> = Matrix3x4::<f32>::new(
-    ///     0.0, 0.0, 0.0,
-    ///     0.0, 0.0, 0.0,
-    ///     0.0, 0.0, 0.0,
-    ///     0.0, 0.0, 0.0,
-    ///  );
-    /// assert_eq!(const { MAT.shape_const() }, (3, 4));
-    /// ```
-    #[inline]
-    #[must_use]
-    pub const fn shape_const(&self) -> (usize, usize) {
-        (R, C)
-    }
-}
-
 impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// Creates a new matrix with the given data.
     #[inline(always)]

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -32,7 +32,7 @@ use crate::base::iter::{
 };
 use crate::base::storage::{Owned, RawStorage, RawStorageMut, SameShapeStorage};
 use crate::base::{Const, DefaultAllocator, OMatrix, OVector, Scalar, Unit};
-use crate::{ArrayStorage, SMatrix, SimdComplexField, Storage, UninitMatrix};
+use crate::{ArrayStorage, DimName, SMatrix, SimdComplexField, Storage, UninitMatrix};
 
 use crate::storage::IsContiguous;
 use crate::uninit::{Init, InitStatus, Uninit};
@@ -405,10 +405,31 @@ where
     }
 }
 
+impl<T, const R: usize, const C: usize, MR: DimName, MC: DimName> Matrix<T, MR, MC, ArrayStorage<T, R, C>> {
+    /// The shape of this matrix returned as the tuple (number of rows, number of columns).
+    ///
+    /// # Example
+    /// ```
+    /// # use nalgebra::Matrix3x4;
+    /// const MAT: Matrix3x4<f32> = Matrix3x4::<f32>::new(
+    ///     0.0, 0.0, 0.0,
+    ///     0.0, 0.0, 0.0,
+    ///     0.0, 0.0, 0.0,
+    ///     0.0, 0.0, 0.0,
+    ///  );
+    /// assert_eq!(const { MAT.shape_const() }, (3, 4));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn shape_const(&self) -> (usize, usize) {
+        (R, C)
+    }
+}
+
 impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// Creates a new matrix with the given data.
     #[inline(always)]
-    pub fn from_data(data: S) -> Self {
+    pub const fn from_data(data: S) -> Self {
         unsafe { Self::from_data_statically_unchecked(data) }
     }
 

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -1136,7 +1136,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// }
     /// ```
     #[inline]
-    pub fn row_iter(&self) -> RowIter<'_, T, R, C, S> {
+    pub const fn row_iter(&self) -> RowIter<'_, T, R, C, S> {
         RowIter::new(self)
     }
 
@@ -1181,7 +1181,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     /// assert_eq!(a, expected);
     /// ```
     #[inline]
-    pub fn row_iter_mut(&mut self) -> RowIterMut<'_, T, R, C, S>
+    pub const fn row_iter_mut(&mut self) -> RowIterMut<'_, T, R, C, S>
     where
         S: RawStorageMut<T, R, C>,
     {

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -48,7 +48,7 @@ macro_rules! view_storage_impl (
             ///
             /// `*ptr` must point to memory that is valid `[T; R * C]`.
             #[inline]
-            pub unsafe fn from_raw_parts(ptr:     $Ptr,
+            pub const unsafe fn from_raw_parts(ptr:     $Ptr,
                                          shape:   (R, C),
                                          strides: (RStride, CStride))
                                         -> Self

--- a/src/base/norm.rs
+++ b/src/base/norm.rs
@@ -536,7 +536,7 @@ where
                 nbasis_elements += 1;
 
                 // All the other vectors will be dependent.
-                if nbasis_elements == D::dim() {
+                if nbasis_elements == D::DIM {
                     break;
                 }
             }
@@ -556,11 +556,11 @@ where
     {
         // TODO: is this necessary?
         assert!(
-            vs.len() <= D::dim(),
+            vs.len() <= D::DIM,
             "The given set of vectors has no chance of being a free family."
         );
 
-        match D::dim() {
+        match D::DIM {
             1 => {
                 if vs.is_empty() {
                     let _ = f(&Self::canonical_basis_element(0));
@@ -613,7 +613,7 @@ where
                         known_basis.push(v.normalize())
                     }
 
-                    for i in 0..D::dim() - vs.len() {
+                    for i in 0..D::DIM - vs.len() {
                         let mut elt = Self::canonical_basis_element(i);
 
                         for v in &known_basis {

--- a/src/base/unit.rs
+++ b/src/base/unit.rs
@@ -190,7 +190,7 @@ impl<T> Unit<T> {
 
     /// Wraps the given reference, assuming it is already normalized.
     #[inline]
-    pub fn from_ref_unchecked(value: &T) -> &Self {
+    pub const fn from_ref_unchecked(value: &T) -> &Self {
         unsafe { &*(value as *const T as *const Self) }
     }
 
@@ -212,7 +212,7 @@ impl<T> Unit<T> {
     /// the underlying value in such a way that it no longer has unit length may lead to unexpected
     /// results.
     #[inline]
-    pub fn as_mut_unchecked(&mut self) -> &mut T {
+    pub const fn as_mut_unchecked(&mut self) -> &mut T {
         &mut self.value
     }
 }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -131,7 +131,7 @@ impl<T, R: Dim, C: Dim> VecStorage<T, R, C> {
     /// The underlying data storage.
     #[inline]
     #[must_use]
-    pub fn as_vec(&self) -> &Vec<T> {
+    pub const fn as_vec(&self) -> &Vec<T> {
         &self.data
     }
 
@@ -141,7 +141,7 @@ impl<T, R: Dim, C: Dim> VecStorage<T, R, C> {
     /// This is unsafe because this may cause UB if the size of the vector is changed
     /// by the user.
     #[inline]
-    pub unsafe fn as_vec_mut(&mut self) -> &mut Vec<T> {
+    pub const unsafe fn as_vec_mut(&mut self) -> &mut Vec<T> {
         &mut self.data
     }
 
@@ -198,14 +198,14 @@ impl<T, R: Dim, C: Dim> VecStorage<T, R, C> {
     /// The number of elements on the underlying vector.
     #[inline]
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns true if the underlying vector contains no elements.
     #[inline]
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/src/geometry/dual_quaternion_construction.rs
+++ b/src/geometry/dual_quaternion_construction.rs
@@ -20,7 +20,7 @@ impl<T: Scalar> DualQuaternion<T> {
     /// assert_eq!(dq.real.w, 1.0);
     /// ```
     #[inline]
-    pub fn from_real_and_dual(real: Quaternion<T>, dual: Quaternion<T>) -> Self {
+    pub const fn from_real_and_dual(real: Quaternion<T>, dual: Quaternion<T>) -> Self {
         Self { real, dual }
     }
 

--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -139,7 +139,7 @@ impl<T: Scalar, R: AbstractRotation<T, D>, const D: usize> Isometry<T, R, D> {
     /// assert_relative_eq!(iso * Point3::new(1.0, 2.0, 3.0), Point3::new(-1.0, 2.0, 0.0), epsilon = 1.0e-6);
     /// ```
     #[inline]
-    pub fn from_parts(translation: Translation<T, D>, rotation: R) -> Self {
+    pub const fn from_parts(translation: Translation<T, D>, rotation: R) -> Self {
         Self {
             rotation,
             translation,

--- a/src/geometry/isometry_alias.rs
+++ b/src/geometry/isometry_alias.rs
@@ -31,8 +31,8 @@ pub type IsometryMatrix3<T> = Isometry<T, Rotation3<T>, 3>;
 // This tests that the types correctly implement `Copy`, without having to run tests
 // (when targeting no-std for example).
 #[allow(dead_code)]
-fn ensure_copy() {
-    fn is_copy<T: Copy>() {}
+const fn ensure_copy() {
+    const fn is_copy<T: Copy>() {}
 
     is_copy::<IsometryMatrix2<f32>>();
     is_copy::<IsometryMatrix3<f32>>();

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -271,7 +271,7 @@ impl<T: RealField> Orthographic3<T> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn as_matrix(&self) -> &Matrix4<T> {
+    pub const fn as_matrix(&self) -> &Matrix4<T> {
         &self.matrix
     }
 
@@ -285,7 +285,7 @@ impl<T: RealField> Orthographic3<T> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn as_projective(&self) -> &Projective3<T> {
+    pub const fn as_projective(&self) -> &Projective3<T> {
         unsafe { &*(self as *const Orthographic3<T> as *const Projective3<T>) }
     }
 

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -161,14 +161,14 @@ impl<T: RealField> Perspective3<T> {
     /// A reference to the underlying homogeneous transformation matrix.
     #[inline]
     #[must_use]
-    pub fn as_matrix(&self) -> &Matrix4<T> {
+    pub const fn as_matrix(&self) -> &Matrix4<T> {
         &self.matrix
     }
 
     /// A reference to this transformation seen as a `Projective3`.
     #[inline]
     #[must_use]
-    pub fn as_projective(&self) -> &Projective3<T> {
+    pub const fn as_projective(&self) -> &Projective3<T> {
         unsafe { &*(self as *const Perspective3<T> as *const Projective3<T>) }
     }
 

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -247,7 +247,7 @@ where
     /// Creates a new point with the given coordinates.
     #[deprecated(note = "Use Point::from(vector) instead.")]
     #[inline]
-    pub fn from_coordinates(coords: OVector<T, D>) -> Self {
+    pub const fn from_coordinates(coords: OVector<T, D>) -> Self {
         Self { coords }
     }
 

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -112,8 +112,8 @@ where
         D: DimNameAdd<U1>,
         DefaultAllocator: Allocator<DimNameSum<D, U1>>,
     {
-        if !v[D::dim()].is_zero() {
-            let coords = v.generic_view((0, 0), (D::name(), Const::<1>)) / v[D::dim()].clone();
+        if !v[D::DIM].is_zero() {
+            let coords = v.generic_view((0, 0), (D::name(), Const::<1>)) / v[D::DIM].clone();
             Some(Self::from(coords))
         } else {
             None

--- a/src/geometry/point_conversion.rs
+++ b/src/geometry/point_conversion.rs
@@ -58,12 +58,12 @@ where
 
     #[inline]
     fn is_in_subset(v: &OVector<T2, DimNameSum<D, U1>>) -> bool {
-        crate::is_convertible::<_, OVector<T1, DimNameSum<D, U1>>>(v) && !v[D::dim()].is_zero()
+        crate::is_convertible::<_, OVector<T1, DimNameSum<D, U1>>>(v) && !v[D::DIM].is_zero()
     }
 
     #[inline]
     fn from_superset_unchecked(v: &OVector<T2, DimNameSum<D, U1>>) -> Self {
-        let coords = v.generic_view((0, 0), (D::name(), Const::<1>)) / v[D::dim()].clone();
+        let coords = v.generic_view((0, 0), (D::name(), Const::<1>)) / v[D::DIM].clone();
         Self {
             coords: crate::convert_unchecked(coords),
         }

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -121,7 +121,7 @@ where
     /// Moves this unit quaternion into one that owns its data.
     #[inline]
     #[deprecated(note = "This method is a no-op and will be removed in a future release.")]
-    pub fn into_owned(self) -> Self {
+    pub const fn into_owned(self) -> Self {
         self
     }
 
@@ -230,7 +230,7 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub fn as_vector(&self) -> &Vector4<T> {
+    pub const fn as_vector(&self) -> &Vector4<T> {
         &self.coords
     }
 
@@ -572,7 +572,7 @@ where
     /// assert!(q.i == 1.0 && q.j == 2.0 && q.k == 3.0 && q.w == 4.0);
     /// ```
     #[inline]
-    pub fn as_vector_mut(&mut self) -> &mut Vector4<T> {
+    pub const fn as_vector_mut(&mut self) -> &mut Vector4<T> {
         &mut self.coords
     }
 

--- a/src/geometry/reflection.rs
+++ b/src/geometry/reflection.rs
@@ -35,7 +35,7 @@ impl<T: ComplexField, D: Dim, S: Storage<T, D>> Reflection<T, D, S> {
 
     /// The reflection axis.
     #[must_use]
-    pub fn axis(&self) -> &Vector<T, D, S> {
+    pub const fn axis(&self) -> &Vector<T, D, S> {
         &self.axis
     }
 

--- a/src/geometry/rotation.rs
+++ b/src/geometry/rotation.rs
@@ -182,7 +182,7 @@ impl<T: Scalar, const D: usize> Rotation<T, D> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn matrix(&self) -> &SMatrix<T, D, D> {
+    pub const fn matrix(&self) -> &SMatrix<T, D, D> {
         &self.matrix
     }
 
@@ -193,7 +193,7 @@ impl<T: Scalar, const D: usize> Rotation<T, D> {
     /// Invariants of the rotation matrix should not be violated.
     #[inline]
     #[deprecated(note = "Use `.matrix_mut_unchecked()` instead.")]
-    pub unsafe fn matrix_mut(&mut self) -> &mut SMatrix<T, D, D> {
+    pub const unsafe fn matrix_mut(&mut self) -> &mut SMatrix<T, D, D> {
         &mut self.matrix
     }
 
@@ -203,7 +203,7 @@ impl<T: Scalar, const D: usize> Rotation<T, D> {
     /// matrix by another one that is non-inversible or non-orthonormal. If one of
     /// those properties is broken, subsequent method calls may return bogus results.
     #[inline]
-    pub fn matrix_mut_unchecked(&mut self) -> &mut SMatrix<T, D, D> {
+    pub const fn matrix_mut_unchecked(&mut self) -> &mut SMatrix<T, D, D> {
         &mut self.matrix
     }
 

--- a/src/geometry/transform.rs
+++ b/src/geometry/transform.rs
@@ -104,7 +104,7 @@ impl TCategory for TAffine {
         T::Epsilon: Clone,
         DefaultAllocator: Allocator<D, D>,
     {
-        let last = D::dim() - 1;
+        let last = D::DIM - 1;
         mat.is_invertible()
             && mat[(last, last)] == T::one()
             && (0..last).all(|i| mat[(last, i)].is_zero())
@@ -287,7 +287,7 @@ where
     /// Creates a new transformation from the given homogeneous matrix. The transformation category
     /// of `Self` is not checked to be verified by the given matrix.
     #[inline]
-    pub fn from_matrix_unchecked(
+    pub const fn from_matrix_unchecked(
         matrix: OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>>,
     ) -> Self {
         Transform {
@@ -335,7 +335,7 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub fn matrix(&self) -> &OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
+    pub const fn matrix(&self) -> &OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
         &self.matrix
     }
 
@@ -362,7 +362,7 @@ where
     /// assert_eq!(*t.matrix(), expected);
     /// ```
     #[inline]
-    pub fn matrix_mut_unchecked(
+    pub const fn matrix_mut_unchecked(
         &mut self,
     ) -> &mut OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
         &mut self.matrix
@@ -582,7 +582,7 @@ where
     /// A mutable reference to underlying matrix. Use `.matrix_mut_unchecked` instead if this
     /// transformation category is not `TGeneral`.
     #[inline]
-    pub fn matrix_mut(
+    pub const fn matrix_mut(
         &mut self,
     ) -> &mut OMatrix<T, DimNameSum<Const<D>, U1>, DimNameSum<Const<D>, U1>> {
         self.matrix_mut_unchecked()

--- a/src/geometry/translation.rs
+++ b/src/geometry/translation.rs
@@ -105,7 +105,7 @@ impl<T: Scalar, const D: usize> Translation<T, D> {
     /// Creates a new translation from the given vector.
     #[inline]
     #[deprecated(note = "Use `::from` instead.")]
-    pub fn from_vector(vector: SVector<T, D>) -> Translation<T, D> {
+    pub const fn from_vector(vector: SVector<T, D>) -> Translation<T, D> {
         Translation { vector }
     }
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -108,7 +108,7 @@ where
     /// assert_relative_eq!(rot * Point2::new(3.0, 4.0), Point2::new(-4.0, 3.0));
     /// ```
     #[inline]
-    pub fn from_cos_sin_unchecked(cos: T, sin: T) -> Self {
+    pub const fn from_cos_sin_unchecked(cos: T, sin: T) -> Self {
         Self::new_unchecked(Complex::new(cos, sin))
     }
 

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -156,11 +156,7 @@ where
 
     #[inline]
     const fn axis_shift(&self) -> (usize, usize) {
-        if self.upper_diagonal {
-            (0, 1)
-        } else {
-            (1, 0)
-        }
+        if self.upper_diagonal { (0, 1) } else { (1, 0) }
     }
 
     /// Unpacks this decomposition into its three matrix factors `(U, D, V^t)`.

--- a/src/linalg/bidiagonal.rs
+++ b/src/linalg/bidiagonal.rs
@@ -150,13 +150,17 @@ where
     /// Indicates whether this decomposition contains an upper-diagonal matrix.
     #[inline]
     #[must_use]
-    pub fn is_upper_diagonal(&self) -> bool {
+    pub const fn is_upper_diagonal(&self) -> bool {
         self.upper_diagonal
     }
 
     #[inline]
-    fn axis_shift(&self) -> (usize, usize) {
-        if self.upper_diagonal { (0, 1) } else { (1, 0) }
+    const fn axis_shift(&self) -> (usize, usize) {
+        if self.upper_diagonal {
+            (0, 1)
+        } else {
+            (1, 0)
+        }
     }
 
     /// Unpacks this decomposition into its three matrix factors `(U, D, V^t)`.
@@ -302,7 +306,7 @@ where
     }
 
     #[doc(hidden)]
-    pub fn uv_internal(&self) -> &OMatrix<T, R, C> {
+    pub const fn uv_internal(&self) -> &OMatrix<T, R, C> {
         &self.uv
     }
 }

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -78,7 +78,7 @@ where
     /// Cholesky decomposition.
     ///
     /// It is up to the user to ensure all invariants hold.
-    pub fn pack_dirty(matrix: OMatrix<T, D, D>) -> Self {
+    pub const fn pack_dirty(matrix: OMatrix<T, D, D>) -> Self {
         Cholesky { chol: matrix }
     }
 
@@ -111,7 +111,7 @@ where
     /// This is an allocation-less version of `self.l()`. The values of the strict upper-triangular
     /// part are garbage and should be ignored by further computations.
     #[must_use]
-    pub fn l_dirty(&self) -> &OMatrix<T, D, D> {
+    pub const fn l_dirty(&self) -> &OMatrix<T, D, D> {
         &self.chol
     }
 

--- a/src/linalg/col_piv_qr.rs
+++ b/src/linalg/col_piv_qr.rs
@@ -150,7 +150,7 @@ where
     /// Retrieves the column permutation of this decomposition.
     #[inline]
     #[must_use]
-    pub fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
+    pub const fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
         &self.p
     }
 
@@ -172,7 +172,7 @@ where
     }
 
     #[doc(hidden)]
-    pub fn col_piv_qr_internal(&self) -> &OMatrix<T, R, C> {
+    pub const fn col_piv_qr_internal(&self) -> &OMatrix<T, R, C> {
         &self.col_piv_qr
     }
 

--- a/src/linalg/full_piv_lu.rs
+++ b/src/linalg/full_piv_lu.rs
@@ -90,7 +90,7 @@ where
     }
 
     #[doc(hidden)]
-    pub fn lu_internal(&self) -> &OMatrix<T, R, C> {
+    pub const fn lu_internal(&self) -> &OMatrix<T, R, C> {
         &self.lu
     }
 
@@ -122,14 +122,14 @@ where
     /// The row permutations of this decomposition.
     #[inline]
     #[must_use]
-    pub fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
+    pub const fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
         &self.p
     }
 
     /// The column permutations of this decomposition.
     #[inline]
     #[must_use]
-    pub fn q(&self) -> &PermutationSequence<DimMinimum<R, C>> {
+    pub const fn q(&self) -> &PermutationSequence<DimMinimum<R, C>> {
         &self.q
     }
 

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -29,7 +29,7 @@ impl<T: ComplexField> GivensRotation<T> {
     ///
     /// The components are copies as-is. It is not checked whether they describe
     /// an actually valid Givens rotation.
-    pub fn new_unchecked(c: T::RealField, s: T) -> Self {
+    pub const fn new_unchecked(c: T::RealField, s: T) -> Self {
         Self { c, s }
     }
 

--- a/src/linalg/hessenberg.rs
+++ b/src/linalg/hessenberg.rs
@@ -148,7 +148,7 @@ where
     }
 
     #[doc(hidden)]
-    pub fn hess_internal(&self) -> &OMatrix<T, D, D> {
+    pub const fn hess_internal(&self) -> &OMatrix<T, D, D> {
         &self.hess
     }
 }

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -121,7 +121,7 @@ where
     }
 
     #[doc(hidden)]
-    pub fn lu_internal(&self) -> &OMatrix<T, R, C> {
+    pub const fn lu_internal(&self) -> &OMatrix<T, R, C> {
         &self.lu
     }
 
@@ -183,7 +183,7 @@ where
     /// The row permutations of this decomposition.
     #[inline]
     #[must_use]
-    pub fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
+    pub const fn p(&self) -> &PermutationSequence<DimMinimum<R, C>> {
         &self.p
     }
 

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -141,13 +141,13 @@ where
 
     /// The number of non-identity permutations applied by this sequence.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if the permutation sequence contains no elements.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -143,12 +143,12 @@ where
     }
 
     #[doc(hidden)]
-    pub fn qr_internal(&self) -> &OMatrix<T, R, C> {
+    pub const fn qr_internal(&self) -> &OMatrix<T, R, C> {
         &self.qr
     }
 
     #[must_use]
-    pub(crate) fn diag_internal(&self) -> &OVector<T, DimMinimum<R, C>> {
+    pub(crate) const fn diag_internal(&self) -> &OVector<T, DimMinimum<R, C>> {
         &self.diag
     }
 

--- a/src/linalg/symmetric_tridiagonal.rs
+++ b/src/linalg/symmetric_tridiagonal.rs
@@ -94,7 +94,7 @@ where
 
     #[doc(hidden)]
     // For debugging.
-    pub fn internal_tri(&self) -> &OMatrix<T, D, D> {
+    pub const fn internal_tri(&self) -> &OMatrix<T, D, D> {
         &self.tri
     }
 

--- a/src/third_party/alga/alga_matrix.rs
+++ b/src/third_party/alga/alga_matrix.rs
@@ -115,7 +115,7 @@ where
 {
     #[inline]
     fn dimension() -> usize {
-        R::dim() * C::dim()
+        R::DIM * C::DIM
     }
 
     #[inline]


### PR DESCRIPTION
Improve compile-time usability by adding const to as many functions as possible without `const_traits`