### PR TITLE
Fixes the Schur decomposition for a zero matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Moved to Rust 2024 edition.
 - Several methods are now `const` whenever possible. See details in [#1522](https://github.com/dimforge/nalgebra/pull/1522).
 
+### Fixed
+
+- Fix infinite loop when attempting to take the Schur decomposition of a 0 matrix.
+
 ## [0.33.2] (29 October 2024)
 
 ### Added

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use approx::AbsDiffEq;
 use num_complex::Complex as NumComplex;
+use num_traits::identities::Zero;
 use simba::scalar::{ComplexField, RealField};
 use std::cmp;
 
@@ -110,7 +111,12 @@ where
         }
 
         let amax_m = m.camax();
-        m.unscale_mut(amax_m.clone());
+        // if amax_m == 0 (i.e. the matrix is the zero matrix),
+        // then the unscale_mut call will turn the entire matrix into NaNs
+        // see https://github.com/dimforge/nalgebra/issues/1291
+        if !amax_m.is_zero() {
+            m.unscale_mut(amax_m.clone());
+        }
 
         let hess = Hessenberg::new_with_workspace(m, work);
         let mut q;

--- a/tests/linalg/schur.rs
+++ b/tests/linalg/schur.rs
@@ -1,4 +1,4 @@
-use na::{DMatrix, Matrix3, Matrix4};
+use na::{DMatrix, Matrix3, Matrix4, Schur};
 
 #[test]
 #[rustfmt::skip]
@@ -128,4 +128,15 @@ fn schur_singular() {
 
     let (vecs, vals) = m.clone().schur().unpack();
     assert!(relative_eq!(&vecs * vals * vecs.transpose(), m, epsilon = 1.0e-7))
+}
+
+// Regression test for issue #1291
+// where Schur hangs on a zero matrix due to a bad 0/0
+#[test]
+#[rustfmt::skip]
+fn schur_zero() {
+    // use max_niter as this hangs if the workaround isn't triggered
+    let (q, t) = Schur::try_new(Matrix3::<f64>::zeros(), f64::EPSILON, 128).unwrap().unpack();
+    assert!(q == Matrix3::<f64>::identity());
+    assert!(t == Matrix3::<f64>::zeros())
 }

--- a/tests/linalg/schur.rs
+++ b/tests/linalg/schur.rs
@@ -4,8 +4,8 @@ use na::{DMatrix, Matrix3, Matrix4, Schur};
 #[rustfmt::skip]
 fn schur_simpl_mat3() {
     let m = Matrix3::new(-2.0, -4.0, 2.0,
-                                   -2.0,  1.0, 2.0,
-                                   4.0,  2.0, 5.0);
+                         -2.0,  1.0, 2.0,
+                         4.0,  2.0, 5.0);
 
     let schur = m.schur();
     let (vecs, vals) = schur.unpack();
@@ -133,10 +133,11 @@ fn schur_singular() {
 // Regression test for issue #1291
 // where Schur hangs on a zero matrix due to a bad 0/0
 #[test]
-#[rustfmt::skip]
 fn schur_zero() {
     // use max_niter as this hangs if the workaround isn't triggered
-    let (q, t) = Schur::try_new(Matrix3::<f64>::zeros(), f64::EPSILON, 128).unwrap().unpack();
+    let (q, t) = Schur::try_new(Matrix3::<f64>::zeros(), f64::EPSILON, 128)
+        .unwrap()
+        .unpack();
     assert!(q == Matrix3::<f64>::identity());
     assert!(t == Matrix3::<f64>::zeros())
 }


### PR DESCRIPTION
This PR fixes #1291, by adding a check to avoid a 0/0 division in `Schur.do_decompose()` which was causing the decomposition to hang. The decomposition now works correctly for zero matrices (giving the identity for $Q$ and the zero matrix for $T$).