### PR TITLE
Move to rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 categories = ["science", "mathematics", "wasm", "no-std"]
 keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2024"
 exclude = ["/ci/*", "/.travis.yml", "/Makefile"]
 
 [badges]
@@ -134,7 +134,7 @@ rayon = { version = "1.6", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 rand_xorshift = "0.4"
-rand_isaac = "0.3"
+rand_isaac = "0.4"
 criterion = { version = "0.4", features = ["html_reports"] }
 nalgebra = { path = ".", features = ["debug", "compare", "rand", "macros"] }
 

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -5,8 +5,8 @@ macro_rules! bench_binop(
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
-            let a = rng.gen::<$t1>();
-            let b = rng.gen::<$t2>();
+            let a = rng.random::<$t1>();
+            let b = rng.random::<$t2>();
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {
                 a.$binop(b)
@@ -20,8 +20,8 @@ macro_rules! bench_binop_ref(
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
-            let a = rng.gen::<$t1>();
-            let b = rng.gen::<$t2>();
+            let a = rng.random::<$t1>();
+            let b = rng.random::<$t2>();
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {
                 a.$binop(&b)
@@ -35,8 +35,8 @@ macro_rules! bench_binop_fn(
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
-            let a = rng.gen::<$t1>();
-            let b = rng.gen::<$t2>();
+            let a = rng.random::<$t1>();
+            let b = rng.random::<$t2>();
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {
                 $binop(&a, &b)
@@ -53,7 +53,7 @@ macro_rules! bench_unop_na(
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
 
-            let elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.gen::<$t>()).collect();
+            let elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.random::<$t>()).collect();
             let mut i = 0;
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {
@@ -75,7 +75,7 @@ macro_rules! bench_unop(
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
 
-            let mut elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.gen::<$t>()).collect();
+            let mut elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.random::<$t>()).collect();
             let mut i = 0;
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {
@@ -97,7 +97,7 @@ macro_rules! bench_construction(
             use rand::SeedableRng;
             let mut rng = IsaacRng::seed_from_u64(0);
 
-            $(let $args: Vec<$types> = (0usize .. LEN).map(|_| rng.gen::<$types>()).collect();)*
+            $(let $args: Vec<$types> = (0usize .. LEN).map(|_| rng.random::<$types>()).collect();)*
             let mut i = 0;
 
             bh.bench_function(stringify!($name), move |bh| bh.iter(|| {

--- a/benches/core/vector.rs
+++ b/benches/core/vector.rs
@@ -52,7 +52,7 @@ fn vec10000_axpy_f64(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
-    let n = rng.gen::<f64>();
+    let n = rng.random::<f64>();
 
     bh.bench_function("vec10000_axpy_f64", move |bh| {
         bh.iter(|| a.axpy(n, &b, 1.0))
@@ -64,8 +64,8 @@ fn vec10000_axpy_beta_f64(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
-    let n = rng.gen::<f64>();
-    let beta = rng.gen::<f64>();
+    let n = rng.random::<f64>();
+    let beta = rng.random::<f64>();
 
     bh.bench_function("vec10000_axpy_beta_f64", move |bh| {
         bh.iter(|| a.axpy(n, &b, beta))
@@ -77,7 +77,7 @@ fn vec10000_axpy_f64_slice(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
-    let n = rng.gen::<f64>();
+    let n = rng.random::<f64>();
 
     bh.bench_function("vec10000_axpy_f64_slice", move |bh| {
         bh.iter(|| {
@@ -94,7 +94,7 @@ fn vec10000_axpy_f64_static(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = SVector::<f64, 10000>::new_random();
     let b = SVector::<f64, 10000>::new_random();
-    let n = rng.gen::<f64>();
+    let n = rng.random::<f64>();
 
     // NOTE: for some reasons, it is much faster if the argument are boxed (Box::new(OVector...)).
     bh.bench_function("vec10000_axpy_f64_static", move |bh| {
@@ -107,7 +107,7 @@ fn vec10000_axpy_f32(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
-    let n = rng.gen::<f32>();
+    let n = rng.random::<f32>();
 
     bh.bench_function("vec10000_axpy_f32", move |bh| {
         bh.iter(|| a.axpy(n, &b, 1.0))
@@ -119,8 +119,8 @@ fn vec10000_axpy_beta_f32(bh: &mut criterion::Criterion) {
     let mut rng = IsaacRng::seed_from_u64(0);
     let mut a = DVector::new_random(10000);
     let b = DVector::new_random(10000);
-    let n = rng.gen::<f32>();
-    let beta = rng.gen::<f32>();
+    let n = rng.random::<f32>();
+    let beta = rng.random::<f32>();
 
     bh.bench_function("vec10000_axpy_beta_f32", move |bh| {
         bh.iter(|| a.axpy(n, &b, beta))

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -17,7 +17,7 @@ pub mod linalg;
 fn reproducible_dmatrix(nrows: usize, ncols: usize) -> DMatrix<f64> {
     use rand::SeedableRng;
     let mut rng = IsaacRng::seed_from_u64(0);
-    DMatrix::<f64>::from_fn(nrows, ncols, |_, _| rng.gen())
+    DMatrix::<f64>::from_fn(nrows, ncols, |_, _| rng.random())
 }
 
 criterion_main!(

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 categories = ["science", "mathematics", "wasm", "no standard library"]
 keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2024"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/nalgebra-glm/src/lib.rs
+++ b/nalgebra-glm/src/lib.rs
@@ -115,7 +115,7 @@
     unused,
     missing_docs,
     rust_2018_idioms,
-    rust_2018_compatibility,
+    rust_2024_compatibility,
     future_incompatible,
     missing_copy_implementations,
     missing_debug_implementations

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 categories = ["science", "mathematics"]
 keywords = ["linear", "algebra", "matrix", "vector", "lapack"]
 license = "MIT"
-edition = "2018"
+edition = "2024"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/nalgebra-macros/Cargo.toml
+++ b/nalgebra-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nalgebra-macros"
 version = "0.2.2"
 authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
-edition = "2018"
+edition = "2024"
 description = "Procedural macros for nalgebra"
 documentation = "https://www.nalgebra.org/docs"
 homepage = "https://nalgebra.org"

--- a/nalgebra-macros/src/lib.rs
+++ b/nalgebra-macros/src/lib.rs
@@ -8,7 +8,7 @@
     unused,
     missing_docs,
     rust_2018_idioms,
-    rust_2018_compatibility,
+    rust_2024_compatibility,
     future_incompatible,
     missing_copy_implementations,
     missing_debug_implementations,

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nalgebra-sparse"
 version = "0.10.0"
 authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
-edition = "2018"
+edition = "2024"
 description = "Sparse matrix computation based on nalgebra."
 documentation = "https://www.nalgebra.org/docs"
 homepage = "https://nalgebra.org"

--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -137,7 +137,7 @@
     unused,
     missing_docs,
     rust_2018_idioms,
-    rust_2018_compatibility,
+    rust_2024_compatibility,
     future_incompatible,
     missing_copy_implementations
 )]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
-edition = "2018"
+edition = "2024"
 use_try_shorthand = true
 use_field_init_shorthand = true

--- a/src/base/array_storage.rs
+++ b/src/base/array_storage.rs
@@ -105,9 +105,9 @@ unsafe impl<T, const R: usize, const C: usize> RawStorage<T, Const<R>, Const<C>>
     }
 
     #[inline]
-    unsafe fn as_slice_unchecked(&self) -> &[T] {
+    unsafe fn as_slice_unchecked(&self) -> &[T] { unsafe {
         std::slice::from_raw_parts(self.ptr(), R * C)
-    }
+    }}
 }
 
 unsafe impl<T: Scalar, const R: usize, const C: usize> Storage<T, Const<R>, Const<C>>
@@ -147,9 +147,9 @@ unsafe impl<T, const R: usize, const C: usize> RawStorageMut<T, Const<R>, Const<
     }
 
     #[inline]
-    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] { unsafe {
         std::slice::from_raw_parts_mut(self.ptr_mut(), R * C)
-    }
+    }}
 }
 
 unsafe impl<T, const R: usize, const C: usize> IsContiguous for ArrayStorage<T, R, C> {}

--- a/src/base/blas_uninit.rs
+++ b/src/base/blas_uninit.rs
@@ -42,13 +42,13 @@ unsafe fn array_axcpy<Status, T>(
 ) where
     Status: InitStatus<T>,
     T: Scalar + Zero + ClosedAddAssign + ClosedMulAssign,
-{
+{ unsafe {
     for i in 0..len {
         let y = Status::assume_init_mut(y.get_unchecked_mut(i * stride1));
         *y =
             a.clone() * x.get_unchecked(i * stride2).clone() * c.clone() + beta.clone() * y.clone();
     }
-}
+}}
 
 fn array_axc<Status, T>(
     _: Status,
@@ -94,7 +94,7 @@ pub unsafe fn axcpy_uninit<Status, T, D1: Dim, D2: Dim, SA, SB>(
     SB: RawStorage<T, D2>,
     ShapeConstraint: DimEq<D1, D2>,
     Status: InitStatus<T>,
-{
+{ unsafe {
     assert_eq!(y.nrows(), x.nrows(), "Axcpy: mismatched vector shapes.");
 
     let rstride1 = y.strides().0;
@@ -110,7 +110,7 @@ pub unsafe fn axcpy_uninit<Status, T, D1: Dim, D2: Dim, SA, SB>(
     } else {
         array_axc(status, y, a, x, c, rstride1, rstride2, x.len());
     }
-}
+}}
 
 /// Computes `y = alpha * a * x + beta * y`, where `a` is a matrix, `x` a vector, and
 /// `alpha, beta` two scalars.
@@ -134,7 +134,7 @@ pub unsafe fn gemv_uninit<Status, T, D1: Dim, R2: Dim, C2: Dim, D3: Dim, SA, SB,
     SB: RawStorage<T, R2, C2>,
     SC: RawStorage<T, D3>,
     ShapeConstraint: DimEq<D1, R2> + AreMultipliable<R2, C2, D3, U1>,
-{
+{ unsafe {
     let dim1 = y.nrows();
     let (nrows2, ncols2) = a.shape();
     let dim3 = x.nrows();
@@ -168,7 +168,7 @@ pub unsafe fn gemv_uninit<Status, T, D1: Dim, R2: Dim, C2: Dim, D3: Dim, SA, SB,
         // SAFETY: safe because y was initialized above.
         axcpy_uninit(status, y, alpha.clone(), &col2, val, T::one());
     }
-}
+}}
 
 /// Computes `y = alpha * a * b + beta * y`, where `a, b, y` are matrices.
 /// `alpha` and `beta` are scalar.
@@ -205,7 +205,7 @@ pub unsafe fn gemm_uninit<
     SC: RawStorage<T, R3, C3>,
     ShapeConstraint:
         SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C3> + AreMultipliable<R2, C2, R3, C3>,
-{
+{ unsafe {
     let ncols1 = y.ncols();
 
     #[cfg(feature = "std")]
@@ -319,4 +319,4 @@ pub unsafe fn gemm_uninit<
             beta.clone(),
         );
     }
-}
+}}

--- a/src/base/componentwise.rs
+++ b/src/base/componentwise.rs
@@ -47,7 +47,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
 }
 
 macro_rules! component_binop_impl(
-    ($($binop: ident, $binop_mut: ident, $binop_assign: ident, $cmpy: ident, $Trait: ident . $op: ident . $op_assign: ident, $desc:expr, $desc_cmpy:expr, $desc_mut:expr);* $(;)*) => {$(
+    ($($binop: ident, $binop_mut: ident, $binop_assign: ident, $cmpy: ident, $Trait: ident . $op: ident . $op_assign: ident, $desc:expr_2021, $desc_cmpy:expr_2021, $desc_mut:expr_2021);* $(;)*) => {$(
         #[doc = $desc]
         #[inline]
         #[must_use]

--- a/src/base/constraint.rs
+++ b/src/base/constraint.rs
@@ -44,7 +44,7 @@ impl<D: DimName> DimEq<Dyn, D> for ShapeConstraint {
 }
 
 macro_rules! equality_trait_decl(
-    ($($doc: expr, $Trait: ident),* $(,)*) => {$(
+    ($($doc: expr_2021, $Trait: ident),* $(,)*) => {$(
         // XXX: we can't do something like `DimEq<D1> for D2` because we would require a blanket impl…
         #[doc = $doc]
         pub trait $Trait<D1: Dim, D2: Dim>: DimEq<D1, D2> + DimEq<D2, D1> {

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -13,7 +13,6 @@ use rand::{
     Rng,
 };
 
-use std::iter;
 use typenum::{self, Cmp, Greater};
 
 use simba::scalar::{ClosedAddAssign, ClosedMulAssign};
@@ -56,7 +55,7 @@ where
     #[inline]
     pub fn from_element_generic(nrows: R, ncols: C, elem: T) -> Self {
         let len = nrows.value() * ncols.value();
-        Self::from_iterator_generic(nrows, ncols, iter::repeat(elem).take(len))
+        Self::from_iterator_generic(nrows, ncols, std::iter::repeat_n(elem, len))
     }
 
     /// Creates a matrix with all its elements set to `elem`.
@@ -65,7 +64,7 @@ where
     #[inline]
     pub fn repeat_generic(nrows: R, ncols: C, elem: T) -> Self {
         let len = nrows.value() * ncols.value();
-        Self::from_iterator_generic(nrows, ncols, iter::repeat(elem).take(len))
+        Self::from_iterator_generic(nrows, ncols, std::iter::repeat_n(elem, len))
     }
 
     /// Creates a matrix with all its elements set to 0.
@@ -382,7 +381,7 @@ where
  *
  */
 macro_rules! impl_constructors(
-    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr),*; $($args: ident),*) => {
+    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr_2021),*; $($args: ident),*) => {
         /// Creates a matrix or vector with all its elements set to `elem`.
         ///
         /// # Example
@@ -696,7 +695,7 @@ where
  *
  */
 macro_rules! impl_constructors_from_data(
-    ($data: ident; $($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr),*; $($args: ident),*) => {
+    ($data: ident; $($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr_2021),*; $($args: ident),*) => {
         impl<T: Scalar, $($DimIdent: $DimBound, )*> OMatrix<T $(, $Dims)*>
         where DefaultAllocator: Allocator<$($Dims),*> {
             /// Creates a matrix with its elements filled with the components provided by a slice
@@ -939,7 +938,7 @@ macro_rules! transpose_array(
 );
 
 macro_rules! componentwise_constructors_impl(
-    ($($R: expr, $C: expr, [$($($args: ident),*);*] $(;)*)*) => {$(
+    ($($R: expr_2021, $C: expr_2021, [$($($args: ident),*);*] $(;)*)*) => {$(
         impl<T> Matrix<T, Const<$R>, Const<$C>, ArrayStorage<T, $R, $C>> {
             /// Initializes this matrix from its components.
             #[inline]

--- a/src/base/construction_view.rs
+++ b/src/base/construction_view.rs
@@ -21,14 +21,14 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
         ncols: C,
         rstride: RStride,
         cstride: CStride,
-    ) -> Self {
+    ) -> Self { unsafe {
         let data = ViewStorage::from_raw_parts(
             data.as_ptr().add(start),
             (nrows, ncols),
             (rstride, cstride),
         );
         Self::from_data(data)
-    }
+    }}
 
     /// Creates a matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
@@ -69,11 +69,11 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixView<'a, T, R, C> {
         start: usize,
         nrows: R,
         ncols: C,
-    ) -> Self {
+    ) -> Self { unsafe {
         Self::from_slice_with_strides_generic_unchecked(
             data, start, nrows, ncols, Const::<1>, nrows,
         )
-    }
+    }}
 
     /// Creates a matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
@@ -86,7 +86,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixView<'a, T, R, C> {
 }
 
 macro_rules! impl_constructors(
-    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr),*; $($args: ident),*) => {
+    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr_2021),*; $($args: ident),*) => {
         impl<'a, T: Scalar, $($DimIdent: $DimBound),*> MatrixView<'a, T, $($Dims),*> {
             /// Creates a new matrix view from the given data array.
             ///
@@ -100,9 +100,9 @@ macro_rules! impl_constructors(
             /// # Safety
             /// `data[start..start+rstride * cstride]` must be within bounds.
             #[inline]
-            pub unsafe fn from_slice_unchecked(data: &'a [T], start: usize, $($args: usize),*) -> Self {
+            pub unsafe fn from_slice_unchecked(data: &'a [T], start: usize, $($args: usize),*) -> Self { unsafe {
                 Self::from_slice_generic_unchecked(data, start, $($gargs),*)
-            }
+            }}
         }
 
         impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixView<'a, T, $($Dims,)* Dyn, Dyn> {
@@ -121,9 +121,9 @@ macro_rules! impl_constructors(
             /// `start`, `rstride`, and `cstride`, with the given matrix size will not index
             /// outside of `data`.
             #[inline]
-            pub unsafe fn from_slice_with_strides_unchecked(data: &'a [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self {
+            pub unsafe fn from_slice_with_strides_unchecked(data: &'a [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self { unsafe {
                 Self::from_slice_with_strides_generic_unchecked(data, start, $($gargs,)* Dyn(rstride), Dyn(cstride))
-            }
+            }}
         }
     }
 );
@@ -166,14 +166,14 @@ impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
         ncols: C,
         rstride: RStride,
         cstride: CStride,
-    ) -> Self {
+    ) -> Self { unsafe {
         let data = ViewStorageMut::from_raw_parts(
             data.as_mut_ptr().add(start),
             (nrows, ncols),
             (rstride, cstride),
         );
         Self::from_data(data)
-    }
+    }}
 
     /// Creates a mutable matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
@@ -236,11 +236,11 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixViewMut<'a, T, R, C> {
         start: usize,
         nrows: R,
         ncols: C,
-    ) -> Self {
+    ) -> Self { unsafe {
         Self::from_slice_with_strides_generic_unchecked(
             data, start, nrows, ncols, Const::<1>, nrows,
         )
-    }
+    }}
 
     /// Creates a mutable matrix view from an array and with dimensions and strides specified by generic types instances.
     ///
@@ -253,7 +253,7 @@ impl<'a, T: Scalar, R: Dim, C: Dim> MatrixViewMut<'a, T, R, C> {
 }
 
 macro_rules! impl_constructors_mut(
-    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr),*; $($args: ident),*) => {
+    ($($Dims: ty),*; $(=> $DimIdent: ident: $DimBound: ident),*; $($gargs: expr_2021),*; $($args: ident),*) => {
         impl<'a, T: Scalar, $($DimIdent: $DimBound),*> MatrixViewMut<'a, T, $($Dims),*> {
             /// Creates a new mutable matrix view from the given data array.
             ///
@@ -269,9 +269,9 @@ macro_rules! impl_constructors_mut(
             ///
             /// `data[start..start+(R * C)]` must be within bounds.
             #[inline]
-            pub unsafe fn from_slice_unchecked(data: &'a mut [T], start: usize, $($args: usize),*) -> Self {
+            pub unsafe fn from_slice_unchecked(data: &'a mut [T], start: usize, $($args: usize),*) -> Self { unsafe {
                 Self::from_slice_generic_unchecked(data, start, $($gargs),*)
-            }
+            }}
         }
 
         impl<'a, T: Scalar, $($DimIdent: $DimBound, )*> MatrixViewMut<'a, T, $($Dims,)* Dyn, Dyn> {
@@ -288,10 +288,10 @@ macro_rules! impl_constructors_mut(
             /// # Safety
             /// `data[start..start+rstride * cstride]` must be within bounds.
             #[inline]
-            pub unsafe fn from_slice_with_strides_unchecked(data: &'a mut [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self {
+            pub unsafe fn from_slice_with_strides_unchecked(data: &'a mut [T], start: usize, $($args: usize,)* rstride: usize, cstride: usize) -> Self { unsafe {
                 Self::from_slice_with_strides_generic_unchecked(
                     data, start, $($gargs,)* Dyn(rstride), Dyn(cstride))
-            }
+            }}
         }
     }
 );

--- a/src/base/conversion.rs
+++ b/src/base/conversion.rs
@@ -187,7 +187,7 @@ where
 }
 
 macro_rules! impl_from_into_asref_1D(
-    ($(($NRows: ident, $NCols: ident) => $SZ: expr);* $(;)*) => {$(
+    ($(($NRows: ident, $NCols: ident) => $SZ: expr_2021);* $(;)*) => {$(
         impl<T, S> AsRef<[T; $SZ]> for Matrix<T, $NRows, $NCols, S>
         where T: Scalar,
               S: RawStorage<T, $NRows, $NCols> + IsContiguous {
@@ -265,7 +265,7 @@ macro_rules! impl_from_into_asref_borrow_2D(
 
     //does the impls on one case for either AsRef/AsMut and Borrow/BorrowMut
     (
-        ($NRows: ty, $NCols: ty) => ($SZRows: expr, $SZCols: expr);
+        ($NRows: ty, $NCols: ty) => ($SZRows: expr_2021, $SZCols: expr_2021);
         $Ref:ident.$ref:ident(), $Mut:ident.$mut:ident()
     ) => {
         impl<T: Scalar, S> $Ref<[[T; $SZRows]; $SZCols]> for Matrix<T, $NRows, $NCols, S>
@@ -292,7 +292,7 @@ macro_rules! impl_from_into_asref_borrow_2D(
     };
 
     //collects the mappings from typenum pairs to consts
-    ($(($NRows: ty, $NCols: ty) => ($SZRows: expr, $SZCols: expr));* $(;)*) => {$(
+    ($(($NRows: ty, $NCols: ty) => ($SZRows: expr_2021, $SZCols: expr_2021));* $(;)*) => {$(
         impl_from_into_asref_borrow_2D!(
             ($NRows, $NCols) => ($SZRows, $SZCols); AsRef.as_ref(), AsMut.as_mut()
         );

--- a/src/base/dimension.rs
+++ b/src/base/dimension.rs
@@ -304,7 +304,7 @@ impl ToConst for typenum::U1 {
 }
 
 macro_rules! from_to_typenum (
-    ($($D: ident, $VAL: expr);* $(;)*) => {$(
+    ($($D: ident, $VAL: expr_2021);* $(;)*) => {$(
         pub type $D = Const<$VAL>;
 
         impl ToTypenum for Const<$VAL> {

--- a/src/base/edition.rs
+++ b/src/base/edition.rs
@@ -689,7 +689,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         D: Dim,
         C: DimAdd<D>,
         DefaultAllocator: Reallocator<T, R, C, R, DimSum<C, D>>,
-    {
+    { unsafe {
         let m = self.into_owned();
         let (nrows, ncols) = m.shape_generic();
         let mut res = Matrix::from_data(DefaultAllocator::reallocate_copy(
@@ -711,7 +711,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         }
 
         res
-    }
+    }}
 
     /*
      *
@@ -783,7 +783,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         D: Dim,
         R: DimAdd<D>,
         DefaultAllocator: Reallocator<T, R, C, DimSum<R, D>, C>,
-    {
+    { unsafe {
         let m = self.into_owned();
         let (nrows, ncols) = m.shape_generic();
         let mut res = Matrix::from_data(DefaultAllocator::reallocate_copy(
@@ -805,7 +805,7 @@ impl<T: Scalar, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
         }
 
         res
-    }
+    }}
 }
 
 /// # Resizing and reshaping
@@ -1086,7 +1086,7 @@ unsafe fn compress_rows<T: Scalar>(
     ncols: usize,
     i: usize,
     nremove: usize,
-) {
+) { unsafe {
     let new_nrows = nrows - nremove;
 
     if nremove == 0 {
@@ -1133,11 +1133,11 @@ unsafe fn compress_rows<T: Scalar>(
         ptr_out.add(curr_i),
         remaining_len,
     );
-}
+}}
 
 // Moves entries of a matrix buffer to make place for `ninsert` empty rows starting at the `i-th` row index.
 // The `data` buffer is assumed to contained at least `(nrows + ninsert) * ncols` elements.
-unsafe fn extend_rows<T>(data: &mut [T], nrows: usize, ncols: usize, i: usize, ninsert: usize) {
+unsafe fn extend_rows<T>(data: &mut [T], nrows: usize, ncols: usize, i: usize, ninsert: usize) { unsafe {
     let new_nrows = nrows + ninsert;
 
     if new_nrows == 0 || ncols == 0 {
@@ -1162,7 +1162,7 @@ unsafe fn extend_rows<T>(data: &mut [T], nrows: usize, ncols: usize, i: usize, n
 
         ptr::copy(ptr_in.add(k * nrows + i), ptr_out.add(curr_i), nrows);
     }
-}
+}}
 
 /// Extend the number of columns of the `Matrix` with elements from
 /// a given iterator.

--- a/src/base/indexing.rs
+++ b/src/base/indexing.rs
@@ -528,9 +528,9 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     pub unsafe fn get_unchecked<'a, I>(&'a self, index: I) -> I::Output
     where
         I: MatrixIndex<'a, T, R, C, S>,
-    {
+    { unsafe {
         index.get_unchecked(self)
-    }
+    }}
 
     /// Returns a mutable view of the data at the given index, without doing
     /// any bounds checking.
@@ -543,9 +543,9 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
     where
         S: RawStorageMut<T, R, C>,
         I: MatrixIndexMut<'a, T, R, C, S>,
-    {
+    { unsafe {
         index.get_unchecked_mut(self)
-    }
+    }}
 }
 
 // EXTRACT A SINGLE ELEMENT BY 1D LINEAR ADDRESS
@@ -567,12 +567,12 @@ where
 
     #[doc(hidden)]
     #[inline(always)]
-    unsafe fn get_unchecked(self, matrix: &'a Matrix<T, R, C, S>) -> Self::Output {
+    unsafe fn get_unchecked(self, matrix: &'a Matrix<T, R, C, S>) -> Self::Output { unsafe {
         let nrows = matrix.shape().0;
         let row = self % nrows;
         let col = self / nrows;
         matrix.data.get_unchecked(row, col)
-    }
+    }}
 }
 
 impl<'a, T, R, C, S> MatrixIndexMut<'a, T, R, C, S> for usize
@@ -589,12 +589,12 @@ where
     unsafe fn get_unchecked_mut(self, matrix: &'a mut Matrix<T, R, C, S>) -> Self::OutputMut
     where
         S: RawStorageMut<T, R, C>,
-    {
+    { unsafe {
         let nrows = matrix.shape().0;
         let row = self % nrows;
         let col = self / nrows;
         matrix.data.get_unchecked_mut(row, col)
-    }
+    }}
 }
 
 // EXTRACT A SINGLE ELEMENT BY 2D COORDINATES
@@ -617,10 +617,10 @@ where
 
     #[doc(hidden)]
     #[inline(always)]
-    unsafe fn get_unchecked(self, matrix: &'a Matrix<T, R, C, S>) -> Self::Output {
+    unsafe fn get_unchecked(self, matrix: &'a Matrix<T, R, C, S>) -> Self::Output { unsafe {
         let (row, col) = self;
         matrix.data.get_unchecked(row, col)
-    }
+    }}
 }
 
 impl<'a, T: 'a, R, C, S> MatrixIndexMut<'a, T, R, C, S> for (usize, usize)
@@ -636,10 +636,10 @@ where
     unsafe fn get_unchecked_mut(self, matrix: &'a mut Matrix<T, R, C, S>) -> Self::OutputMut
     where
         S: RawStorageMut<T, R, C>,
-    {
+    { unsafe {
         let (row, col) = self;
         matrix.data.get_unchecked_mut(row, col)
-    }
+    }}
 }
 
 macro_rules! impl_index_pair {
@@ -682,7 +682,7 @@ macro_rules! impl_index_pair {
 
             #[doc(hidden)]
             #[inline(always)]
-            unsafe fn get_unchecked(self, matrix: &'a Matrix<T, $R, $C, S>) -> Self::Output {
+            unsafe fn get_unchecked(self, matrix: &'a Matrix<T, $R, $C, S>) -> Self::Output { unsafe {
                 use crate::base::ViewStorage;
 
                 let (rows, cols) = self;
@@ -694,7 +694,7 @@ macro_rules! impl_index_pair {
                         (rows.length(nrows), cols.length(ncols)));
 
                 Matrix::from_data_statically_unchecked(data)
-            }
+            }}
         }
 
         impl<'a, T, $R, $C, S, $($RTyP : $RTyPB,)* $($CTyP : $CTyPB),*> MatrixIndexMut<'a, T, $R, $C, S> for ($RIdx, $CIdx)
@@ -710,7 +710,7 @@ macro_rules! impl_index_pair {
 
             #[doc(hidden)]
             #[inline(always)]
-            unsafe fn get_unchecked_mut(self, matrix: &'a mut Matrix<T, $R, $C, S>) -> Self::OutputMut {
+            unsafe fn get_unchecked_mut(self, matrix: &'a mut Matrix<T, $R, $C, S>) -> Self::OutputMut { unsafe {
                 use crate::base::ViewStorageMut;
 
                 let (rows, cols) = self;
@@ -722,7 +722,7 @@ macro_rules! impl_index_pair {
                         (rows.length(nrows), cols.length(ncols)));
 
                 Matrix::from_data_statically_unchecked(data)
-            }
+            }}
         }
     }
 }

--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -393,11 +393,11 @@ where
     /// The user must make sure that every single entry of the buffer has been initialized,
     /// or Undefined Behavior will immediately occur.
     #[inline(always)]
-    pub unsafe fn assume_init(self) -> OMatrix<T, R, C> {
+    pub unsafe fn assume_init(self) -> OMatrix<T, R, C> { unsafe {
         OMatrix::from_data(<DefaultAllocator as Allocator<R, C>>::assume_init(
             self.data,
         ))
-    }
+    }}
 }
 
 impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
@@ -1202,11 +1202,11 @@ impl<T, R: Dim, C: Dim, S: RawStorageMut<T, R, C>> Matrix<T, R, C, S> {
     ///
     /// Both `(r, c)` must have `r < nrows(), c < ncols()`.
     #[inline]
-    pub unsafe fn swap_unchecked(&mut self, row_cols1: (usize, usize), row_cols2: (usize, usize)) {
+    pub unsafe fn swap_unchecked(&mut self, row_cols1: (usize, usize), row_cols2: (usize, usize)) { unsafe {
         debug_assert!(row_cols1.0 < self.nrows() && row_cols1.1 < self.ncols());
         debug_assert!(row_cols2.0 < self.nrows() && row_cols2.1 < self.ncols());
         self.data.swap_unchecked(row_cols1, row_cols2)
-    }
+    }}
 
     /// Swaps two entries.
     #[inline]
@@ -1311,11 +1311,11 @@ impl<T, D: Dim, S: RawStorage<T, D>> Vector<T, D, S> {
     /// `i` must be less than `D`.
     #[inline]
     #[must_use]
-    pub unsafe fn vget_unchecked(&self, i: usize) -> &T {
+    pub unsafe fn vget_unchecked(&self, i: usize) -> &T { unsafe {
         debug_assert!(i < self.nrows(), "Vector index out of bounds.");
         let i = i * self.strides().0;
         self.data.get_unchecked_linear(i)
-    }
+    }}
 }
 
 impl<T, D: Dim, S: RawStorageMut<T, D>> Vector<T, D, S> {
@@ -1324,11 +1324,11 @@ impl<T, D: Dim, S: RawStorageMut<T, D>> Vector<T, D, S> {
     /// `i` must be less than `D`.
     #[inline]
     #[must_use]
-    pub unsafe fn vget_unchecked_mut(&mut self, i: usize) -> &mut T {
+    pub unsafe fn vget_unchecked_mut(&mut self, i: usize) -> &mut T { unsafe {
         debug_assert!(i < self.nrows(), "Vector index out of bounds.");
         let i = i * self.strides().0;
         self.data.get_unchecked_linear_mut(i)
-    }
+    }}
 }
 
 impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> Matrix<T, R, C, S> {
@@ -1902,7 +1902,7 @@ where
 }
 
 macro_rules! impl_fmt {
-    ($trait: path, $fmt_str_without_precision: expr, $fmt_str_with_precision: expr) => {
+    ($trait: path, $fmt_str_without_precision: expr_2021, $fmt_str_with_precision: expr_2021) => {
         impl<T, R: Dim, C: Dim, S> $trait for Matrix<T, R, C, S>
         where
             T: Scalar + $trait,

--- a/src/base/matrix_simba.rs
+++ b/src/base/matrix_simba.rs
@@ -32,9 +32,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         self.map(|e| e.extract_unchecked(i))
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -44,11 +44,11 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.zip_apply(&val, |a, b| {
             a.replace_unchecked(i, b);
         })
-    }
+    }}
 
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {
         self.zip_map(&other, |a, b| a.select(cond, b))

--- a/src/base/matrix_view.rs
+++ b/src/base/matrix_view.rs
@@ -12,7 +12,7 @@ use crate::constraint::{DimEq, ShapeConstraint};
 use crate::ReshapableStorage;
 
 macro_rules! view_storage_impl (
-    ($doc: expr; $Storage: ident as $SRef: ty; $legacy_name:ident => $T: ident.$get_addr: ident ($Ptr: ty as $Ref: ty)) => {
+    ($doc: expr_2021; $Storage: ident as $SRef: ty; $legacy_name:ident => $T: ident.$get_addr: ident ($Ptr: ty as $Ref: ty)) => {
         #[doc = $doc]
         #[derive(Debug)]
         pub struct $T<'a, T, R: Dim, C: Dim, RStride: Dim, CStride: Dim>  {
@@ -77,11 +77,11 @@ macro_rules! view_storage_impl (
                 -> $T<'a, T, R, C, S::RStride, S::CStride>
                 where RStor: Dim,
                       CStor: Dim,
-                      S:     $Storage<T, RStor, CStor> {
+                      S:     $Storage<T, RStor, CStor> { unsafe {
 
                 let strides = storage.strides();
                 $T::new_with_strides_unchecked(storage, start, shape, strides)
-            }
+            }}
 
             /// Create a new matrix view without bounds checking.
             ///
@@ -98,9 +98,9 @@ macro_rules! view_storage_impl (
                       CStor: Dim,
                       S: $Storage<T, RStor, CStor>,
                       RStride: Dim,
-                      CStride: Dim {
+                      CStride: Dim { unsafe {
                 $T::from_raw_parts(storage.$get_addr(start.0, start.1), shape, strides)
-            }
+            }}
         }
 
         impl <'a, T, R: Dim, C: Dim, RStride: Dim, CStride: Dim>
@@ -202,7 +202,7 @@ macro_rules! storage_impl(
             }
 
             #[inline]
-            unsafe fn as_slice_unchecked(&self) -> &[T] {
+            unsafe fn as_slice_unchecked(&self) -> &[T] { unsafe {
                 let (nrows, ncols) = self.shape();
                 if nrows.value() != 0 && ncols.value() != 0 {
                     let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
@@ -211,7 +211,7 @@ macro_rules! storage_impl(
                 else {
                     slice::from_raw_parts(self.ptr, 0)
                 }
-            }
+            }}
         }
 
         unsafe impl<'a, T: Scalar, R: Dim, C: Dim, RStride: Dim, CStride: Dim> Storage<T, R, C>
@@ -249,7 +249,7 @@ unsafe impl<T, R: Dim, C: Dim, RStride: Dim, CStride: Dim> RawStorageMut<T, R, C
     }
 
     #[inline]
-    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] {
+    unsafe fn as_mut_slice_unchecked(&mut self) -> &mut [T] { unsafe {
         let (nrows, ncols) = self.shape();
         if nrows.value() != 0 && ncols.value() != 0 {
             let sz = self.linear_index(nrows.value() - 1, ncols.value() - 1);
@@ -257,7 +257,7 @@ unsafe impl<T, R: Dim, C: Dim, RStride: Dim, CStride: Dim> RawStorageMut<T, R, C
         } else {
             slice::from_raw_parts_mut(self.ptr, 0)
         }
-    }
+    }}
 }
 
 unsafe impl<T, R: Dim, CStride: Dim> IsContiguous for ViewStorage<'_, T, R, U1, U1, CStride> {}
@@ -297,7 +297,7 @@ impl<T, R: Dim, C: Dim, S: RawStorage<T, R, C>> Matrix<T, R, C, S> {
 }
 
 macro_rules! matrix_view_impl (
-    ($me: ident: $Me: ty, $MatrixView: ident, $ViewStorage: ident, $Storage: ident.$get_addr: ident (), $data: expr;
+    ($me: ident: $Me: ty, $MatrixView: ident, $ViewStorage: ident, $Storage: ident.$get_addr: ident (), $data: expr_2021;
      $row: ident,
      $row_part: ident,
      $rows: ident,

--- a/src/base/ops.rs
+++ b/src/base/ops.rs
@@ -398,11 +398,11 @@ where
     /// iter::empty::<DMatrix<f64>>().sum::<DMatrix<f64>>(); // panics!
     /// ```
     fn sum<I: Iterator<Item = OMatrix<T, Dyn, C>>>(mut iter: I) -> OMatrix<T, Dyn, C> {
-        if let Some(first) = iter.next() {
+        match iter.next() { Some(first) => {
             iter.fold(first, |acc, x| acc + x)
-        } else {
+        } _ => {
             panic!("Cannot compute `sum` of empty iterator.")
-        }
+        }}
     }
 }
 

--- a/src/base/storage.rs
+++ b/src/base/storage.rs
@@ -99,18 +99,18 @@ pub unsafe trait RawStorage<T, R: Dim, C: Dim = U1>: Sized {
     /// # Safety
     /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
-    unsafe fn get_unchecked_linear(&self, i: usize) -> &T {
+    unsafe fn get_unchecked_linear(&self, i: usize) -> &T { unsafe {
         &*self.get_address_unchecked_linear(i)
-    }
+    }}
 
     /// Retrieves a reference to the i-th element without bound-checking.
     ///
     /// # Safety
     /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
-    unsafe fn get_unchecked(&self, irow: usize, icol: usize) -> &T {
+    unsafe fn get_unchecked(&self, irow: usize, icol: usize) -> &T { unsafe {
         self.get_unchecked_linear(self.linear_index(irow, icol))
-    }
+    }}
 
     /// Indicates whether this data buffer stores its elements contiguously.
     ///
@@ -192,18 +192,18 @@ pub unsafe trait RawStorageMut<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     ///
     /// # Safety
     /// If the index is out of bounds, the method will cause undefined behavior.
-    unsafe fn get_unchecked_linear_mut(&mut self, i: usize) -> &mut T {
+    unsafe fn get_unchecked_linear_mut(&mut self, i: usize) -> &mut T { unsafe {
         &mut *self.get_address_unchecked_linear_mut(i)
-    }
+    }}
 
     /// Retrieves a mutable reference to the element at `(irow, icol)` without bound-checking.
     ///
     /// # Safety
     /// If the index is out of bounds, the method will cause undefined behavior.
     #[inline]
-    unsafe fn get_unchecked_mut(&mut self, irow: usize, icol: usize) -> &mut T {
+    unsafe fn get_unchecked_mut(&mut self, irow: usize, icol: usize) -> &mut T { unsafe {
         &mut *self.get_address_unchecked_mut(irow, icol)
-    }
+    }}
 
     /// Swaps two elements using their linear index without bound-checking.
     ///
@@ -217,7 +217,7 @@ pub unsafe trait RawStorageMut<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
     /// moves as a consequence of invoking either of these methods then this default
     /// trait implementation may be invalid or unsound and should be overridden.
     #[inline]
-    unsafe fn swap_unchecked_linear(&mut self, i1: usize, i2: usize) {
+    unsafe fn swap_unchecked_linear(&mut self, i1: usize, i2: usize) { unsafe {
         // we can't just use the pointers returned from `get_address_unchecked_linear_mut` because calling a
         // method taking self mutably invalidates any existing (mutable) pointers. since `get_address_unchecked_linear_mut` can
         // also be overridden by a custom implementation, we can't just use `wrapping_add` assuming that's what the method does.
@@ -233,19 +233,19 @@ pub unsafe trait RawStorageMut<T, R: Dim, C: Dim = U1>: RawStorage<T, R, C> {
         let b = base.offset(offset2);
 
         ptr::swap(a, b);
-    }
+    }}
 
     /// Swaps two elements without bound-checking.
     ///
     /// # Safety
     /// If the indices are out of bounds, the method will cause undefined behavior.
     #[inline]
-    unsafe fn swap_unchecked(&mut self, row_col1: (usize, usize), row_col2: (usize, usize)) {
+    unsafe fn swap_unchecked(&mut self, row_col1: (usize, usize), row_col2: (usize, usize)) { unsafe {
         let lid1 = self.linear_index(row_col1.0, row_col1.1);
         let lid2 = self.linear_index(row_col2.0, row_col2.1);
 
         self.swap_unchecked_linear(lid1, lid2)
-    }
+    }}
 
     /// Retrieves the mutable data buffer as a contiguous slice.
     ///

--- a/src/base/swizzle.rs
+++ b/src/base/swizzle.rs
@@ -3,7 +3,7 @@ use crate::storage::RawStorage;
 use typenum::{self, Cmp, Greater};
 
 macro_rules! impl_swizzle {
-    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr),+] ),+ ;)* ) => {
+    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr_2021),+] ),+ ;)* ) => {
         $(
             $(
                 /// Builds a new vector from components of `self`.

--- a/src/base/uninit.rs
+++ b/src/base/uninit.rs
@@ -65,12 +65,12 @@ unsafe impl<T> InitStatus<T> for Uninit {
     }
 
     #[inline(always)]
-    unsafe fn assume_init_ref(t: &MaybeUninit<T>) -> &T {
+    unsafe fn assume_init_ref(t: &MaybeUninit<T>) -> &T { unsafe {
         &*t.as_ptr() // TODO: use t.assume_init_ref()
-    }
+    }}
 
     #[inline(always)]
-    unsafe fn assume_init_mut(t: &mut MaybeUninit<T>) -> &mut T {
+    unsafe fn assume_init_mut(t: &mut MaybeUninit<T>) -> &mut T { unsafe {
         &mut *t.as_mut_ptr() // TODO: use t.assume_init_mut()
-    }
+    }}
 }

--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -152,7 +152,7 @@ impl<T, R: Dim, C: Dim> VecStorage<T, R, C> {
     /// - If `sz` is smaller than the current size, additional elements are truncated but **not** dropped.
     ///   It is the responsibility of the caller of this method to drop these elements.
     #[inline]
-    pub unsafe fn resize(mut self, sz: usize) -> Vec<MaybeUninit<T>> {
+    pub unsafe fn resize(mut self, sz: usize) -> Vec<MaybeUninit<T>> { unsafe {
         let len = self.len();
 
         let new_data = if sz < len {
@@ -191,7 +191,7 @@ impl<T, R: Dim, C: Dim> VecStorage<T, R, C> {
         // been transferred to `new_data`.
         std::mem::forget(self);
         new_data
-    }
+    }}
 
     /// The number of elements on the underlying vector.
     #[inline]

--- a/src/geometry/dual_quaternion.rs
+++ b/src/geometry/dual_quaternion.rs
@@ -960,7 +960,7 @@ impl<T: RealField> Default for UnitDualQuaternion<T> {
 
 impl<T: RealField + fmt::Display> fmt::Display for UnitDualQuaternion<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(axis) = self.rotation().axis() {
+        match self.rotation().axis() { Some(axis) => {
             let axis = axis.into_inner();
             write!(
                 f,
@@ -971,14 +971,14 @@ impl<T: RealField + fmt::Display> fmt::Display for UnitDualQuaternion<T> {
                 axis[1],
                 axis[2]
             )
-        } else {
+        } _ => {
             write!(
                 f,
                 "UnitDualQuaternion translation: {} − angle: {} − axis: (undefined)",
                 self.translation().vector,
                 self.rotation().angle()
             )
-        }
+        }}
     }
 }
 

--- a/src/geometry/dual_quaternion_ops.rs
+++ b/src/geometry/dual_quaternion_ops.rs
@@ -139,7 +139,7 @@ macro_rules! dual_quaternion_op_impl(
      ($LhsRDim: ident, $LhsCDim: ident), ($RhsRDim: ident, $RhsCDim: ident)
      $(for $Storage: ident: $StoragesBound: ident $(<$($BoundParam: ty),*>)*),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty $(=> $VDimA: ty, $VDimB: ty)*;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField $(, $Storage: $StoragesBound $(<$($BoundParam),*>)*)*> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField, {
             type Output = $Result;
@@ -960,7 +960,7 @@ macro_rules! dual_quaternion_op_impl(
     ($OpAssign: ident, $op_assign: ident;
      ($LhsRDim: ident, $LhsCDim: ident), ($RhsRDim: ident, $RhsCDim: ident);
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty $(=> $VDimA: ty, $VDimB: ty)*;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField> $OpAssign<$Rhs> for $Lhs
             where T::Element: SimdRealField {
 

--- a/src/geometry/isometry_ops.rs
+++ b/src/geometry/isometry_ops.rs
@@ -68,7 +68,7 @@ use crate::geometry::{
 macro_rules! isometry_binop_impl(
     ($Op: ident, $op: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField, R, const D: usize> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField,
                   R: AbstractRotation<T, D>, {
@@ -85,10 +85,10 @@ macro_rules! isometry_binop_impl(
 macro_rules! isometry_binop_impl_all(
     ($Op: ident, $op: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
         isometry_binop_impl!(
             $Op, $op;
             $lhs: $Lhs, $rhs: $Rhs, Output = $Output;
@@ -114,8 +114,8 @@ macro_rules! isometry_binop_impl_all(
 macro_rules! isometry_binop_assign_impl_all(
     ($OpAssign: ident, $op_assign: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty;
-     [val] => $action_val: expr;
-     [ref] => $action_ref: expr;) => {
+     [val] => $action_val: expr_2021;
+     [ref] => $action_ref: expr_2021;) => {
         impl<T: SimdRealField, R, const D: usize> $OpAssign<$Rhs> for $Lhs
             where T::Element: SimdRealField,
                   R: AbstractRotation<T, D> {
@@ -314,7 +314,7 @@ macro_rules! isometry_from_composition_impl(
     ($Op: ident, $op: ident;
      $($Dims: ident),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField $(, const $Dims: usize)*> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField {
             type Output = $Output;
@@ -331,10 +331,10 @@ macro_rules! isometry_from_composition_impl_all(
     ($Op: ident, $op: ident;
      $($Dims: ident),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
 
         isometry_from_composition_impl!(
             $Op, $op;

--- a/src/geometry/isometry_simba.rs
+++ b/src/geometry/isometry_simba.rs
@@ -25,12 +25,12 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         Isometry::from_parts(
             self.translation.extract_unchecked(i),
             self.rotation.extract_unchecked(i),
         )
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -39,10 +39,10 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.translation.replace_unchecked(i, val.translation);
         self.rotation.replace_unchecked(i, val.rotation);
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/op_macros.rs
+++ b/src/geometry/op_macros.rs
@@ -17,7 +17,7 @@ macro_rules! md_impl(
      // Argument identifiers and types + output.
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
      // Operator actual implementation.
-     $action: expr;
+     $action: expr_2021;
      // Lifetime.
      $($lives: tt),*) => {
         impl<$($lives ,)* T $(, $DimsDecl)* $(, const $D: usize)*> $Op<$Rhs> for $Lhs
@@ -51,10 +51,10 @@ macro_rules! md_impl_all(
      // Argument identifiers and types + output.
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
      // Operators actual implementations.
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
 
         md_impl!(
             $Op, $op $(where T: $($ScalarBounds),*)*;
@@ -110,7 +110,7 @@ macro_rules! md_assign_impl(
      // Argument identifiers and types.
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty;
      // Actual implementation and lifetimes.
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T $(, $DimsDecl)* $(, const $D: usize)*> $Op<$Rhs> for $Lhs
             where T: Scalar + Zero + One + ClosedAddAssign + ClosedMulAssign $($(+ $ScalarBounds)*)*,
                   $($(T::Element: $ElementBounds,)*)*
@@ -141,8 +141,8 @@ macro_rules! md_assign_impl_all(
      // Argument identifiers and types.
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty;
      // Actual implementation and lifetimes.
-     [val] => $action_val: expr;
-     [ref] => $action_ref: expr;) => {
+     [val] => $action_val: expr_2021;
+     [ref] => $action_ref: expr_2021;) => {
         md_assign_impl!(
             $Op, $op $(where T: $($ScalarBounds),*)* $(for T::Element: $($ElementBounds),*)*;
             ($R1, $C1),($R2, $C2)
@@ -175,7 +175,7 @@ macro_rules! add_sub_impl(
      // Where clause.
      where $($ConstraintType: ty: $ConstraintBound: ident$(<$($ConstraintBoundParams: ty $( = $EqBound: ty )*),*>)*),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T $(, $DimsDecl)* $(, const $D: usize)*> $Op<$Rhs> for $Lhs
             where T: Scalar + $bound,
                   ShapeConstraint: SameNumberOfRows<$R1, $R2 $(, Representative = $RRes)*> +
@@ -197,7 +197,7 @@ macro_rules! add_sub_assign_impl(
     ($Op: ident, $op: ident, $bound: ident;
     $(const $D: ident),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T $(, const $D: usize),*> $Op<$Rhs> for $Lhs
             where T: Scalar + $bound {
             #[inline]

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -315,9 +315,9 @@ where
     /// `i` must be less than `self.len()`.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked(&self, i: usize) -> &T {
+    pub unsafe fn get_unchecked(&self, i: usize) -> &T { unsafe {
         self.coords.vget_unchecked(i)
-    }
+    }}
 
     /// Mutably iterates through this point coordinates.
     ///
@@ -346,9 +346,9 @@ where
     /// `i` must be less than `self.len()`.
     #[inline]
     #[must_use]
-    pub unsafe fn get_unchecked_mut(&mut self, i: usize) -> &mut T {
+    pub unsafe fn get_unchecked_mut(&mut self, i: usize) -> &mut T { unsafe {
         self.coords.vget_unchecked_mut(i)
-    }
+    }}
 
     /// Swaps two entries without bound-checking.
     ///
@@ -356,9 +356,9 @@ where
     ///
     /// `i1` and `i2` must be less than `self.len()`.
     #[inline]
-    pub unsafe fn swap_unchecked(&mut self, i1: usize, i2: usize) {
+    pub unsafe fn swap_unchecked(&mut self, i1: usize, i2: usize) { unsafe {
         self.coords.swap_unchecked((i1, 0), (i2, 0))
-    }
+    }}
 }
 
 impl<T: Scalar + AbsDiffEq, D: DimName> AbsDiffEq for OPoint<T, D>

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -209,7 +209,7 @@ impl<T: Scalar> Point1<T> {
     }
 }
 macro_rules! componentwise_constructors_impl(
-    ($($doc: expr; $Point: ident, $Vector: ident, $($args: ident:$irow: expr),*);* $(;)*) => {$(
+    ($($doc: expr_2021; $Point: ident, $Vector: ident, $($args: ident:$irow: expr_2021),*);* $(;)*) => {$(
         impl<T: Scalar> $Point<T> {
             #[doc = "Initializes this point from its components."]
             #[doc = "# Example\n```"]

--- a/src/geometry/point_simba.rs
+++ b/src/geometry/point_simba.rs
@@ -23,9 +23,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         self.coords.extract_unchecked(i).into()
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -33,9 +33,9 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.coords.replace_unchecked(i, val.coords)
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -468,17 +468,17 @@ where
     where
         T: RealField,
     {
-        if let Some((q, n)) = Unit::try_new_and_get(self.clone(), T::zero()) {
-            if let Some(axis) = Unit::try_new(self.vector().clone_owned(), T::zero()) {
+        match Unit::try_new_and_get(self.clone(), T::zero()) { Some((q, n)) => {
+            match Unit::try_new(self.vector().clone_owned(), T::zero()) { Some(axis) => {
                 let angle = q.angle() / crate::convert(2.0f64);
 
                 (n, angle, Some(axis))
-            } else {
+            } _ => {
                 (n, T::zero(), None)
-            }
-        } else {
+            }}
+        } _ => {
             (T::zero(), T::zero(), None)
-        }
+        }}
     }
 
     /// Compute the natural logarithm of a quaternion.
@@ -1319,11 +1319,11 @@ where
     where
         T: RealField,
     {
-        if let Some(axis) = self.axis() {
+        match self.axis() { Some(axis) => {
             axis.into_inner() * self.angle()
-        } else {
+        } _ => {
             Vector3::zero()
-        }
+        }}
     }
 
     /// The rotation axis and angle in (0, pi] of this unit quaternion.
@@ -1380,11 +1380,11 @@ where
     where
         T: RealField,
     {
-        if let Some(v) = self.axis() {
+        match self.axis() { Some(v) => {
             Quaternion::from_imag(v.into_inner() * self.angle())
-        } else {
+        } _ => {
             Quaternion::zero()
-        }
+        }}
     }
 
     /// Raise the quaternion to a given floating power.
@@ -1409,11 +1409,11 @@ where
     where
         T: RealField,
     {
-        if let Some(v) = self.axis() {
+        match self.axis() { Some(v) => {
             Self::from_axis_angle(&v, self.angle() * n)
-        } else {
+        } _ => {
             Self::identity()
-        }
+        }}
     }
 
     /// Builds a rotation matrix from this unit quaternion.
@@ -1642,7 +1642,7 @@ impl<T: RealField> Default for UnitQuaternion<T> {
 
 impl<T: RealField + fmt::Display> fmt::Display for UnitQuaternion<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(axis) = self.axis() {
+        match self.axis() { Some(axis) => {
             let axis = axis.into_inner();
             write!(
                 f,
@@ -1652,13 +1652,13 @@ impl<T: RealField + fmt::Display> fmt::Display for UnitQuaternion<T> {
                 axis[1],
                 axis[2]
             )
-        } else {
+        } _ => {
             write!(
                 f,
                 "UnitQuaternion angle: {} − axis: (undefined)",
                 self.angle()
             )
-        }
+        }}
     }
 }
 

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -487,14 +487,14 @@ where
         SC: Storage<T, U3>,
     {
         // TODO: code duplication with Rotation.
-        if let (Some(na), Some(nb)) = (
+        match (
             Unit::try_new(a.clone_owned(), T::zero()),
             Unit::try_new(b.clone_owned(), T::zero()),
-        ) {
+        ) { (Some(na), Some(nb)) => {
             Self::scaled_rotation_between_axis(&na, &nb, s)
-        } else {
+        } _ => {
             Some(Self::identity())
-        }
+        }}
     }
 
     /// The unit quaternion needed to make `a` and `b` be collinear and point toward the same
@@ -551,7 +551,7 @@ where
         // TODO: code duplication with Rotation.
         let c = na.cross(nb);
 
-        if let Some(axis) = Unit::try_new(c, T::default_epsilon()) {
+        match Unit::try_new(c, T::default_epsilon()) { Some(axis) => {
             let cos = na.dot(nb);
 
             // The cosinus may be out of [-1, 1] because of inaccuracies.
@@ -562,7 +562,7 @@ where
             } else {
                 Some(Self::from_axis_angle(&axis, cos.acos() * s))
             }
-        } else if na.dot(nb) < T::zero() {
+        } _ => if na.dot(nb) < T::zero() {
             // PI
             //
             // The rotation axis is undefined but the angle not zero. This is not a
@@ -571,7 +571,7 @@ where
         } else {
             // Zero
             Some(Self::identity())
-        }
+        }}
     }
 
     /// Creates an unit quaternion that corresponds to the local frame of an observer standing at the

--- a/src/geometry/quaternion_ops.rs
+++ b/src/geometry/quaternion_ops.rs
@@ -84,7 +84,7 @@ macro_rules! quaternion_op_impl(
     ($Op: ident, $op: ident;
      $($Storage: ident: $StoragesBound: ident $(<$($BoundParam: ty),*>)*),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField $(, $Storage: $StoragesBound $(<$($BoundParam),*>)*)*> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField {
             type Output = $Result;
@@ -564,7 +564,7 @@ where
 macro_rules! quaternion_op_impl(
     ($OpAssign: ident, $op_assign: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty $(=> $VDimA: ty, $VDimB: ty)*;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField> $OpAssign<$Rhs> for $Lhs
             where T::Element: SimdRealField {
 

--- a/src/geometry/quaternion_simba.rs
+++ b/src/geometry/quaternion_simba.rs
@@ -23,9 +23,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         self.coords.extract_unchecked(i).into()
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -33,9 +33,9 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.coords.replace_unchecked(i, val.coords)
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {
@@ -62,9 +62,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         UnitQuaternion::new_unchecked(self.as_ref().extract_unchecked(i))
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -72,10 +72,10 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.as_mut_unchecked()
             .replace_unchecked(i, val.into_inner())
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/rotation_simba.rs
+++ b/src/geometry/rotation_simba.rs
@@ -24,9 +24,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         Rotation::from_matrix_unchecked(self.matrix().extract_unchecked(i))
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -34,10 +34,10 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.matrix_mut_unchecked()
             .replace_unchecked(i, val.into_inner())
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -685,14 +685,14 @@ where
     where
         T: RealField,
     {
-        if let Some(axis) = self.axis() {
+        match self.axis() { Some(axis) => {
             Self::from_axis_angle(&axis, self.angle() * n)
-        } else if self.matrix()[(0, 0)] < T::zero() {
+        } _ => if self.matrix()[(0, 0)] < T::zero() {
             let minus_id = SMatrix::<T, 3, 3>::from_diagonal_element(-T::one());
             Self::from_matrix_unchecked(minus_id)
         } else {
             Self::identity()
-        }
+        }}
     }
 
     /// Builds a rotation from a basis assumed to be orthonormal.
@@ -753,9 +753,9 @@ where
 
             let axisangle = axis / (denom.abs() + T::default_epsilon());
 
-            if let Some((axis, angle)) = Unit::try_new_and_get(axisangle, eps.clone()) {
+            match Unit::try_new_and_get(axisangle, eps.clone()) { Some((axis, angle)) => {
                 rot = Rotation3::from_axis_angle(&axis, angle) * rot;
-            } else {
+            } _ => {
                 // Check if stuck in a maximum w.r.t. the norm (m - rot).norm()
                 let mut perturbed = rot.clone();
                 let norm_squared = (m - &rot).norm_squared();
@@ -783,7 +783,7 @@ where
                 // If not, continue from perturbed rotation, but use a different axes for the next perturbation
                 perturbation_axes = UnitVector3::new_unchecked(perturbation_axes.yzx());
                 rot = perturbed;
-            }
+            }}
         }
 
         Self::from_matrix_unchecked(rot)
@@ -873,11 +873,11 @@ impl<T: SimdRealField> Rotation3<T> {
     where
         T: RealField,
     {
-        if let Some(axis) = self.axis() {
+        match self.axis() { Some(axis) => {
             axis.into_inner() * self.angle()
-        } else {
+        } _ => {
             Vector::zero()
-        }
+        }}
     }
 
     /// The rotation axis and angle in (0, pi] of this rotation matrix.

--- a/src/geometry/scale.rs
+++ b/src/geometry/scale.rs
@@ -262,12 +262,12 @@ impl<T: Scalar, const D: usize> Scale<T, D> {
     where
         T: ClosedDivAssign + One + Zero,
     {
-        if let Some(v) = self.try_inverse() {
+        match self.try_inverse() { Some(v) => {
             self.vector = v.vector;
             true
-        } else {
+        } _ => {
             false
-        }
+        }}
     }
 }
 

--- a/src/geometry/scale_construction.rs
+++ b/src/geometry/scale_construction.rs
@@ -92,7 +92,7 @@ where
  *
  */
 macro_rules! componentwise_constructors_impl(
-    ($($doc: expr; $D: expr, $($args: ident:$irow: expr),*);* $(;)*) => {$(
+    ($($doc: expr_2021; $D: expr_2021, $($args: ident:$irow: expr_2021),*);* $(;)*) => {$(
         impl<T> Scale<T, $D>
              {
             #[doc = "Initializes this Scale from its components."]

--- a/src/geometry/scale_coordinates.rs
+++ b/src/geometry/scale_coordinates.rs
@@ -12,7 +12,7 @@ use crate::geometry::Scale;
  */
 
 macro_rules! deref_impl(
-    ($D: expr, $Target: ident $(, $comps: ident)*) => {
+    ($D: expr_2021, $Target: ident $(, $comps: ident)*) => {
         impl<T: Scalar> Deref for Scale<T, $D> {
             type Target = $Target<T>;
 

--- a/src/geometry/scale_simba.rs
+++ b/src/geometry/scale_simba.rs
@@ -24,9 +24,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         self.vector.extract_unchecked(i).into()
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -34,9 +34,9 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.vector.replace_unchecked(i, val.vector)
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/similarity_ops.rs
+++ b/src/geometry/similarity_ops.rs
@@ -70,7 +70,7 @@ use crate::geometry::{
 macro_rules! similarity_binop_impl(
     ($Op: ident, $op: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField, R, const D: usize> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField,
                   R: AbstractRotation<T, D> {
@@ -87,10 +87,10 @@ macro_rules! similarity_binop_impl(
 macro_rules! similarity_binop_impl_all(
     ($Op: ident, $op: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
         similarity_binop_impl!(
             $Op, $op;
             $lhs: $Lhs, $rhs: $Rhs, Output = $Output;
@@ -116,8 +116,8 @@ macro_rules! similarity_binop_impl_all(
 macro_rules! similarity_binop_assign_impl_all(
     ($OpAssign: ident, $op_assign: ident;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty;
-     [val] => $action_val: expr;
-     [ref] => $action_ref: expr;) => {
+     [val] => $action_val: expr_2021;
+     [ref] => $action_ref: expr_2021;) => {
         impl<T: SimdRealField, R, const D: usize> $OpAssign<$Rhs> for $Lhs
             where T::Element: SimdRealField,
                   R: AbstractRotation<T, D>{
@@ -395,7 +395,7 @@ macro_rules! similarity_from_composition_impl(
     ($Op: ident, $op: ident;
      $($Dims: ident),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField $(, const $Dims: usize)*> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField {
             type Output = $Output;
@@ -412,10 +412,10 @@ macro_rules! similarity_from_composition_impl_all(
     ($Op: ident, $op: ident;
      $($Dims: ident),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Output: ty;
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
 
         similarity_from_composition_impl!(
             $Op, $op;

--- a/src/geometry/similarity_simba.rs
+++ b/src/geometry/similarity_simba.rs
@@ -24,12 +24,12 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         Similarity::from_isometry(
             self.isometry.extract_unchecked(i),
             self.scaling().extract_unchecked(i),
         )
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -40,12 +40,12 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         let mut s = self.scaling();
         s.replace_unchecked(i, val.scaling());
         self.set_scaling(s);
         self.isometry.replace_unchecked(i, val.isometry);
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/swizzle.rs
+++ b/src/geometry/swizzle.rs
@@ -3,7 +3,7 @@ use crate::geometry::{Point, Point2, Point3};
 use typenum::{self, Cmp, Greater};
 
 macro_rules! impl_swizzle {
-    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr),+] ),+ ;)* ) => {
+    ($( where $BaseDim: ident: $( $name: ident() -> $Result: ident[$($i: expr_2021),+] ),+ ;)* ) => {
         $(
             $(
                 /// Builds a new point from components of `self`.

--- a/src/geometry/transform_simba.rs
+++ b/src/geometry/transform_simba.rs
@@ -29,9 +29,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         Transform::from_matrix_unchecked(self.matrix().extract_unchecked(i))
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -39,10 +39,10 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.matrix_mut_unchecked()
             .replace_unchecked(i, val.into_inner())
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -98,7 +98,7 @@ where
  *
  */
 macro_rules! componentwise_constructors_impl(
-    ($($doc: expr; $D: expr, $($args: ident:$irow: expr),*);* $(;)*) => {$(
+    ($($doc: expr_2021; $D: expr_2021, $($args: ident:$irow: expr_2021),*);* $(;)*) => {$(
         impl<T> Translation<T, $D>
              {
             #[doc = "Initializes this translation from its components."]

--- a/src/geometry/translation_coordinates.rs
+++ b/src/geometry/translation_coordinates.rs
@@ -12,7 +12,7 @@ use crate::geometry::Translation;
  */
 
 macro_rules! deref_impl(
-    ($D: expr, $Target: ident $(, $comps: ident)*) => {
+    ($D: expr_2021, $Target: ident $(, $comps: ident)*) => {
         impl<T: Scalar> Deref for Translation<T, $D> {
             type Target = $Target<T>;
 

--- a/src/geometry/translation_simba.rs
+++ b/src/geometry/translation_simba.rs
@@ -24,9 +24,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         self.vector.extract_unchecked(i).into()
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -34,9 +34,9 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.vector.replace_unchecked(i, val.vector)
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -334,14 +334,14 @@ where
         SC: Storage<T, U2>,
     {
         // TODO: code duplication with Rotation.
-        if let (Some(na), Some(nb)) = (
+        match (
             Unit::try_new(a.clone_owned(), T::zero()),
             Unit::try_new(b.clone_owned(), T::zero()),
-        ) {
+        ) { (Some(na), Some(nb)) => {
             Self::scaled_rotation_between_axis(&na, &nb, s)
-        } else {
+        } _ => {
             Self::identity()
-        }
+        }}
     }
 
     /// The unit complex needed to make `a` and `b` be collinear and point toward the same

--- a/src/geometry/unit_complex_ops.rs
+++ b/src/geometry/unit_complex_ops.rs
@@ -145,7 +145,7 @@ macro_rules! complex_op_impl(
     ($Op: ident, $op: ident;
      $($Storage: ident: $StoragesBound: ident $(<$($BoundParam: ty),*>)*),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
-     $action: expr; $($lives: tt),*) => {
+     $action: expr_2021; $($lives: tt),*) => {
         impl<$($lives ,)* T: SimdRealField $(, $Storage: $StoragesBound $(<$($BoundParam),*>)*)*> $Op<$Rhs> for $Lhs
             where T::Element: SimdRealField {
             type Output = $Result;
@@ -162,10 +162,10 @@ macro_rules! complex_op_impl_all(
     ($Op: ident, $op: ident;
      $($Storage: ident: $StoragesBound: ident $(<$($BoundParam: ty),*>)*),*;
      $lhs: ident: $Lhs: ty, $rhs: ident: $Rhs: ty, Output = $Result: ty;
-     [val val] => $action_val_val: expr;
-     [ref val] => $action_ref_val: expr;
-     [val ref] => $action_val_ref: expr;
-     [ref ref] => $action_ref_ref: expr;) => {
+     [val val] => $action_val_val: expr_2021;
+     [ref val] => $action_ref_val: expr_2021;
+     [val ref] => $action_val_ref: expr_2021;
+     [ref ref] => $action_ref_ref: expr_2021;) => {
 
     complex_op_impl!($Op, $op;
                      $($Storage: $StoragesBound $(<$($BoundParam),*>)*),*;

--- a/src/geometry/unit_complex_simba.rs
+++ b/src/geometry/unit_complex_simba.rs
@@ -25,9 +25,9 @@ where
     }
 
     #[inline]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element { unsafe {
         Unit::new_unchecked(self.deref().extract_unchecked(i))
-    }
+    }}
 
     #[inline]
     fn replace(&mut self, i: usize, val: Self::Element) {
@@ -35,10 +35,10 @@ where
     }
 
     #[inline]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) { unsafe {
         self.as_mut_unchecked()
             .replace_unchecked(i, val.into_inner())
-    }
+    }}
 
     #[inline]
     fn select(self, cond: Self::SimdBool, other: Self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ an optimized set of tools for computer graphics and physics. Those features incl
     unused_mut,
     unused_parens,
     rust_2018_idioms,
-    rust_2018_compatibility,
+    rust_2024_compatibility,
     future_incompatible,
     missing_copy_implementations
 )]

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -486,7 +486,7 @@ fn compute_2x2_basis<T: ComplexField, S: Storage<T, U2, U2>>(
         return None;
     }
 
-    if let Some((eigval1, eigval2)) = compute_2x2_eigvals(m) {
+    match compute_2x2_eigvals(m) { Some((eigval1, eigval2)) => {
         let x1 = eigval1 - m[(1, 1)].clone();
         let x2 = eigval2 - m[(1, 1)].clone();
 
@@ -498,9 +498,9 @@ fn compute_2x2_basis<T: ComplexField, S: Storage<T, U2, U2>>(
         } else {
             Some(GivensRotation::new(x2, h10).0)
         }
-    } else {
+    } _ => {
         None
-    }
+    }}
 }
 
 impl<T: ComplexField, D: Dim, S: Storage<T, D, D>> SquareMatrix<T, D, S>

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -213,7 +213,7 @@ where
                         m12,
                     );
 
-                    if let Some((rot1, norm1)) = GivensRotation::cancel_y(&vec) {
+                    match GivensRotation::cancel_y(&vec) { Some((rot1, norm1)) => {
                         rot1.inverse()
                             .rotate_rows(&mut subm.fixed_columns_mut::<2>(0));
                         let rot1 = GivensRotation::new_unchecked(rot1.c(), T::from_real(rot1.s()));
@@ -259,9 +259,9 @@ where
 
                         vec.x = subm[(0, 1)].clone();
                         vec.y = subm[(0, 2)].clone();
-                    } else {
+                    } _ => {
                         break;
-                    }
+                    }}
                 }
             } else if subdim == 2 {
                 // Solve the remaining 2x2 subproblem.
@@ -476,7 +476,7 @@ where
         off_diagonal[i] = T::RealField::zero();
 
         for k in i..end {
-            if let Some((rot, norm)) = GivensRotation::cancel_x(&v) {
+            match GivensRotation::cancel_x(&v) { Some((rot, norm)) => {
                 let rot = GivensRotation::new_unchecked(rot.c(), T::from_real(rot.s()));
                 diagonal[k + 1] = norm;
 
@@ -494,9 +494,9 @@ where
                     v.y = diagonal[k + 2].clone();
                     off_diagonal[k + 1] *= rot.c();
                 }
-            } else {
+            } _ => {
                 break;
-            }
+            }}
         }
     }
 
@@ -513,7 +513,7 @@ where
         off_diagonal[i] = T::RealField::zero();
 
         for k in (0..i + 1).rev() {
-            if let Some((rot, norm)) = GivensRotation::cancel_y(&v) {
+            match GivensRotation::cancel_y(&v) { Some((rot, norm)) => {
                 let rot = GivensRotation::new_unchecked(rot.c(), T::from_real(rot.s()));
                 diagonal[k] = norm;
 
@@ -531,9 +531,9 @@ where
                     v.y = rot.s().real() * off_diagonal[k - 1].clone();
                     off_diagonal[k - 1] *= rot.c();
                 }
-            } else {
+            } _ => {
                 break;
-            }
+            }}
         }
     }
 

--- a/src/linalg/symmetric_eigen.rs
+++ b/src/linalg/symmetric_eigen.rs
@@ -151,7 +151,7 @@ where
                 for i in start..n {
                     let j = i + 1;
 
-                    if let Some((rot, norm)) = GivensRotation::cancel_y(&vec) {
+                    match GivensRotation::cancel_y(&vec) { Some((rot, norm)) => {
                         if i > start {
                             // Not the first iteration.
                             off_diag[i - 1] = norm;
@@ -181,9 +181,9 @@ where
                             let rot = GivensRotation::new_unchecked(rot.c(), T::from_real(rot.s()));
                             rot.inverse().rotate_rows(&mut q.fixed_columns_mut::<2>(i));
                         }
-                    } else {
+                    } _ => {
                         break;
-                    }
+                    }}
                 }
 
                 if off_diag[m].clone().norm1()

--- a/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions.stderr
@@ -18,15 +18,3 @@ error[E0282]: type annotations needed
    | |____________________^ cannot infer type
    |
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, Const<3>, _, _>` in the current scope
-  --> tests/macros/trybuild/stack_incompatible_block_dimensions.rs:11:5
-   |
-11 |       stack![a11, a12;
-   |  _____^
-12 | |            a21, a22];
-   | |____________________^ method not found in `Matrix<_, Const<3>, _, _>`
-   |
-   = note: the method was found for
-           - `Matrix<T, R, C, S>`
-   = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
+++ b/tests/macros/trybuild/stack_incompatible_block_dimensions2.stderr
@@ -18,15 +18,3 @@ error[E0282]: type annotations needed
    | |____________________^ cannot infer type
    |
    = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0599]: no method named `generic_view_mut` found for struct `Matrix<_, _, Const<4>, _>` in the current scope
-  --> tests/macros/trybuild/stack_incompatible_block_dimensions2.rs:12:5
-   |
-12 |       stack![a11, a12;
-   |  _____^
-13 | |            a21, a22];
-   | |____________________^ method not found in `Matrix<_, _, Const<4>, _>`
-   |
-   = note: the method was found for
-           - `Matrix<T, R, C, S>`
-   = note: this error originates in the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This patch moves all crates in the repo to rust 2024 edition.

## Benchmarks
Consistent improvement in large matrices especially asymmetric ones. I also saw a consistent improvement in 4x4.

PS. Sorry for the big PR