### PR TITLE
Fix linalg bench warnings

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -64,7 +64,7 @@ jobs:
           override: true
       - uses: actions/checkout@v4
       - name: check
-        run: cargo check --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
+        run: cargo check --all-targets --features arbitrary,rand,serde-serialize,sparse,debug,io,compare,libm,proptest-support,slow-tests,rkyv-safe-deser,rayon;
   test-nalgebra:
     runs-on: ubuntu-latest
     #    env:

--- a/benches/linalg/bidiagonal.rs
+++ b/benches/linalg/bidiagonal.rs
@@ -32,13 +32,6 @@ fn bidiagonalize_500x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn bidiagonalize_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("bidiagonalize_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(Bidiagonal::new(m.clone())))
-    });
-}
-
 // With unpack.
 fn bidiagonalize_unpack_100x100(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(100, 100);
@@ -70,25 +63,13 @@ fn bidiagonalize_unpack_500x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn bidiagonalize_unpack_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("bidiagonalize_unpack_500x500", move |bh| {
-        bh.iter(|| {
-            let bidiag = Bidiagonal::new(m.clone());
-            let _ = bidiag.unpack();
-        })
-    });
-}
-
 criterion_group!(
     bidiagonal,
     bidiagonalize_100x100,
     bidiagonalize_100x500,
     bidiagonalize_4x4,
     bidiagonalize_500x100,
-    //    bidiagonalize_500x500, // too long
     bidiagonalize_unpack_100x100,
     bidiagonalize_unpack_100x500,
     bidiagonalize_unpack_500x100,
-    //    bidiagonalize_unpack_500x500 // too long
 );

--- a/benches/linalg/full_piv_lu.rs
+++ b/benches/linalg/full_piv_lu.rs
@@ -15,13 +15,6 @@ fn full_piv_lu_decompose_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn full_piv_lu_decompose_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("full_piv_lu_decompose_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(FullPivLU::new(m.clone())))
-    });
-}
-
 fn full_piv_lu_solve_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let lu = FullPivLU::new(m.clone());
@@ -46,18 +39,6 @@ fn full_piv_lu_solve_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn full_piv_lu_solve_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = FullPivLU::new(m.clone());
-
-    bh.bench_function("full_piv_lu_solve_500x500", move |bh| {
-        bh.iter(|| {
-            let mut b = DVector::<f64>::from_element(500, 1.0);
-            lu.solve(&mut b);
-        })
-    });
-}
-
 fn full_piv_lu_inverse_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let lu = FullPivLU::new(m.clone());
@@ -72,15 +53,6 @@ fn full_piv_lu_inverse_100x100(bh: &mut criterion::Criterion) {
     let lu = FullPivLU::new(m.clone());
 
     bh.bench_function("full_piv_lu_inverse_100x100", move |bh| {
-        bh.iter(|| std::hint::black_box(lu.try_inverse()))
-    });
-}
-
-fn full_piv_lu_inverse_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = FullPivLU::new(m.clone());
-
-    bh.bench_function("full_piv_lu_inverse_500x500", move |bh| {
         bh.iter(|| std::hint::black_box(lu.try_inverse()))
     });
 }
@@ -103,27 +75,14 @@ fn full_piv_lu_determinant_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn full_piv_lu_determinant_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = FullPivLU::new(m.clone());
-
-    bh.bench_function("full_piv_lu_determinant_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(lu.determinant()))
-    });
-}
-
 criterion_group!(
     full_piv_lu,
     full_piv_lu_decompose_10x10,
     full_piv_lu_decompose_100x100,
-    //    full_piv_lu_decompose_500x500,
     full_piv_lu_solve_10x10,
     full_piv_lu_solve_100x100,
-    //    full_piv_lu_solve_500x500,
     full_piv_lu_inverse_10x10,
     full_piv_lu_inverse_100x100,
-    //    full_piv_lu_inverse_500x500,
     full_piv_lu_determinant_10x10,
     full_piv_lu_determinant_100x100,
-    //    full_piv_lu_determinant_500x500
 );

--- a/benches/linalg/full_piv_lu.rs
+++ b/benches/linalg/full_piv_lu.rs
@@ -22,7 +22,8 @@ fn full_piv_lu_solve_10x10(bh: &mut criterion::Criterion) {
     bh.bench_function("full_piv_lu_solve_10x10", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(10, 1.0);
-            lu.solve(&mut b);
+            lu.solve_mut(&mut b);
+            b
         })
     });
 }
@@ -34,7 +35,8 @@ fn full_piv_lu_solve_100x100(bh: &mut criterion::Criterion) {
     bh.bench_function("full_piv_lu_solve_100x100", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(100, 1.0);
-            lu.solve(&mut b);
+            lu.solve_mut(&mut b);
+            b
         })
     });
 }

--- a/benches/linalg/hessenberg.rs
+++ b/benches/linalg/hessenberg.rs
@@ -25,13 +25,6 @@ fn hessenberg_decompose_200x200(bh: &mut criterion::Criterion) {
     });
 }
 
-fn hessenberg_decompose_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("hessenberg_decompose_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(Hessenberg::new(m.clone())))
-    });
-}
-
 // With unpack.
 fn hessenberg_decompose_unpack_100x100(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(100, 100);
@@ -53,23 +46,11 @@ fn hessenberg_decompose_unpack_200x200(bh: &mut criterion::Criterion) {
     });
 }
 
-fn hessenberg_decompose_unpack_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("hessenberg_decompose_unpack_500x500", move |bh| {
-        bh.iter(|| {
-            let hess = Hessenberg::new(m.clone());
-            let _ = hess.unpack();
-        })
-    });
-}
-
 criterion_group!(
     hessenberg,
     hessenberg_decompose_4x4,
     hessenberg_decompose_100x100,
     hessenberg_decompose_200x200,
-    //    hessenberg_decompose_500x500,
     hessenberg_decompose_unpack_100x100,
     hessenberg_decompose_unpack_200x200,
-    //    hessenberg_decompose_unpack_500x500
 );

--- a/benches/linalg/lu.rs
+++ b/benches/linalg/lu.rs
@@ -15,13 +15,6 @@ fn lu_decompose_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn lu_decompose_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("lu_decompose_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(LU::new(m.clone())))
-    });
-}
-
 fn lu_solve_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let lu = LU::new(m.clone());
@@ -46,18 +39,6 @@ fn lu_solve_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn lu_solve_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = LU::new(m.clone());
-
-    bh.bench_function("", move |bh| {
-        bh.iter(|| {
-            let mut b = DVector::<f64>::from_element(500, 1.0);
-            lu.solve(&mut b);
-        })
-    });
-}
-
 fn lu_inverse_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let lu = LU::new(m.clone());
@@ -72,15 +53,6 @@ fn lu_inverse_100x100(bh: &mut criterion::Criterion) {
     let lu = LU::new(m.clone());
 
     bh.bench_function("lu_inverse_100x100", move |bh| {
-        bh.iter(|| std::hint::black_box(lu.try_inverse()))
-    });
-}
-
-fn lu_inverse_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = LU::new(m.clone());
-
-    bh.bench_function("lu_inverse_500x500", move |bh| {
         bh.iter(|| std::hint::black_box(lu.try_inverse()))
     });
 }
@@ -103,25 +75,14 @@ fn lu_determinant_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn lu_determinant_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let lu = LU::new(m.clone());
-
-    bh.bench_function("", move |bh| {
-        bh.iter(|| std::hint::black_box(lu.determinant()))
-    });
-}
-
 criterion_group!(
     lu,
     lu_decompose_10x10,
     lu_decompose_100x100,
-    //    lu_decompose_500x500,
     lu_solve_10x10,
     lu_solve_100x100,
     lu_inverse_10x10,
     lu_inverse_100x100,
-    //    lu_inverse_500x500,
     lu_determinant_10x10,
-    lu_determinant_100x100
+    lu_determinant_100x100,
 );

--- a/benches/linalg/lu.rs
+++ b/benches/linalg/lu.rs
@@ -22,7 +22,8 @@ fn lu_solve_10x10(bh: &mut criterion::Criterion) {
     bh.bench_function("lu_solve_10x10", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(10, 1.0);
-            lu.solve(&mut b);
+            lu.solve_mut(&mut b);
+            b
         })
     });
 }
@@ -34,7 +35,8 @@ fn lu_solve_100x100(bh: &mut criterion::Criterion) {
     bh.bench_function("lu_solve_100x100", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(100, 1.0);
-            lu.solve(&mut b);
+            lu.solve_mut(&mut b);
+            b
         })
     });
 }

--- a/benches/linalg/qr.rs
+++ b/benches/linalg/qr.rs
@@ -32,13 +32,6 @@ fn qr_decompose_500x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn qr_decompose_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("qr_decompose_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(QR::new(m.clone())))
-    });
-}
-
 // With unpack.
 fn qr_decompose_unpack_100x100(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(100, 100);
@@ -70,16 +63,6 @@ fn qr_decompose_unpack_500x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn qr_decompose_unpack_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    bh.bench_function("qr_decompose_unpack_500x500", move |bh| {
-        bh.iter(|| {
-            let qr = QR::new(m.clone());
-            let _ = qr.unpack();
-        })
-    });
-}
-
 fn qr_solve_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let qr = QR::new(m.clone());
@@ -104,18 +87,6 @@ fn qr_solve_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn qr_solve_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let qr = QR::new(m.clone());
-
-    bh.bench_function("qr_solve_500x500", move |bh| {
-        bh.iter(|| {
-            let mut b = DVector::<f64>::from_element(500, 1.0);
-            qr.solve(&mut b);
-        })
-    });
-}
-
 fn qr_inverse_10x10(bh: &mut criterion::Criterion) {
     let m = DMatrix::<f64>::new_random(10, 10);
     let qr = QR::new(m.clone());
@@ -134,30 +105,17 @@ fn qr_inverse_100x100(bh: &mut criterion::Criterion) {
     });
 }
 
-fn qr_inverse_500x500(bh: &mut criterion::Criterion) {
-    let m = DMatrix::<f64>::new_random(500, 500);
-    let qr = QR::new(m.clone());
-
-    bh.bench_function("qr_inverse_500x500", move |bh| {
-        bh.iter(|| std::hint::black_box(qr.try_inverse()))
-    });
-}
-
 criterion_group!(
     qr,
     qr_decompose_100x100,
     qr_decompose_100x500,
     qr_decompose_4x4,
     qr_decompose_500x100,
-    //    qr_decompose_500x500,
     qr_decompose_unpack_100x100,
     qr_decompose_unpack_100x500,
     qr_decompose_unpack_500x100,
-    //    qr_decompose_unpack_500x500,
     qr_solve_10x10,
     qr_solve_100x100,
-    //    qr_solve_500x500,
     qr_inverse_10x10,
     qr_inverse_100x100,
-    //    qr_inverse_500x500
 );

--- a/benches/linalg/qr.rs
+++ b/benches/linalg/qr.rs
@@ -70,7 +70,8 @@ fn qr_solve_10x10(bh: &mut criterion::Criterion) {
     bh.bench_function("qr_solve_10x10", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(10, 1.0);
-            qr.solve(&mut b);
+            qr.solve_mut(&mut b);
+            b
         })
     });
 }
@@ -82,7 +83,8 @@ fn qr_solve_100x100(bh: &mut criterion::Criterion) {
     bh.bench_function("qr_solve_100x100", move |bh| {
         bh.iter(|| {
             let mut b = DVector::<f64>::from_element(100, 1.0);
-            qr.solve(&mut b);
+            qr.solve_mut(&mut b);
+            b
         })
     });
 }


### PR DESCRIPTION
This fixes following warnings:

```text
warning: function `bidiagonalize_500x500` is never used
  --> benches/linalg/bidiagonal.rs:35:4
   |
35 | fn bidiagonalize_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `bidiagonalize_unpack_500x500` is never used
  --> benches/linalg/bidiagonal.rs:73:4
   |
73 | fn bidiagonalize_unpack_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `full_piv_lu_decompose_500x500` is never used
  --> benches/linalg/full_piv_lu.rs:18:4
   |
18 | fn full_piv_lu_decompose_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `full_piv_lu_solve_500x500` is never used
  --> benches/linalg/full_piv_lu.rs:49:4
   |
49 | fn full_piv_lu_solve_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `full_piv_lu_inverse_500x500` is never used
  --> benches/linalg/full_piv_lu.rs:79:4
   |
79 | fn full_piv_lu_inverse_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `full_piv_lu_determinant_500x500` is never used
   --> benches/linalg/full_piv_lu.rs:106:4
    |
106 | fn full_piv_lu_determinant_500x500(bh: &mut criterion::Criterion) {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `hessenberg_decompose_500x500` is never used
  --> benches/linalg/hessenberg.rs:28:4
   |
28 | fn hessenberg_decompose_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `hessenberg_decompose_unpack_500x500` is never used
  --> benches/linalg/hessenberg.rs:56:4
   |
56 | fn hessenberg_decompose_unpack_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `lu_decompose_500x500` is never used
  --> benches/linalg/lu.rs:18:4
   |
18 | fn lu_decompose_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^

warning: function `lu_solve_500x500` is never used
  --> benches/linalg/lu.rs:49:4
   |
49 | fn lu_solve_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^

warning: function `lu_inverse_500x500` is never used
  --> benches/linalg/lu.rs:79:4
   |
79 | fn lu_inverse_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^

warning: function `lu_determinant_500x500` is never used
   --> benches/linalg/lu.rs:106:4
    |
106 | fn lu_determinant_500x500(bh: &mut criterion::Criterion) {
    |    ^^^^^^^^^^^^^^^^^^^^^^

warning: function `qr_decompose_500x500` is never used
  --> benches/linalg/qr.rs:35:4
   |
35 | fn qr_decompose_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^

warning: function `qr_decompose_unpack_500x500` is never used
  --> benches/linalg/qr.rs:73:4
   |
73 | fn qr_decompose_unpack_500x500(bh: &mut criterion::Criterion) {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `qr_solve_500x500` is never used
   --> benches/linalg/qr.rs:107:4
    |
107 | fn qr_solve_500x500(bh: &mut criterion::Criterion) {
    |    ^^^^^^^^^^^^^^^^

warning: function `qr_inverse_500x500` is never used
   --> benches/linalg/qr.rs:137:4
    |
137 | fn qr_inverse_500x500(bh: &mut criterion::Criterion) {
    |    ^^^^^^^^^^^^^^^^^^

warning: unused return value of `FullPivLU::<T, D, D>::solve` that must be used
  --> benches/linalg/full_piv_lu.rs:32:13
   |
32 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
32 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `FullPivLU::<T, D, D>::solve` that must be used
  --> benches/linalg/full_piv_lu.rs:44:13
   |
44 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
44 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `FullPivLU::<T, D, D>::solve` that must be used
  --> benches/linalg/full_piv_lu.rs:56:13
   |
56 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
56 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `LU::<T, D, D>::solve` that must be used
  --> benches/linalg/lu.rs:32:13
   |
32 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
32 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `LU::<T, D, D>::solve` that must be used
  --> benches/linalg/lu.rs:44:13
   |
44 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
44 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `LU::<T, D, D>::solve` that must be used
  --> benches/linalg/lu.rs:56:13
   |
56 |             lu.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
56 |             let _ = lu.solve(&mut b);
   |             +++++++

warning: unused return value of `QR::<T, D, D>::solve` that must be used
  --> benches/linalg/qr.rs:90:13
   |
90 |             qr.solve(&mut b);
   |             ^^^^^^^^^^^^^^^^
   |
   = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
   |
90 |             let _ = qr.solve(&mut b);
   |             +++++++

warning: unused return value of `QR::<T, D, D>::solve` that must be used
   --> benches/linalg/qr.rs:102:13
    |
102 |             qr.solve(&mut b);
    |             ^^^^^^^^^^^^^^^^
    |
    = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
    |
102 |             let _ = qr.solve(&mut b);
    |             +++++++

warning: unused return value of `QR::<T, D, D>::solve` that must be used
   --> benches/linalg/qr.rs:114:13
    |
114 |             qr.solve(&mut b);
    |             ^^^^^^^^^^^^^^^^
    |
    = note: Did you mean to use solve_mut()?
help: use `let _ = ...` to ignore the resulting value
    |
114 |             let _ = qr.solve(&mut b);
    |             +++++++

warning: `nalgebra` (bench "nalgebra_bench") generated 25 warnings
```