### PR TITLE
test: fix flaky rotation_between_is_identity

### DIFF
--- a/tests/geometry/rotation.rs
+++ b/tests/geometry/rotation.rs
@@ -206,7 +206,7 @@ mod proptest_tests {
             prop_assert!(relative_eq!(v2.angle(&vv2), 0.0, epsilon = 1.0e-7));
             prop_assert!(relative_eq!(v3.angle(&vv3), 0.0, epsilon = 1.0e-7));
             prop_assert!(relative_eq!(Rotation2::rotation_between(&v2, &vv2), Rotation2::identity()));
-            prop_assert_eq!(Rotation3::rotation_between(&v3, &vv3).unwrap(), Rotation3::identity());
+            prop_assert!(relative_eq!(Rotation3::rotation_between(&v3, &vv3).unwrap(), Rotation3::identity(), epsilon = 1.0e-7));
         }
 
         #[test]


### PR DESCRIPTION
This fixes following test failure:

	---- geometry::rotation::proptest_tests::rotation_between_is_identity stdout ----
	proptest: Saving this and future failures in /home/im/projects/patches/nalgebra/proptest-regressions/geometry/rotation.txt
	proptest: If this test was run on a CI system, you may wish to add the following line to your copy of the file. (You may need to create it.)
	cc 3f8e4df3b22ad80e431c610aec6ed6368da0198877fc96a07dd00978cfce619a

	thread 'geometry::rotation::proptest_tests::rotation_between_is_identity' panicked at tests/geometry/rotation.rs:99:5:
	Test failed: assertion failed: `(left == right)`
	  left: `[[1.0, 8.23149217580028e-11, 1.6462984785248345e-10], [-8.231492522718508e-11, 0.9999999999999998, 2.1072620414097273e-8], [-1.6462984611789232e-10, -2.1072620414110825e-8, 0.9999999999999998]]`,
	 right: `[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]` at tests/geometry/rotation.rs:209.
	minimal failing input: v2 = [
		[
			0.0,
			0.0,
		],
	], v3 = [
		[
			0.909512349774636,
			59.888745019601366,
			-71.4865423250859,
		],
	]
		successes: 22
		local rejects: 0
		global rejects: 0