### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] (?)
+## [0.34.0] (31 July 2025)
 
 ### Added
 
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Bumped MSRV to 1.87.0.
+- Updated rand dependency to 0.9.0.
 - Renamed associated const `DimName::USIZE` to `DimName::DIM`.
 - Moved to Rust 2024 edition.
 - Several methods are now `const` whenever possible. See details in [#1522](https://github.com/dimforge/nalgebra/pull/1522).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra"
-version = "0.33.2"
+version = "0.34.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ slow-tests = []
 rkyv-safe-deser = ["rkyv-serialize", "rkyv/validation"]
 
 [dependencies]
-nalgebra-macros = { version = "0.2.2", path = "nalgebra-macros", optional = true }
+nalgebra-macros = { version = "0.3.0", path = "nalgebra-macros", optional = true }
 typenum = "1.12"
 rand-package = { package = "rand", version = "0.9", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/examples/cargo/Cargo.toml
+++ b/examples/cargo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["You"]
 
 [dependencies]
-nalgebra = "0.33.0"
+nalgebra = "0.34.0"
 
 [[bin]]
 name = "example"

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-glm"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["sebcrozet <developer@crozet.re>"]
 
 description = "A computer-graphics oriented API for nalgebra, inspired by the C++ GLM library."

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -35,4 +35,4 @@ convert-glam018 = ["nalgebra/glam018"]
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 simba = { version = "0.9", default-features = false }
-nalgebra = { path = "..", version = "0.33", default-features = false }
+nalgebra = { path = "..", version = "0.34", default-features = false }

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -29,7 +29,7 @@ accelerate = ["lapack-src/accelerate"]
 intel-mkl = ["lapack-src/intel-mkl"]
 
 [dependencies]
-nalgebra = { version = "0.33", path = ".." }
+nalgebra = { version = "0.34", path = ".." }
 num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }
 simba = "0.9"
@@ -39,7 +39,7 @@ lapack-src = { version = "0.8", default-features = false }
 # clippy = "*"
 
 [dev-dependencies]
-nalgebra = { version = "0.33", features = ["arbitrary", "rand"], path = ".." }
+nalgebra = { version = "0.34", features = ["arbitrary", "rand"], path = ".." }
 proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = "1"
 approx = "0.5"

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-lapack"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>"]
 
 description = "Matrix decompositions using nalgebra matrices and Lapack bindings."

--- a/nalgebra-macros/Cargo.toml
+++ b/nalgebra-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-macros"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
 edition = "2024"
 description = "Procedural macros for nalgebra"

--- a/nalgebra-macros/Cargo.toml
+++ b/nalgebra-macros/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-nalgebra = { version = "0.33", path = ".." }
+nalgebra = { version = "0.34", path = ".." }

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -24,7 +24,7 @@ io = ["pest", "pest_derive"]
 slow-tests = []
 
 [dependencies]
-nalgebra = { version = "0.33", path = "../" }
+nalgebra = { version = "0.34", path = "../" }
 num-traits = { version = "0.2", default-features = false }
 proptest = { version = "1.0", optional = true }
 matrixcompare-core = { version = "0.1.0", optional = true }
@@ -35,7 +35,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 [dev-dependencies]
 itertools = "0.13"
 matrixcompare = { version = "0.3.0", features = ["proptest-support"] }
-nalgebra = { version = "0.33", path = "../", features = ["compare"] }
+nalgebra = { version = "0.34", path = "../", features = ["compare"] }
 tempfile = "3.3"
 serde_json = "1.0"
 

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-sparse"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Andreas Longva", "Sébastien Crozet <developer@crozet.re>"]
 edition = "2024"
 description = "Sparse matrix computation based on nalgebra."


### PR DESCRIPTION
## [0.34.0] (31 July 2025)

### Added

- Add the `convert-glam030` feature to enable conversion from/to types from `glam` v0.30.
- Add the `defmt` cargo feature that enables derives of `defmt::Format` for all no-std types.

### Changed

- Bumped MSRV to 1.87.0.
- Updated rand dependency to 0.9.0.
- Renamed associated const `DimName::USIZE` to `DimName::DIM`.
- Moved to Rust 2024 edition.
- Several methods are now `const` whenever possible. See details in [#1522](https://github.com/dimforge/nalgebra/pull/1522).
- Features for conversion from/to types from `glam` (such as `convert-glam029`) no longer enable default features for
  `glam`, allowing use in `no_std` environments.

### Fixed

- Fix infinite loop when attempting to take the Schur decomposition of a 0 matrix.
