### PR TITLE
Feature/colpiv qr in nalgebra lapack

### DIFF
--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -45,4 +45,3 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = "1"
 approx = "0.5"
 rand = "0.8"
-

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-lapack"
-version = "0.27.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>"]
 
 description = "Matrix decompositions using nalgebra matrices and Lapack bindings."

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -36,6 +36,7 @@ simba = "0.9"
 serde = { version = "1.0", features = ["derive"], optional = true }
 lapack = { version = "0.19", default-features = false }
 lapack-src = { version = "0.8", default-features = false }
+thiserror = "1.0"
 # clippy = "*"
 
 [dev-dependencies]

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra-lapack"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Sébastien Crozet <developer@crozet.re>", "Andrew Straw <strawman@astraw.com>"]
 
 description = "Matrix decompositions using nalgebra matrices and Lapack bindings."
@@ -34,8 +34,8 @@ num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }
 simba = "0.9"
 serde = { version = "1.0", features = ["derive"], optional = true }
-lapack = { version = "0.19", default-features = false }
-lapack-src = { version = "0.8", default-features = false }
+lapack = { version = "0.20", default-features = false }
+lapack-src = { version = "0.11", default-features = false }
 thiserror = "1.0"
 # clippy = "*"
 

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -246,6 +246,26 @@ where
     }
 
     ///
+    //@todo
+    pub fn solve<C2: Dim, S, S2>(
+        &self,
+        rhs: &Matrix<T, R, C2, S>,
+    ) -> Result<OMatrix<T, C, C2>, Error>
+    where
+        S: RawStorageMut<T, R, C2> + IsContiguous + Storage<T, R, C2>,
+        S2: RawStorageMut<T, C, C2> + IsContiguous,
+        T: Zero,
+        DefaultAllocator: Allocator<C, C2> + Allocator<R, C2>,
+    {
+        let (_, c2) = rhs.shape_generic();
+        let (_, c) = self.qr.shape_generic();
+        let mut rhs = rhs.clone_owned();
+        let mut x = OMatrix::zeros_generic(c, c2);
+        self.solve_mut(&mut rhs, &mut x)?;
+        Ok(x)
+    }
+
+    ///
     //@todo(geo-ant) document!
     pub fn solve_mut<C2: Dim, S, S2>(
         &self,

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -74,7 +74,7 @@ pub enum DiagonalKind {
 }
 
 /// todo
-pub struct ColPivQR<T, R, C>
+pub struct ColPivQr<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: Scalar + ComplexField,
@@ -92,7 +92,7 @@ where
     rank: i32,
 }
 
-impl<T, R, C> ColPivQR<T, R, C>
+impl<T, R, C> ColPivQr<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrScalar + Zero + RealField + TotalOrder + Float,
@@ -142,7 +142,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQR<T, R, C>
+impl<T, R, C> ColPivQr<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrScalar + Zero + RealField,
@@ -175,7 +175,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQR<T, R, C>
+impl<T, R, C> ColPivQr<T, R, C>
 where
     DefaultAllocator: Allocator<R, C>
         + Allocator<R, DimMinimum<R, C>>
@@ -335,7 +335,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQR<T, R, C>
+impl<T, R, C> ColPivQr<T, R, C>
 where
     DefaultAllocator: Allocator<R, C>
         + Allocator<R, DimMinimum<R, C>>

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -428,7 +428,7 @@ where
             &mut info,
         );
 
-        debug_assert!(check_lapack_info(info).is_ok(), "error in lapack backend");
+        assert_eq!(check_lapack_info(info), Ok(()), "error in lapack backend");
 
         let mut work = vec![T::zero(); lwork as usize];
 
@@ -444,7 +444,7 @@ where
             &mut info,
         );
 
-        debug_assert!(check_lapack_info(info).is_ok(), "error in lapack backend");
+        assert_eq!(check_lapack_info(info), Ok(()), "error in lapack backend");
 
         q
     }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -14,6 +14,9 @@ mod utility;
 mod permutation;
 pub use permutation::PermutationRef;
 
+/// utility functionality to calculate the rank of matrices
+mod rank;
+
 #[derive(Debug)]
 pub enum Error {
     Backend(LapackErrorCode),
@@ -244,10 +247,8 @@ where
             return Err(Error::Dimension);
         }
 
-        // 1. Calculate Q^T * RHS
         self.mul_q_mut(rhs, Side::Left, Transposition::Transpose)?;
 
-        // 2.
         let rank = self.rank();
 
         if rank == 0 {
@@ -288,8 +289,8 @@ where
             //@todo
         .unwrap();
 
-        // self.p().inv_permute_cols_mut(&mut x);
-        todo!()
+        self.p().inv_permute_rows_mut(x)?;
+        Ok(())
     }
 }
 

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -374,7 +374,7 @@ where
             //@todo
         .unwrap();
 
-        self.p().permute_rows_mut(x)?;
+        self.p().inv_permute_rows_mut(x)?;
         Ok(())
     }
 }
@@ -744,69 +744,3 @@ macro_rules! colpiv_qr_real_impl {
 
 colpiv_qr_real_impl!(f32, xormqr = lapack::sormqr);
 colpiv_qr_real_impl!(f64, xormqr = lapack::dormqr);
-
-// impl ColPivQrReal for f32 {
-//     fn xormqr(
-//         side: Side,
-//         trans: Transposition,
-//         m: i32,
-//         n: i32,
-//         k: i32,
-//         a: &[Self],
-//         lda: i32,
-//         tau: &[Self],
-//         c: &mut [Self],
-//         ldc: i32,
-//         work: &mut [Self],
-//         lwork: i32,
-//     ) -> Result<(), LapackErrorCode> {
-//         let mut info = 0;
-//         let side = side.into_lapack_side_character();
-
-//         // this would be different for complex numbers!
-//         let trans = match trans {
-//             Transposition::No => b'N',
-//             Transposition::Transpose => b'T',
-//         };
-
-//         unsafe {
-//             lapack::sormqr(
-//                 side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork, &mut info,
-//             );
-//         }
-//         check_lapack_info(info)
-//     }
-
-//     fn xormqr_work_size(
-//         side: Side,
-//         trans: Transposition,
-//         m: i32,
-//         n: i32,
-//         k: i32,
-//         a: &[Self],
-//         lda: i32,
-//         tau: &[Self],
-//         c: &mut [Self],
-//         ldc: i32,
-//     ) -> Result<i32, LapackErrorCode> {
-//         let mut info = 0;
-//         let side = side.into_lapack_side_character();
-
-//         // this would be different for complex numbers!
-//         let trans = match trans {
-//             Transposition::No => b'N',
-//             Transposition::Transpose => b'T',
-//         };
-
-//         let mut work = [Zero::zero()];
-//         let lwork = -1 as i32;
-//         unsafe {
-//             lapack::sormqr(
-//                 side, trans, m, n, k, a, lda, tau, c, ldc, &mut work, lwork, &mut info,
-//             );
-//         }
-//         check_lapack_info(info)?;
-//         // for complex numbers: real part
-//         Ok(ComplexHelper::real_part(work[0]) as i32)
-//     }
-// }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -374,7 +374,7 @@ where
             //@todo
         .unwrap();
 
-        self.p().inv_permute_rows_mut(x)?;
+        self.p().permute_rows_mut(x)?;
         Ok(())
     }
 }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -58,7 +58,7 @@ pub enum DiagonalKind {
 }
 
 /// todo
-pub struct ColPivQr<T, R, C>
+pub struct ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: Scalar + ComplexField,
@@ -76,7 +76,7 @@ where
     rank: i32,
 }
 
-impl<T, R, C> ColPivQr<T, R, C>
+impl<T, R, C> ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrScalar + Zero + RealField + TotalOrder + Float,
@@ -134,7 +134,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQr<T, R, C>
+impl<T, R, C> ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrScalar + Zero + RealField,
@@ -167,7 +167,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQr<T, R, C>
+impl<T, R, C> ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrReal + Zero + RealField,
@@ -373,7 +373,7 @@ where
     }
 }
 
-impl<T, R, C> ColPivQr<T, R, C>
+impl<T, R, C> ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: Scalar + ComplexField,

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -1,0 +1,96 @@
+use error::{ErrorCode, check_lapack_info};
+use na::{Const, Matrix};
+use nalgebra::{DefaultAllocator, Dim, DimMin, DimMinimum, OMatrix, Scalar, allocator::Allocator};
+use num::Zero;
+
+pub mod error;
+
+use super::qr::{QRReal, QRScalar};
+
+pub struct ColPivQR<T, R, C>
+where
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>>,
+    T: Scalar,
+    R: DimMin<C>,
+    C: Dim,
+{
+    qr: OMatrix<T, R, C>,
+}
+
+impl<T, R, C> ColPivQR<T, R, C>
+where
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
+    T: ColPivQrScalar,
+    R: DimMin<C>,
+    C: Dim,
+{
+    pub fn new(mut m: OMatrix<T, R, C>) -> Option<Self> {
+        let (nrows, ncols) = m.shape_generic();
+        let mut info = 0;
+        let mut tau = Matrix::zeros_generic(nrows.min(ncols), Const::<1>);
+        let mut jpvt= Matrix::zeros_generic(ncols, Const::<1>);
+
+        let lwork = T::xgeqp3_work_size(nrows.value(), ncols.value(), m.as_mut_slice(), nrows.value(), jpvt, tau)
+
+        
+        todo!()
+    }
+}
+
+pub trait ColPivQrScalar: QRScalar {
+    /// routine for column pivoting QR decomposition using level 3 BLAS,
+    /// see https://www.netlib.org/lapack/lug/node42.html
+    /// or https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2023-0/geqp3.html
+    fn xgeqp3(
+        m: i32,
+        n: i32,
+        a: &mut [Self],
+        lda: i32,
+        jpvt: &mut [i32],
+        tau: &mut [Self],
+        work: &mut [Self],
+        lwork: i32,
+    ) -> Result<(), ErrorCode>;
+
+    fn xgeqp3_work_size(
+        m: i32,
+        n: i32,
+        a: &mut [Self],
+        lda: i32,
+        jpvt: &mut [i32],
+        tau: &mut [Self],
+    ) -> Result<i32, ErrorCode>;
+}
+
+impl ColPivQrScalar for f32 {
+    fn xgeqp3(
+        m: i32,
+        n: i32,
+        a: &mut [Self],
+        lda: i32,
+        jpvt: &mut [i32],
+        tau: &mut [Self],
+        work: &mut [Self],
+        lwork: i32,
+    ) -> Result<(), ErrorCode> {
+        let mut info = 0;
+        unsafe { lapack::sgeqp3(m, n, a, lda, jpvt, tau, work, lwork, &mut info) };
+        check_lapack_info(info)
+    }
+
+    fn xgeqp3_work_size(
+        m: i32,
+        n: i32,
+        a: &mut [Self],
+        lda: i32,
+        jpvt: &mut [i32],
+        tau: &mut [Self],
+    ) -> Result<i32, ErrorCode> {
+        let mut work = [Zero::zero()];
+        let lwork = -1 as i32;
+        let mut info = 0;
+        unsafe { lapack::sgeqp3(m, n, a, lda, jpvt, tau, &mut work, lwork, &mut info) };
+        check_lapack_info(info)?;
+        Ok(work[0] as i32)
+    }
+}

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -272,7 +272,6 @@ where
         R2: Dim,
         C2: Dim,
     {
-        //@todo test matrix dimensions
         let a = self.qr.as_slice();
         let lda = self
             .qr
@@ -300,9 +299,9 @@ where
         let trans = transpose;
         let tau = self.tau.as_slice();
 
-        let lwork = T::xormqr_work_size(side, transpose, m, n, k, a, lda, tau, c, ldc).unwrap();
+        let lwork = T::xormqr_work_size(side, transpose, m, n, k, a, lda, tau, c, ldc)?;
         let mut work = vec![T::zero(); lwork as usize];
-        T::xormqr(side, trans, m, n, k, a, lda, tau, c, ldc, &mut work, lwork).unwrap();
+        T::xormqr(side, trans, m, n, k, a, lda, tau, c, ldc, &mut work, lwork)?;
         Ok(())
     }
 
@@ -389,9 +388,7 @@ where
                 .expect("integer dimensions out of bounds"),
             x.as_mut_slice(),
             ldb,
-        )
-            //@todo
-        .unwrap();
+        )?;
 
         self.p().permute_rows_mut(x)?;
         Ok(())

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -167,7 +167,8 @@ where
         self.qr.ncols()
     }
 
-    /// obtain the permutation matrix.
+    /// obtain the permutation matrix $\boldsymbol{P}$,
+    /// such that $\boldsymbol{A P}= \boldsymbol{Q R}$.
     pub fn p(&self) -> Permutation<C> {
         Permutation::new(self.jpvt.clone())
     }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -328,7 +328,7 @@ where
             //@todo
         .unwrap();
 
-        self.p().inv_permute_rows_mut(x)?;
+        self.p().permute_rows_mut(x)?;
         Ok(())
     }
 }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -183,11 +183,7 @@ where
 
 impl<T, R, C> ColPivQr<T, R, C>
 where
-    DefaultAllocator: Allocator<R, C>
-        + Allocator<R, DimMinimum<R, C>>
-        + Allocator<DimMinimum<R, C>, C>
-        + Allocator<DimMinimum<R, C>>
-        + Allocator<C>,
+    DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
     T: ColPivQrReal + Zero + RealField,
     R: DimMin<C>,
     C: Dim,

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -1,3 +1,6 @@
+use super::qr::{QRReal, QRScalar};
+use crate::ComplexHelper;
+use error::Error;
 use error::{LapackErrorCode, check_lapack_info};
 use na::{ComplexField, Const, IsContiguous, Matrix, OVector, RealField, Storage, Vector};
 use nalgebra::storage::RawStorageMut;
@@ -7,30 +10,13 @@ use num::{Float, Zero};
 use rank::{RankDeterminationAlgorithm, calculate_rank};
 
 pub mod error;
-use crate::ComplexHelper;
-
-use super::qr::{QRReal, QRScalar};
+mod permutation;
 #[cfg(test)]
 mod test;
 mod utility;
-
-mod permutation;
 pub use permutation::Permutation;
-
 /// utility functionality to calculate the rank of matrices
 mod rank;
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Error in lapack backend (code: {0})")]
-    Backend(#[from] LapackErrorCode),
-    #[error("Wrong matrix dimensions")]
-    Dimensions,
-    #[error("QR decomposition for underdetermined systems not supported")]
-    Underdetermined,
-    #[error("Matrix has rank zero")]
-    ZeroRank,
-}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 /// Indicates the side from which a matrix multiplication is to be performed.

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -9,7 +9,9 @@ use num::float::TotalOrder;
 use num::{Float, Zero};
 use rank::{RankDeterminationAlgorithm, calculate_rank};
 
+/// error type for the column pivoting QR decomposition
 pub mod error;
+
 mod permutation;
 #[cfg(test)]
 mod test;
@@ -63,6 +65,7 @@ pub enum DiagonalKind {
 /// The columns of the matrix `A` are permuted such that `A P = Q R`, meaning
 /// the column-permuted `A` is the product of `Q` and `R`, where `Q` is an orthonormal
 /// matrix `Q^T Q = I` and `R` is upper triangular.
+#[derive(Debug, Clone)]
 pub struct ColPivQR<T, R, C>
 where
     DefaultAllocator: Allocator<R, C> + Allocator<DimMinimum<R, C>> + Allocator<C>,
@@ -479,6 +482,9 @@ where
     }
 }
 
+/// Utility trait to add a thin abstraction layer over lapack functionality for
+/// column pivoted QR decomposition.
+#[allow(missing_docs)]
 pub trait ColPivQrScalar: ComplexField + QRScalar {
     /// routine for column pivoting QR decomposition using level 3 BLAS,
     /// see https://www.netlib.org/lapack/lug/node42.html
@@ -663,6 +669,7 @@ colpiv_qr_scalar_impl!(
 // @note(geo-ant) This mirrors the behavior in the existing QR implementation
 // without pivoting. I'm not 100% sure that we can't abstract over real and
 // complex behavior in the scalar trait, but I'll keep it like this for now.
+#[allow(missing_docs)]
 pub trait ColPivQrReal: ColPivQrScalar + QRReal {
     fn xormqr(
         side: Side,

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -168,7 +168,8 @@ where
     }
 
     /// obtain the permutation matrix $\boldsymbol{P}$,
-    /// such that $\boldsymbol{A P}= \boldsymbol{Q R}$.
+    /// such that $\boldsymbol{A P}= \boldsymbol{Q R}$. This function
+    /// allocates a copy of the stored permutation vector.
     pub fn p(&self) -> Permutation<C> {
         Permutation::new(self.jpvt.clone())
     }

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -247,13 +247,9 @@ where
 
     ///
     //@todo
-    pub fn solve<C2: Dim, S, S2>(
-        &self,
-        rhs: &Matrix<T, R, C2, S>,
-    ) -> Result<OMatrix<T, C, C2>, Error>
+    pub fn solve<C2: Dim, S>(&self, rhs: &Matrix<T, R, C2, S>) -> Result<OMatrix<T, C, C2>, Error>
     where
         S: RawStorageMut<T, R, C2> + IsContiguous + Storage<T, R, C2>,
-        S2: RawStorageMut<T, C, C2> + IsContiguous,
         T: Zero,
         DefaultAllocator: Allocator<C, C2> + Allocator<R, C2>,
     {

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -17,7 +17,7 @@ mod test;
 mod utility;
 
 mod permutation;
-pub use permutation::PermutationRef;
+pub use permutation::Permutation;
 
 /// utility functionality to calculate the rank of matrices
 mod rank;
@@ -167,9 +167,9 @@ where
         self.qr.ncols()
     }
 
-    /// get the column permutation
-    pub fn p(&self) -> PermutationRef<'_, C> {
-        PermutationRef::new(&self.jpvt)
+    /// obtain the permutation matrix.
+    pub fn p(&self) -> Permutation<C> {
+        Permutation::new(self.jpvt.clone())
     }
 }
 

--- a/nalgebra-lapack/src/colpiv_qr.rs
+++ b/nalgebra-lapack/src/colpiv_qr.rs
@@ -398,9 +398,14 @@ where
     /// Retrieves the upper trapezoidal submatrix `R` of this decomposition.
     #[inline]
     #[must_use]
-    pub fn r(&self) -> OMatrix<T, DimMinimum<R, C>, C> {
+    pub fn r(&self) -> OMatrix<T, DimMinimum<R, C>, DimMinimum<R, C>>
+    where
+        DefaultAllocator: Allocator<DimMinimum<R, C>, DimMinimum<R, C>>,
+    {
         let (nrows, ncols) = self.qr.shape_generic();
-        self.qr.rows_generic(0, nrows.min(ncols)).upper_triangle()
+        let d = nrows.min(ncols);
+        let m = self.qr.generic_view((0, 0), (d, d));
+        m.upper_triangle()
     }
 }
 

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,6 +1,6 @@
 /// newtype for a lapack error code
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct LapackErrorCode(i32);
+pub struct LapackErrorCode(pub(crate) i32);
 
 impl PartialEq<i32> for LapackErrorCode {
     #[inline]

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,12 +1,17 @@
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
+/// error cases during QR decomposition and linear system solving
 pub enum Error {
     #[error("Error in lapack backend (code: {0})")]
+    /// error in the lapack backend
     Backend(#[from] LapackErrorCode),
     #[error("Wrong matrix dimensions")]
+    /// wrong dimensions for a matrix operation
     Dimensions,
     #[error("QR decomposition for underdetermined systems not supported")]
+    /// underdetermined system
     Underdetermined,
     #[error("Matrix has rank zero")]
+    /// matrix has zero rank
     ZeroRank,
 }
 

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,4 +1,14 @@
-use std::fmt::Display;
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Error in lapack backend (code: {0})")]
+    Backend(#[from] LapackErrorCode),
+    #[error("Wrong matrix dimensions")]
+    Dimensions,
+    #[error("QR decomposition for underdetermined systems not supported")]
+    Underdetermined,
+    #[error("Matrix has rank zero")]
+    ZeroRank,
+}
 
 /// newtype for a lapack error code
 #[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,5 +1,8 @@
+use std::fmt::Display;
+
 /// newtype for a lapack error code
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
 pub struct LapackErrorCode(pub(crate) i32);
 
 impl PartialEq<i32> for LapackErrorCode {

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,0 +1,11 @@
+/// newtype for a lapack error code
+pub struct ErrorCode(i32);
+
+/// utility function to check the info return value of a lapack function
+pub fn check_lapack_info(info: i32) -> Result<(), ErrorCode> {
+    if info == 0 {
+        Ok(())
+    } else {
+        Err(ErrorCode(info))
+    }
+}

--- a/nalgebra-lapack/src/colpiv_qr/error.rs
+++ b/nalgebra-lapack/src/colpiv_qr/error.rs
@@ -1,11 +1,19 @@
 /// newtype for a lapack error code
-pub struct ErrorCode(i32);
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct LapackErrorCode(i32);
+
+impl PartialEq<i32> for LapackErrorCode {
+    #[inline]
+    fn eq(&self, other: &i32) -> bool {
+        self == &LapackErrorCode(*other)
+    }
+}
 
 /// utility function to check the info return value of a lapack function
-pub fn check_lapack_info(info: i32) -> Result<(), ErrorCode> {
+pub fn check_lapack_info(info: i32) -> Result<(), LapackErrorCode> {
     if info == 0 {
         Ok(())
     } else {
-        Err(ErrorCode(info))
+        Err(LapackErrorCode(info))
     }
 }

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -22,6 +22,7 @@ where
 {
     ///
     //@todo(geo-ant) comment
+    #[inline]
     pub fn permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
     where
         R: Dim,
@@ -33,6 +34,7 @@ where
 
     ///
     //@todo(geo-ant) comment
+    #[inline]
     pub fn inv_permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
     where
         R: Dim,
@@ -43,6 +45,7 @@ where
     }
     ///
     //@todo(geo-ant) comment
+    #[inline]
     pub fn permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
     where
         C: Dim,
@@ -54,6 +57,7 @@ where
 
     ///
     //@todo(geo-ant) comment
+    #[inline]
     pub fn inv_permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
     where
         C: Dim,
@@ -63,6 +67,7 @@ where
         self.apply_rows_mut(false, mat)
     }
 
+    #[inline]
     fn apply_rows_mut<T, C, S>(
         &self,
         forward: bool,
@@ -91,6 +96,7 @@ where
         Ok(())
     }
 
+    #[inline]
     fn apply_cols_mut<T, R, S>(
         &self,
         forward: bool,

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -6,16 +6,16 @@ use na::{
 #[cfg(test)]
 mod test;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PermutationRef<'a, D>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Permutation<D>
 where
     D: Dim,
     DefaultAllocator: Allocator<D>,
 {
-    jpvt: &'a OVector<i32, D>,
+    jpvt: OVector<i32, D>,
 }
 
-impl<'a, D> PermutationRef<'a, D>
+impl<'a, D> Permutation<D>
 where
     D: Dim,
     DefaultAllocator: Allocator<D>,
@@ -23,7 +23,7 @@ where
     ///
     //@todo(geo-ant) comment
     #[inline]
-    pub fn permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
+    pub fn permute_cols_mut<T, R, S>(&mut self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
     where
         R: Dim,
         S: RawStorageMut<T, R, D> + IsContiguous,
@@ -35,7 +35,10 @@ where
     ///
     //@todo(geo-ant) comment
     #[inline]
-    pub fn inv_permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
+    pub fn inv_permute_cols_mut<T, R, S>(
+        &mut self,
+        mat: &mut Matrix<T, R, D, S>,
+    ) -> Result<(), Error>
     where
         R: Dim,
         S: RawStorageMut<T, R, D> + IsContiguous,
@@ -46,7 +49,7 @@ where
     ///
     //@todo(geo-ant) comment
     #[inline]
-    pub fn permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
+    pub fn permute_rows_mut<T, C, S>(&mut self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
     where
         C: Dim,
         S: RawStorageMut<T, D, C> + IsContiguous,
@@ -58,7 +61,10 @@ where
     ///
     //@todo(geo-ant) comment
     #[inline]
-    pub fn inv_permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
+    pub fn inv_permute_rows_mut<T, C, S>(
+        &mut self,
+        mat: &mut Matrix<T, D, C, S>,
+    ) -> Result<(), Error>
     where
         C: Dim,
         S: RawStorageMut<T, D, C> + IsContiguous,
@@ -69,7 +75,7 @@ where
 
     #[inline]
     fn apply_rows_mut<T, C, S>(
-        &self,
+        &mut self,
         forward: bool,
         mat: &mut Matrix<T, D, C, S>,
     ) -> Result<(), Error>
@@ -91,14 +97,21 @@ where
             .try_into()
             .expect("matrix dimensions out of bounds");
 
-        let mut jpvt = self.jpvt.clone_owned();
-        T::xlapmr(forward, m, n, mat.as_mut_slice(), m, jpvt.as_mut_slice()).unwrap();
+        T::xlapmr(
+            forward,
+            m,
+            n,
+            mat.as_mut_slice(),
+            m,
+            self.jpvt.as_mut_slice(),
+        )
+        .unwrap();
         Ok(())
     }
 
     #[inline]
     fn apply_cols_mut<T, R, S>(
-        &self,
+        &mut self,
         forward: bool,
         mat: &mut Matrix<T, R, D, S>,
     ) -> Result<(), Error>
@@ -119,12 +132,19 @@ where
             .try_into()
             .expect("matrix dimensions out of bounds");
 
-        let mut jpvt = self.jpvt.clone_owned();
-        T::xlapmt(forward, m, n, mat.as_mut_slice(), m, jpvt.as_mut_slice()).unwrap();
+        T::xlapmt(
+            forward,
+            m,
+            n,
+            mat.as_mut_slice(),
+            m,
+            self.jpvt.as_mut_slice(),
+        )
+        .unwrap();
         Ok(())
     }
 
-    pub(crate) fn new(jpvt: &'a OVector<i32, D>) -> Self {
+    pub(crate) fn new(jpvt: OVector<i32, D>) -> Self {
         Self { jpvt }
     }
 }

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -33,7 +33,9 @@ where
         S: RawStorageMut<T, R, D> + IsContiguous,
         T: ColPivQrScalar,
     {
-        self.apply_cols_mut(true, mat)
+        //@note(geo-ant) due to the logic in the jpvt vector, we have
+        // to invert the forward/backward argument here
+        self.apply_cols_mut(false, mat)
     }
 
     ///
@@ -48,7 +50,7 @@ where
         S: RawStorageMut<T, R, D> + IsContiguous,
         T: ColPivQrScalar,
     {
-        self.apply_cols_mut(false, mat)
+        self.apply_cols_mut(true, mat)
     }
     ///
     //@todo(geo-ant) comment
@@ -59,7 +61,7 @@ where
         S: RawStorageMut<T, D, C> + IsContiguous,
         T: ColPivQrScalar,
     {
-        self.apply_rows_mut(true, mat)
+        self.apply_rows_mut(false, mat)
     }
 
     ///
@@ -74,10 +76,11 @@ where
         S: RawStorageMut<T, D, C> + IsContiguous,
         T: ColPivQrScalar,
     {
-        self.apply_rows_mut(false, mat)
+        self.apply_rows_mut(true, mat)
     }
 
     #[inline]
+    /// a thin wrapper around lapacks xLAPMR
     fn apply_rows_mut<T, C, S>(
         &mut self,
         forward: bool,
@@ -114,6 +117,7 @@ where
     }
 
     #[inline]
+    /// a thin wrapper around LAPACKS xLAMPT
     fn apply_cols_mut<T, R, S>(
         &mut self,
         forward: bool,

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -7,10 +7,13 @@ use na::{
 mod test;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// describes an orthogonal permutation matrix that can be used to permute
+/// describes an orthogonal permutation matrix `P` that can be used to permute
 /// the rows or columns of an appropriately shaped matrix. Due to LAPACK
 /// internals, an instance must be mutably borrowed when applying the
 /// permutation, but the permutation itself will remain unchanged on success.
+///
+/// **Note**: the associated functions take `Self` by mutable reference due
+/// to the LAPACK internal implementation of the permutation logic.
 pub struct Permutation<D>
 where
     D: Dim,
@@ -24,8 +27,7 @@ where
     D: Dim,
     DefaultAllocator: Allocator<D>,
 {
-    ///
-    //@todo(geo-ant) comment
+    /// Apply the column permutation to a matrix `A`, equivalent to `P A`.
     #[inline]
     pub fn permute_cols_mut<T, R, S>(&mut self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
     where
@@ -33,13 +35,12 @@ where
         S: RawStorageMut<T, R, D> + IsContiguous,
         T: ColPivQrScalar,
     {
-        //@note(geo-ant) due to the logic in the jpvt vector, we have
+        //@note(geo-ant) due to the LAPACK internal logic in the jpvt vector, we have
         // to invert the forward/backward argument here
         self.apply_cols_mut(false, mat)
     }
 
-    ///
-    //@todo(geo-ant) comment
+    /// Apply the inverse column permutation to a matrix `A`, equivalent to `P^T A`.
     #[inline]
     pub fn inv_permute_cols_mut<T, R, S>(
         &mut self,
@@ -52,8 +53,8 @@ where
     {
         self.apply_cols_mut(true, mat)
     }
-    ///
-    //@todo(geo-ant) comment
+
+    /// Apply the row permutation to a matrix `A`, equivalent to `P A`.
     #[inline]
     pub fn permute_rows_mut<T, C, S>(&mut self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
     where
@@ -64,8 +65,7 @@ where
         self.apply_rows_mut(false, mat)
     }
 
-    ///
-    //@todo(geo-ant) comment
+    /// Apply the inverse row permutation to a matrix `A`, equivalent to `P^T A`.
     #[inline]
     pub fn inv_permute_rows_mut<T, C, S>(
         &mut self,

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -7,6 +7,10 @@ use na::{
 mod test;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// describes an orthogonal permutation matrix that can be used to permute
+/// the rows or columns of an appropriately shaped matrix. Due to LAPACK
+/// internals, an instance must be mutably borrowed when applying the
+/// permutation, but the permutation itself will remain unchanged on success.
 pub struct Permutation<D>
 where
     D: Dim,

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -89,7 +89,7 @@ where
         T: ColPivQrScalar,
     {
         if mat.nrows() != self.jpvt.len() {
-            return Err(Error::Dimension);
+            return Err(Error::Dimensions);
         }
 
         let m = mat
@@ -125,7 +125,7 @@ where
         T: ColPivQrScalar,
     {
         if mat.ncols() != self.jpvt.len() {
-            return Err(Error::Dimension);
+            return Err(Error::Dimensions);
         }
         let m = mat
             .nrows()

--- a/nalgebra-lapack/src/colpiv_qr/permutation.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation.rs
@@ -1,0 +1,124 @@
+use super::{ColPivQrScalar, Error};
+use na::{
+    DefaultAllocator, Dim, IsContiguous, Matrix, OVector, RawStorageMut, allocator::Allocator,
+};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PermutationRef<'a, D>
+where
+    D: Dim,
+    DefaultAllocator: Allocator<D>,
+{
+    jpvt: &'a OVector<i32, D>,
+}
+
+impl<'a, D> PermutationRef<'a, D>
+where
+    D: Dim,
+    DefaultAllocator: Allocator<D>,
+{
+    ///
+    //@todo(geo-ant) comment
+    pub fn permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
+    where
+        R: Dim,
+        S: RawStorageMut<T, R, D> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        self.apply_cols_mut(true, mat)
+    }
+
+    ///
+    //@todo(geo-ant) comment
+    pub fn inv_permute_cols_mut<T, R, S>(&self, mat: &mut Matrix<T, R, D, S>) -> Result<(), Error>
+    where
+        R: Dim,
+        S: RawStorageMut<T, R, D> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        self.apply_cols_mut(false, mat)
+    }
+    ///
+    //@todo(geo-ant) comment
+    pub fn permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
+    where
+        C: Dim,
+        S: RawStorageMut<T, D, C> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        self.apply_rows_mut(true, mat)
+    }
+
+    ///
+    //@todo(geo-ant) comment
+    pub fn inv_permute_rows_mut<T, C, S>(&self, mat: &mut Matrix<T, D, C, S>) -> Result<(), Error>
+    where
+        C: Dim,
+        S: RawStorageMut<T, D, C> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        self.apply_rows_mut(false, mat)
+    }
+
+    fn apply_rows_mut<T, C, S>(
+        &self,
+        forward: bool,
+        mat: &mut Matrix<T, D, C, S>,
+    ) -> Result<(), Error>
+    where
+        C: Dim,
+        S: RawStorageMut<T, D, C> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        if mat.nrows() != self.jpvt.len() {
+            return Err(Error::Dimension);
+        }
+
+        let m = mat
+            .nrows()
+            .try_into()
+            .expect("matrix dimensions out of bounds");
+        let n = mat
+            .ncols()
+            .try_into()
+            .expect("matrix dimensions out of bounds");
+
+        let mut jpvt = self.jpvt.clone_owned();
+        T::xlapmr(forward, m, n, mat.as_mut_slice(), m, jpvt.as_mut_slice()).unwrap();
+        Ok(())
+    }
+
+    fn apply_cols_mut<T, R, S>(
+        &self,
+        forward: bool,
+        mat: &mut Matrix<T, R, D, S>,
+    ) -> Result<(), Error>
+    where
+        R: Dim,
+        S: RawStorageMut<T, R, D> + IsContiguous,
+        T: ColPivQrScalar,
+    {
+        if mat.ncols() != self.jpvt.len() {
+            return Err(Error::Dimension);
+        }
+        let m = mat
+            .nrows()
+            .try_into()
+            .expect("matrix dimensions out of bounds");
+        let n = mat
+            .ncols()
+            .try_into()
+            .expect("matrix dimensions out of bounds");
+
+        let mut jpvt = self.jpvt.clone_owned();
+        T::xlapmt(forward, m, n, mat.as_mut_slice(), m, jpvt.as_mut_slice()).unwrap();
+        Ok(())
+    }
+
+    pub(crate) fn new(jpvt: &'a OVector<i32, D>) -> Self {
+        Self { jpvt }
+    }
+}

--- a/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
@@ -15,9 +15,9 @@ fn test_permutation_4x3() {
     let mut mat2 = mat.clone();
     perm.permute_cols_mut(&mut mat2).unwrap();
 
-    assert_eq!(mat2.column(0), mat.column(2));
-    assert_eq!(mat2.column(1), mat.column(0));
-    assert_eq!(mat2.column(2), mat.column(1));
+    assert_eq!(mat2.column(2), mat.column(0));
+    assert_eq!(mat2.column(0), mat.column(1));
+    assert_eq!(mat2.column(1), mat.column(2));
 
     // now inverse permute, which means we expect same as original matrix again
     perm.inv_permute_cols_mut(&mut mat2).unwrap();
@@ -28,10 +28,10 @@ fn test_permutation_4x3() {
     let mut perm = Permutation::new(jpvt);
 
     perm.permute_rows_mut(&mut mat2).unwrap();
-    assert_eq!(mat2.row(0), mat.row(3));
+    assert_eq!(mat2.row(3), mat.row(0));
     assert_eq!(mat2.row(1), mat.row(1));
-    assert_eq!(mat2.row(2), mat.row(0));
-    assert_eq!(mat2.row(3), mat.row(2));
+    assert_eq!(mat2.row(0), mat.row(2));
+    assert_eq!(mat2.row(2), mat.row(3));
 
     perm.inv_permute_rows_mut(&mut mat2).unwrap();
     assert_eq!(mat2, mat);
@@ -57,11 +57,11 @@ fn test_permutation_dynamic_3x5() {
 
     perm.permute_cols_mut(&mut mat2).unwrap();
 
-    assert_eq!(mat2.column(0), mat.column(4));
+    assert_eq!(mat2.column(4), mat.column(0));
     assert_eq!(mat2.column(1), mat.column(1));
-    assert_eq!(mat2.column(2), mat.column(0));
+    assert_eq!(mat2.column(0), mat.column(2));
     assert_eq!(mat2.column(3), mat.column(3));
-    assert_eq!(mat2.column(4), mat.column(2));
+    assert_eq!(mat2.column(2), mat.column(4));
 
     perm.inv_permute_cols_mut(&mut mat2).unwrap();
     assert_eq!(mat2, mat);
@@ -71,9 +71,9 @@ fn test_permutation_dynamic_3x5() {
 
     perm.permute_rows_mut(&mut mat2).unwrap();
 
-    assert_eq!(mat2.row(0), mat.row(1));
-    assert_eq!(mat2.row(1), mat.row(2));
-    assert_eq!(mat2.row(2), mat.row(0));
+    assert_eq!(mat2.row(1), mat.row(0));
+    assert_eq!(mat2.row(2), mat.row(1));
+    assert_eq!(mat2.row(0), mat.row(2));
 
     // Inverse permute should restore original matrix
     perm.inv_permute_rows_mut(&mut mat2).unwrap();

--- a/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
@@ -1,4 +1,4 @@
-use super::PermutationRef;
+use super::Permutation;
 
 #[test]
 fn test_permutation_4x3() {
@@ -11,7 +11,7 @@ fn test_permutation_4x3() {
                            10.,11.,12.]; // 4
 
     let jpvt = nalgebra::vector![3, 1, 2];
-    let perm = PermutationRef::new(&jpvt);
+    let mut perm = Permutation::new(jpvt);
     let mut mat2 = mat.clone();
     perm.permute_cols_mut(&mut mat2).unwrap();
 
@@ -25,7 +25,7 @@ fn test_permutation_4x3() {
 
     // now test column permutation
     let jpvt = nalgebra::vector![4, 2, 1, 3];
-    let perm = PermutationRef::new(&jpvt);
+    let mut perm = Permutation::new(jpvt);
 
     perm.permute_rows_mut(&mut mat2).unwrap();
     assert_eq!(mat2.row(0), mat.row(3));
@@ -52,7 +52,7 @@ fn test_permutation_dynamic_3x5() {
 
     // Test column permutation: [5, 2, 1, 4, 3] - rearrange columns
     let jpvt_cols = DVector::from_vec(vec![5, 2, 1, 4, 3]);
-    let perm = PermutationRef::new(&jpvt_cols);
+    let mut perm = Permutation::new(jpvt_cols);
     let mut mat2 = mat.clone();
 
     perm.permute_cols_mut(&mut mat2).unwrap();
@@ -67,7 +67,7 @@ fn test_permutation_dynamic_3x5() {
     assert_eq!(mat2, mat);
 
     let jpvt_rows = DVector::from_vec(vec![2, 3, 1]);
-    let perm = PermutationRef::new(&jpvt_rows);
+    let mut perm = Permutation::new(jpvt_rows);
 
     perm.permute_rows_mut(&mut mat2).unwrap();
 

--- a/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/permutation/test.rs
@@ -1,0 +1,81 @@
+use super::PermutationRef;
+
+#[test]
+fn test_permutation_4x3() {
+    #[rustfmt::skip]
+    let mat =
+            // col idx     1   2   3 (lapack: 1 based indexing)
+        nalgebra::matrix![ 1., 2., 3.;   // 1
+                           4., 5., 6.;   // 2
+                           7., 8., 9.;   // 3
+                           10.,11.,12.]; // 4
+
+    let jpvt = nalgebra::vector![3, 1, 2];
+    let perm = PermutationRef::new(&jpvt);
+    let mut mat2 = mat.clone();
+    perm.permute_cols_mut(&mut mat2).unwrap();
+
+    assert_eq!(mat2.column(0), mat.column(2));
+    assert_eq!(mat2.column(1), mat.column(0));
+    assert_eq!(mat2.column(2), mat.column(1));
+
+    // now inverse permute, which means we expect same as original matrix again
+    perm.inv_permute_cols_mut(&mut mat2).unwrap();
+    assert_eq!(mat2, mat);
+
+    // now test column permutation
+    let jpvt = nalgebra::vector![4, 2, 1, 3];
+    let perm = PermutationRef::new(&jpvt);
+
+    perm.permute_rows_mut(&mut mat2).unwrap();
+    assert_eq!(mat2.row(0), mat.row(3));
+    assert_eq!(mat2.row(1), mat.row(1));
+    assert_eq!(mat2.row(2), mat.row(0));
+    assert_eq!(mat2.row(3), mat.row(2));
+
+    perm.inv_permute_rows_mut(&mut mat2).unwrap();
+    assert_eq!(mat2, mat);
+}
+
+#[test]
+fn test_permutation_dynamic_3x5() {
+    use nalgebra::{DMatrix, DVector};
+
+    // Create a 3x5 dynamic matrix with a different pattern
+    #[rustfmt::skip]
+    let mat = DMatrix::from_row_slice(3, 5, &[
+        // col idx     1    2    3    4    5  (lapack: 1 based indexing)
+                       10., 20., 30., 40., 50.,     // row 1
+                       100.,200.,300.,400.,500.,    // row 2
+                       1000.,2000.,3000.,4000.,5000.// row 3
+    ]);
+
+    // Test column permutation: [5, 2, 1, 4, 3] - rearrange columns
+    let jpvt_cols = DVector::from_vec(vec![5, 2, 1, 4, 3]);
+    let perm = PermutationRef::new(&jpvt_cols);
+    let mut mat2 = mat.clone();
+
+    perm.permute_cols_mut(&mut mat2).unwrap();
+
+    assert_eq!(mat2.column(0), mat.column(4));
+    assert_eq!(mat2.column(1), mat.column(1));
+    assert_eq!(mat2.column(2), mat.column(0));
+    assert_eq!(mat2.column(3), mat.column(3));
+    assert_eq!(mat2.column(4), mat.column(2));
+
+    perm.inv_permute_cols_mut(&mut mat2).unwrap();
+    assert_eq!(mat2, mat);
+
+    let jpvt_rows = DVector::from_vec(vec![2, 3, 1]);
+    let perm = PermutationRef::new(&jpvt_rows);
+
+    perm.permute_rows_mut(&mut mat2).unwrap();
+
+    assert_eq!(mat2.row(0), mat.row(1));
+    assert_eq!(mat2.row(1), mat.row(2));
+    assert_eq!(mat2.row(2), mat.row(0));
+
+    // Inverse permute should restore original matrix
+    perm.inv_permute_rows_mut(&mut mat2).unwrap();
+    assert_eq!(mat2, mat);
+}

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -1,15 +1,35 @@
 use crate::num::FromPrimitive;
-use na::{ComplexField, Dim, IsContiguous, Matrix, OMatrix, RawStorage, Scalar, Storage};
+use na::ComplexField;
+use na::{Dim, IsContiguous, Matrix, RawStorage, RealField, Scalar, Storage};
+use num::{ConstOne, ToPrimitive};
+use num::{Float, float::TotalOrder};
+
+mod test;
 
 /// describes different algorithms of calculating a matrix rank from the upper
 /// diagonal R matrix of a column-pivoted QR decomposition.
-pub enum RankEstimationAlgo<T: ComplexField> {
-    /// this simplest (and cheapest) strategy is to count the diagonal entries
-    /// >= epsilon and count those as the rank.
-    FixedEps(T::RealField),
-    /// like fixed eps, but the epsilon is scaled with max(M,N) of the matrix
-    /// where M: number of rows, N:number of columns
-    ScaledEps(T::RealField),
+pub enum RankEstimationAlgo<T: RealField> {
+    /// this simplest (and cheapest) strategy is to estimate the rank of the
+    /// matrix $$AP = QR$$ as the number of diagonal elements $$R_{ii}$$ greater
+    /// than this fixed lower bound.
+    ///
+    /// **Note**: this is the fastest method, but
+    /// should be used with extreme care, because it can easily produce bad
+    /// results even in trivial cases.
+    FixedLowerBound(T::RealField),
+    //@todo
+    ScaledEps1,
+    //@todo
+    ScaledEps2,
+}
+
+impl<T> Default for RankEstimationAlgo<T>
+where
+    T: RealField + Float,
+{
+    fn default() -> Self {
+        Self::ScaledEps2
+    }
 }
 
 // WARNING: qr must be a qr decomposition of a matrix where the upper triangular
@@ -19,24 +39,37 @@ pub(crate) fn calculate_rank<T, R, C, S>(
     method: RankEstimationAlgo<T>,
 ) -> usize
 where
-    T: Scalar + ComplexField + Copy,
+    T: Scalar + RealField + Copy + Float + TotalOrder,
     R: Dim,
     C: Dim,
     S: Storage<T, R, C> + RawStorage<T, R, C> + IsContiguous,
 {
     match method {
-        RankEstimationAlgo::FixedEps(eps) => calculate_rank_with_fixed_eps(qr, eps),
-        RankEstimationAlgo::ScaledEps(eps) => calculate_rank_with_fixed_eps(
-            qr,
-            eps * T::RealField::from_usize(qr.nrows().max(qr.ncols()))
-                .expect("matrix dimensions out of floating point bounds"),
-        ),
+        RankEstimationAlgo::FixedLowerBound(eps) => calculate_rank_with_fixed_minimum(qr, eps),
+        RankEstimationAlgo::ScaledEps1 => {
+            let r_max = calculate_max_abs_diag(qr);
+
+            let tol = r_max
+                * T::epsilon()
+                * T::RealField::from_usize(qr.nrows().max(qr.ncols()))
+                    .expect("matrix dimensions out of floating point bounds");
+            calculate_rank_with_fixed_minimum(qr, tol)
+        }
+        RankEstimationAlgo::ScaledEps2 => {
+            let r_max = calculate_max_abs_diag(qr);
+
+            let tol = eps(r_max)
+                * T::RealField::from_usize(qr.nrows().max(qr.ncols()))
+                    .expect("matrix dimensions out of floating point bounds");
+            println!("rmax = {r_max} tol = {tol}");
+            calculate_rank_with_fixed_minimum(qr, tol)
+        }
     }
 }
 
-fn calculate_rank_with_fixed_eps<T, R, C, S>(qr: &Matrix<T, R, C, S>, eps: T::RealField) -> usize
+fn calculate_rank_with_fixed_minimum<T, R, C, S>(qr: &Matrix<T, R, C, S>, eps: T) -> usize
 where
-    T: Scalar + ComplexField + Copy,
+    T: Scalar + RealField + Copy,
     R: Dim,
     C: Dim,
     S: Storage<T, R, C> + RawStorage<T, R, C> + IsContiguous,
@@ -45,9 +78,46 @@ where
     let dim = qr.nrows().min(qr.ncols());
     let mut rank = 0;
     for j in 0..dim {
-        if qr[(j, j)].abs() >= eps {
+        if qr[(j, j)].abs() > eps {
             rank += 1;
         }
     }
     rank
+}
+
+/// helper function to calculate the maximum diagonal element of a matrix
+fn calculate_max_abs_diag<T, R, C, S>(mat: &Matrix<T, R, C, S>) -> T
+where
+    T: Scalar + RealField + Copy + TotalOrder,
+    R: Dim,
+    C: Dim,
+    S: Storage<T, R, C> + RawStorage<T, R, C> + IsContiguous,
+{
+    let dim = mat.nrows().min(mat.ncols());
+
+    (0..dim)
+        .flat_map(|idx| {
+            let val = mat[(idx, idx)];
+            val.is_finite().then_some(val.abs())
+        })
+        .max_by(T::total_cmp)
+        .unwrap_or(T::zero())
+}
+
+//@todo document
+fn eps<T>(x: T) -> T
+where
+    T: ToPrimitive,
+    T: Float,
+{
+    let x = x.abs();
+    if x < T::min_positive_value() {
+        return T::min_positive_value();
+    }
+    let Some(exponent) = T::log2(x).floor().to_i32() else {
+        return T::min_positive_value();
+    };
+
+    let two = T::one() + T::one();
+    two.powi(exponent) * T::epsilon()
 }

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -6,19 +6,34 @@ use num::{Float, float::TotalOrder};
 mod test;
 
 /// describes different algorithms of estimating a matrix rank from the upper
-/// diagonal R matrix of a column-pivoted QR decomposition.
+/// diagonal `R` matrix of a column-pivoted QR decomposition.
 pub enum RankDeterminationAlgorithm<T: RealField> {
-    /// this simplest (and cheapest) strategy is to estimate the rank of the
+    /// This simplest (and cheapest) strategy is to estimate the rank of the
     /// matrix $$AP = QR$$ as the number of diagonal elements $$R_{ii}$$ greater
     /// than this fixed lower bound.
     ///
     /// **Note**: this is the fastest method, but
-    /// should be used with extreme care, because it can easily produce bad
-    /// results even in trivial cases.
+    /// should be used with extreme caution, because it can easily produce
+    /// erroneous results even in trivial cases.
     FixedLowerBound(T::RealField),
-    //@todo
+    /// Calculate the rank of the matrix as the number of diagonal elements
+    /// of `R` greater than `R_max * EPSILON * max(nrows,ncols)`, where `R_max`
+    /// is the largest diagonal entry of `R` and `EPSILON` is the floating
+    /// point accuracy.
+    ///
+    /// This is inspired by the logic of the GNU octave [`rank`](https://octave.sourceforge.io/octave/function/rank.html)
+    /// function. However, that function uses the singular values rather than
+    /// the diagonal elements of `R`.
     ScaledEps1,
-    //@todo
+    /// Calculate the rank of the matrix as the number of diagonal elements
+    /// of `R` greater than `eps(R_max)*max(nrows,ncols)`, where `R_max`
+    /// is the largest diagonal entry of `R` and `eps(R_max)` is the same
+    /// as the matlab function [`eps`](https://www.mathworks.com/help/matlab/ref/double.eps.html)
+    /// for floating point relative accuracy.
+    ///
+    /// This is inspired by the logic of the MatLAB [`rank`](https://de.mathworks.com/help/matlab/ref/rank.html)
+    /// function. However, that function uses the singular values rather than
+    /// the diagonal elements of `R`.
     ScaledEps2,
 }
 

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -62,7 +62,6 @@ where
             let tol = eps(r_max)
                 * T::RealField::from_usize(qr.nrows().max(qr.ncols()))
                     .expect("matrix dimensions out of floating point bounds");
-            println!("rmax = {r_max} tol = {tol}");
             calculate_rank_with_fixed_minimum(qr, tol)
         }
     }

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -1,7 +1,5 @@
-use crate::num::FromPrimitive;
-use na::ComplexField;
 use na::{Dim, IsContiguous, Matrix, RawStorage, RealField, Scalar, Storage};
-use num::{ConstOne, ToPrimitive};
+use num::ToPrimitive;
 use num::{Float, float::TotalOrder};
 
 #[cfg(test)]

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -1,0 +1,53 @@
+use crate::num::FromPrimitive;
+use na::{ComplexField, Dim, IsContiguous, Matrix, OMatrix, RawStorage, Scalar, Storage};
+
+/// describes different algorithms of calculating a matrix rank from the upper
+/// diagonal R matrix of a column-pivoted QR decomposition.
+pub enum RankEstimationAlgo<T: ComplexField> {
+    /// this simplest (and cheapest) strategy is to count the diagonal entries
+    /// >= epsilon and count those as the rank.
+    FixedEps(T::RealField),
+    /// like fixed eps, but the epsilon is scaled with max(M,N) of the matrix
+    /// where M: number of rows, N:number of columns
+    ScaledEps(T::RealField),
+}
+
+// WARNING: qr must be a qr decomposition of a matrix where the upper triangular
+// part stores the matrix R
+pub(crate) fn calculate_rank<T, R, C, S>(
+    qr: &Matrix<T, R, C, S>,
+    method: RankEstimationAlgo<T>,
+) -> usize
+where
+    T: Scalar + ComplexField + Copy,
+    R: Dim,
+    C: Dim,
+    S: Storage<T, R, C> + RawStorage<T, R, C> + IsContiguous,
+{
+    match method {
+        RankEstimationAlgo::FixedEps(eps) => calculate_rank_with_fixed_eps(qr, eps),
+        RankEstimationAlgo::ScaledEps(eps) => calculate_rank_with_fixed_eps(
+            qr,
+            eps * T::RealField::from_usize(qr.nrows().max(qr.ncols()))
+                .expect("matrix dimensions out of floating point bounds"),
+        ),
+    }
+}
+
+fn calculate_rank_with_fixed_eps<T, R, C, S>(qr: &Matrix<T, R, C, S>, eps: T::RealField) -> usize
+where
+    T: Scalar + ComplexField + Copy,
+    R: Dim,
+    C: Dim,
+    S: Storage<T, R, C> + RawStorage<T, R, C> + IsContiguous,
+{
+    let eps = eps.abs();
+    let dim = qr.nrows().min(qr.ncols());
+    let mut rank = 0;
+    for j in 0..dim {
+        if qr[(j, j)].abs() >= eps {
+            rank += 1;
+        }
+    }
+    rank
+}

--- a/nalgebra-lapack/src/colpiv_qr/rank.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank.rs
@@ -4,6 +4,7 @@ use na::{Dim, IsContiguous, Matrix, RawStorage, RealField, Scalar, Storage};
 use num::{ConstOne, ToPrimitive};
 use num::{Float, float::TotalOrder};
 
+#[cfg(test)]
 mod test;
 
 /// describes different algorithms of calculating a matrix rank from the upper

--- a/nalgebra-lapack/src/colpiv_qr/rank/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank/test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test_calc_max_diag() {
+    todo!()
+}

--- a/nalgebra-lapack/src/colpiv_qr/rank/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/rank/test.rs
@@ -1,4 +1,27 @@
 #[test]
 fn test_calc_max_diag() {
-    todo!()
+    let a = nalgebra::matrix!
+    [
+        1.,2.,3.;
+        4.,5.,6.;
+        7.,8.,-9.;
+    ];
+    assert_eq!(super::calculate_max_abs_diag(&a), 9.);
+
+    let a = nalgebra::dmatrix!
+    [
+        1.,2.,3.;
+        4.,5.,6.;
+        7.,8.,-9.;
+        11.,12.,13.;
+    ];
+    assert_eq!(super::calculate_max_abs_diag(&a), 9.);
+
+    let a = nalgebra::matrix!
+    [
+        1.,2.,3.,11.;
+        4.,5.,6.,12.;
+        7.,8.,-9.,13.;
+    ];
+    assert_eq!(super::calculate_max_abs_diag(&a), 9.);
 }

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -19,27 +19,27 @@ fn test_rank_determination_for_different_matrices() {
     use super::{ColPivQR, rank::RankEstimationAlgo};
     use nalgebra::{DMatrix, matrix};
 
-    // Test 1: Full rank square matrix (3x3)
+    // Full rank square matrix (3x3)
     let full_rank_square = matrix![
         1.0, 2.0, 3.0;
         4.0, 5.0, 6.0;
-        7.0, 8.0, 10.0  // Changed last element to avoid rank deficiency
+        7.0, 8.0, 10.0
     ];
     let qr = ColPivQR::new(full_rank_square, RankEstimationAlgo::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Full rank 3x3 matrix should have rank 3");
 
-    // Test 2: Rank deficient square matrix (3x3, rank 2)
+    // Rank deficient square matrix (3x3, rank 2)
     let rank_deficient_square = matrix![
         1.0, 0.0, 0.0;
         0.0, 1.0, 0.0;
-        1.0, 1.0, 0.0  // This row is row1 + row2, third column is zero
+        1.0, 1.0, 0.0
     ];
     let qr = ColPivQR::new(rank_deficient_square, RankEstimationAlgo::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x3 matrix should have rank 2");
 
-    // Test 3: Overdetermined system (4x3, full column rank)
+    // Overdetermined system (4x3, full column rank)
     let overdetermined_full_rank = matrix![
         1.0, 0.0, 1.0;
         0.0, 1.0, 1.0;
@@ -54,7 +54,7 @@ fn test_rank_determination_for_different_matrices() {
         "Overdetermined 4x3 matrix should have full column rank 3"
     );
 
-    // Test 4: Overdetermined system with rank deficiency (4x3, rank 2)
+    // Overdetermined system with rank deficiency (4x3, rank 2)
     let overdetermined_rank_deficient = matrix![
         1.0, 0.0, 0.0;
         0.0, 1.0, 0.0;
@@ -65,7 +65,7 @@ fn test_rank_determination_for_different_matrices() {
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 4x3 matrix should have rank 2");
 
-    // Test 5: Underdetermined system (3x4, full row rank)
+    // Underdetermined system (3x4, full row rank)
     let underdetermined_full_rank = matrix![
         1.0, 0.0, 1.0, 2.0;
         0.0, 1.0, 1.0, 3.0;
@@ -79,7 +79,7 @@ fn test_rank_determination_for_different_matrices() {
         "Underdetermined 3x4 matrix should have full row rank 3"
     );
 
-    // Test 6: Underdetermined system with rank deficiency (3x4, rank 2)
+    // Underdetermined system with rank deficiency (3x4, rank 2)
     let underdetermined_rank_deficient = matrix![
         1.0, 0.0, 0.0, 0.0;
         0.0, 1.0, 0.0, 0.0;
@@ -92,7 +92,7 @@ fn test_rank_determination_for_different_matrices() {
     .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x4 matrix should have rank 2");
 
-    // Test 7: Rank 1 matrix (3x3)
+    // Rank 1 matrix (3x3)
     let rank_one = matrix![
         1.0, 2.0, 3.0;
         2.0, 4.0, 6.0;  // 2*row1
@@ -103,7 +103,7 @@ fn test_rank_determination_for_different_matrices() {
     print!("qr = {:?}", qr.qr);
     assert_eq!(qr.rank(), 1, "Rank 1 matrix should have rank 1");
 
-    // Test 8: Near-zero matrix (should have rank 0 with strict tolerance)
+    // zero matrix should have rank 0
     let zero = matrix![
         0., 0., 0.;
         0., 0., 0.;
@@ -117,7 +117,7 @@ fn test_rank_determination_for_different_matrices() {
         "Near-zero matrix should have rank 0 with strict tolerance"
     );
 
-    // Test 9: Dynamic matrix with different rank algorithms
+    // Dynamic matrix with different rank algorithms
     let dynamic_mat = DMatrix::from_row_slice(
         3,
         3,
@@ -128,25 +128,15 @@ fn test_rank_determination_for_different_matrices() {
         ],
     );
 
-    // Test with fixed epsilon
-    let qr_fixed = ColPivQR::new(dynamic_mat.clone(), RankEstimationAlgo::default())
+    let qr = ColPivQR::new(dynamic_mat.clone(), RankEstimationAlgo::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
-        qr_fixed.rank(),
+        qr.rank(),
         2,
         "Dynamic matrix should have rank 2 with fixed eps"
     );
 
-    // Test with scaled epsilon (default)
-    let qr_scaled =
-        ColPivQR::new(dynamic_mat, Default::default()).expect("QR decomposition should succeed");
-    assert_eq!(
-        qr_scaled.rank(),
-        2,
-        "Dynamic matrix should have rank 2 with scaled eps"
-    );
-
-    // Test 10: Identity matrix variants
+    // Identity matrix variants
     let identity_3x3 = matrix![
         1.0, 0.0, 0.0;
         0.0, 1.0, 0.0;
@@ -156,10 +146,10 @@ fn test_rank_determination_for_different_matrices() {
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Identity matrix should have full rank");
 
-    // Test 11: Matrix with very small but non-zero eigenvalues
+    // Matrix with very small but non-zero eigenvalues
     let small_eigenvalue = matrix![
         1.0, 0.0, 0.0;
-        0.0, 1e-5, 0.0;  // Small but above tolerance (1e-6)
+        0.0, 1e-5, 0.0;
         0.0, 0.0, 1.0
     ];
     let qr = ColPivQR::new(small_eigenvalue, RankEstimationAlgo::default())
@@ -169,11 +159,6 @@ fn test_rank_determination_for_different_matrices() {
         3,
         "Matrix with small eigenvalues should have full rank with appropriate tolerance"
     );
-    // Note: We use tolerance 1e-6 rather than machine epsilon because LAPACK's QR
-    // decomposition introduces small numerical perturbations that make theoretically
-    // zero diagonal elements become very small non-zero values (around 1e-6 to 1e-7).
-    // This is expected behavior in numerical linear algebra - "rank deficient" means
-    // "approximately rank deficient within tolerance" rather than exactly zero.
 }
 
 #[test]

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -95,12 +95,35 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_for_rank_deficient() {
 
 #[test]
 fn test_q_multiplication() {
+    let a: Matrix<f32, _, _, _> = nalgebra::matrix!
+    [
+       71.,   37.,   61.,   50.;
+       60.,   78.,   42.,   33.;
+       50.,   31.,   80.,   23.;
+       76.,   85.,   62.,   39.;
+       77.,   57.,   26.,   47.;
+    ];
+
+    let qr = ColPivQr::new(a, Default::default()).unwrap();
+
+    let mut b1 = nalgebra::matrix!
+    [
+       32.,   93.;
+       40.,   92.;
+       42.,   65.;
+       68.,   32.;
+       73.,   30.;
+    ];
+
+    qr.q_tr_mul_mut(&mut b1).unwrap();
+    panic!("b = {:?}", b1);
+
     todo!()
 }
 
 #[test]
 fn test_rank_determination_for_different_matrices() {
-    use super::{ColPivQr, rank::RankEstimationAlgo};
+    use super::{ColPivQr, rank::RankDeterminationAlgorithm};
     use nalgebra::{DMatrix, matrix};
 
     // Full rank square matrix (3x3)
@@ -109,7 +132,8 @@ fn test_rank_determination_for_different_matrices() {
         4.0, 5.0, 6.0;
         7.0, 8.0, 10.0
     ];
-    let qr = ColPivQr::new(full_rank_square, RankEstimationAlgo::default())
+
+    let qr = ColPivQr::new(full_rank_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Full rank 3x3 matrix should have rank 3");
 
@@ -119,7 +143,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         1.0, 1.0, 0.0
     ];
-    let qr = ColPivQr::new(rank_deficient_square, RankEstimationAlgo::default())
+    let qr = ColPivQr::new(rank_deficient_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x3 matrix should have rank 2");
 
@@ -130,8 +154,11 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 1.0, 0.0;
         2.0, 1.0, 1.0
     ];
-    let qr = ColPivQr::new(overdetermined_full_rank, RankEstimationAlgo::default())
-        .expect("QR decomposition should succeed");
+    let qr = ColPivQr::new(
+        overdetermined_full_rank,
+        RankDeterminationAlgorithm::default(),
+    )
+    .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
         3,
@@ -145,8 +172,11 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 0.0, 0.0;  // This row is same as row1
         2.0, 2.0, 0.0   // This row is 2*row1 + 2*row2 = 2*row3 + 2*row2
     ];
-    let qr = ColPivQr::new(overdetermined_rank_deficient, RankEstimationAlgo::default())
-        .expect("QR decomposition should succeed");
+    let qr = ColPivQr::new(
+        overdetermined_rank_deficient,
+        RankDeterminationAlgorithm::default(),
+    )
+    .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 4x3 matrix should have rank 2");
 
     // Underdetermined system (3x4, full row rank)
@@ -155,8 +185,11 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 1.0, 3.0;
         1.0, 1.0, 0.0, 1.0
     ];
-    let qr = ColPivQr::new(underdetermined_full_rank, RankEstimationAlgo::default())
-        .expect("QR decomposition should succeed");
+    let qr = ColPivQr::new(
+        underdetermined_full_rank,
+        RankDeterminationAlgorithm::default(),
+    )
+    .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
         3,
@@ -171,7 +204,7 @@ fn test_rank_determination_for_different_matrices() {
     ];
     let qr = ColPivQr::new(
         underdetermined_rank_deficient,
-        RankEstimationAlgo::default(),
+        RankDeterminationAlgorithm::default(),
     )
     .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x4 matrix should have rank 2");
@@ -182,7 +215,7 @@ fn test_rank_determination_for_different_matrices() {
         2.0, 4.0, 6.0;  // 2*row1
         3.0, 6.0, 9.0   // 3*row1
     ];
-    let qr = ColPivQr::new(rank_one, RankEstimationAlgo::default())
+    let qr = ColPivQr::new(rank_one, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     print!("qr = {:?}", qr.qr);
     assert_eq!(qr.rank(), 1, "Rank 1 matrix should have rank 1");
@@ -193,7 +226,7 @@ fn test_rank_determination_for_different_matrices() {
         0., 0., 0.;
         0., 0., 0.
     ];
-    let qr = ColPivQr::new(zero, RankEstimationAlgo::default())
+    let qr = ColPivQr::new(zero, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -212,7 +245,7 @@ fn test_rank_determination_for_different_matrices() {
         ],
     );
 
-    let qr = ColPivQr::new(dynamic_mat.clone(), RankEstimationAlgo::default())
+    let qr = ColPivQr::new(dynamic_mat.clone(), RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -226,7 +259,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQr::new(identity_3x3, RankEstimationAlgo::default())
+    let qr = ColPivQr::new(identity_3x3, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Identity matrix should have full rank");
 
@@ -236,7 +269,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1e-5, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQr::new(small_eigenvalue, RankEstimationAlgo::default())
+    let qr = ColPivQr::new(small_eigenvalue, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,6 +1,6 @@
 use super::ColPivQr;
 use approx::{assert_abs_diff_eq, assert_relative_eq};
-use na::{ColPivQR, DMatrix, Matrix, OMatrix};
+use na::{Matrix, OMatrix};
 
 #[test]
 fn smoketest_qr_decomposition_for_f32_matrix() {

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,4 +1,5 @@
 use super::ColPivQR;
+use approx::{assert_abs_diff_eq, assert_relative_eq};
 use na::OMatrix;
 
 #[test]
@@ -188,5 +189,5 @@ fn solve_overdetermined_system_with_exact_solution() {
     let b = &a * &x;
     let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
     let x_calc = qr.solve(&b).unwrap();
-    assert_eq!(x_calc, x);
+    assert_abs_diff_eq!(x_calc, x, epsilon = 1e-6);
 }

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -15,7 +15,7 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
 }
 
 #[test]
-fn qr_decomposition_is_logically_correct() {
+fn qr_decomposition_satisfies_ap_eq_qr() {
     let a: OMatrix<f32, _, _> = nalgebra::matrix!
     [  65.,   15.,   69.;
        99.,   44.,   63.;
@@ -28,19 +28,15 @@ fn qr_decomposition_is_logically_correct() {
     assert_eq!(qr.rank(), 3);
     let q = qr.q();
     let r = qr.r();
-    let a_calc = {
-        let mut tmp = q * r;
+    let a_calc = q * r;
+    let a_perm = {
+        let mut tmp = a.clone();
         qr.p().permute_cols_mut(&mut tmp).unwrap();
         tmp
     };
 
-    assert_abs_diff_eq!(a_calc, a, epsilon = 1e-6);
-
-    // let a_calc = qr.q().transpose() * qr.r();
-    // assert_eq!(qr.q(), 2. * qr.q());
-    panic!("r = {:?}", qr.r());
-
-    todo!("waaaah")
+    // A*P == Q*R (within numerical accuracy)
+    assert_abs_diff_eq!(a_calc, a_perm, epsilon = 1e-4);
 }
 
 #[test]

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -207,5 +207,9 @@ fn solve_rank_deficient_overdetermined_system_with() {
     let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 2);
     let x_calc = qr.solve(&b).unwrap();
+    //@note(geo-ant) for rank deficient problems we cannot expect the
+    // original vector x to be reproduced, since the solution is not unique.
+    // That's why we don't compare x and x_calc for equality, but we check
+    // that the matrices A*x and A*x_calc are equal (within numerical accuracy)
     assert_abs_diff_eq!(a * x_calc, a * x, epsilon = 1e-4);
 }

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,4 +1,4 @@
-use super::ColPivQr;
+use super::ColPivQR;
 use approx::{assert_abs_diff_eq, assert_relative_eq};
 use na::{Matrix, OMatrix};
 
@@ -11,7 +11,7 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
      8.,   4.,   9.];
 
     let _ =
-        ColPivQr::new(mat, Default::default()).expect("creating qr decomposition must not fail");
+        ColPivQR::new(mat, Default::default()).expect("creating qr decomposition must not fail");
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_full_rank() {
         1.,   51.,   93.;
     ];
 
-    let qr = ColPivQr::new(a, Default::default()).unwrap();
+    let qr = ColPivQR::new(a, Default::default()).unwrap();
     assert_eq!(qr.rank(), 3);
     let q = qr.q();
     let r = qr.r();
@@ -70,7 +70,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_for_rank_deficient() {
        -130.,  58.,   94.;
 
     ];
-    let qr = ColPivQr::new(a.clone(), Default::default()).unwrap();
+    let qr = ColPivQR::new(a.clone(), Default::default()).unwrap();
     assert_eq!(qr.rank(), 2);
     let r = qr.r();
     let q = qr.q();
@@ -104,7 +104,7 @@ fn test_q_multiplication() {
        99.,   20.,   46.,   76.;
     ];
 
-    let qr = ColPivQr::new(a, Default::default()).unwrap();
+    let qr = ColPivQR::new(a, Default::default()).unwrap();
 
     // from Octave
     let q_full: Matrix<f32, _, _, _> = nalgebra::matrix![
@@ -161,7 +161,7 @@ fn test_q_multiplication() {
 
 #[test]
 fn test_rank_determination_for_different_matrices() {
-    use super::{ColPivQr, rank::RankDeterminationAlgorithm};
+    use super::{ColPivQR, rank::RankDeterminationAlgorithm};
     use nalgebra::{DMatrix, matrix};
 
     // Full rank square matrix (3x3)
@@ -171,7 +171,7 @@ fn test_rank_determination_for_different_matrices() {
         7.0, 8.0, 10.0
     ];
 
-    let qr = ColPivQr::new(full_rank_square, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(full_rank_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Full rank 3x3 matrix should have rank 3");
 
@@ -181,7 +181,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         1.0, 1.0, 0.0
     ];
-    let qr = ColPivQr::new(rank_deficient_square, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(rank_deficient_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x3 matrix should have rank 2");
 
@@ -192,7 +192,7 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 1.0, 0.0;
         2.0, 1.0, 1.0
     ];
-    let qr = ColPivQr::new(
+    let qr = ColPivQR::new(
         overdetermined_full_rank,
         RankDeterminationAlgorithm::default(),
     )
@@ -210,7 +210,7 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 0.0, 0.0;  // This row is same as row1
         2.0, 2.0, 0.0   // This row is 2*row1 + 2*row2 = 2*row3 + 2*row2
     ];
-    let qr = ColPivQr::new(
+    let qr = ColPivQR::new(
         overdetermined_rank_deficient,
         RankDeterminationAlgorithm::default(),
     )
@@ -223,7 +223,7 @@ fn test_rank_determination_for_different_matrices() {
         2.0, 4.0, 6.0;  // 2*row1
         3.0, 6.0, 9.0   // 3*row1
     ];
-    let qr = ColPivQr::new(rank_one, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(rank_one, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     print!("qr = {:?}", qr.qr);
     assert_eq!(qr.rank(), 1, "Rank 1 matrix should have rank 1");
@@ -234,7 +234,7 @@ fn test_rank_determination_for_different_matrices() {
         0., 0., 0.;
         0., 0., 0.
     ];
-    let qr = ColPivQr::new(zero, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(zero, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -253,7 +253,7 @@ fn test_rank_determination_for_different_matrices() {
         ],
     );
 
-    let qr = ColPivQr::new(dynamic_mat.clone(), RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(dynamic_mat.clone(), RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -267,7 +267,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQr::new(identity_3x3, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(identity_3x3, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Identity matrix should have full rank");
 
@@ -277,7 +277,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1e-5, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQr::new(small_eigenvalue, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::new(small_eigenvalue, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -297,7 +297,7 @@ fn solve_full_rank_overdetermined_system_with_single_rhs() {
     let x = nalgebra::vector![8., 6., 2.];
 
     let b = &a * &x;
-    let qr = ColPivQr::new(a, Default::default()).expect("qr decomposition must not fail");
+    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 3);
     let x_calc = qr.solve(&b).unwrap();
     assert_abs_diff_eq!(x_calc, x, epsilon = 1e-6);
@@ -314,7 +314,7 @@ fn solve_rank_deficient_overdetermined_system_with_single_rhs() {
     let x = nalgebra::vector![8., 6., 2.];
 
     let b = &a * &x;
-    let qr = ColPivQr::new(a, Default::default()).expect("qr decomposition must not fail");
+    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 2);
     let x_calc = qr.solve(&b).unwrap();
     //@note(geo-ant) for rank deficient problems we cannot expect the

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -31,7 +31,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_full_rank() {
     let a_calc = &q * &r;
     let a_perm = {
         let mut tmp = a.clone();
-        qr.p().permute_cols_mut(&mut tmp).unwrap();
+        qr.p().inv_permute_cols_mut(&mut tmp).unwrap();
         tmp
     };
 
@@ -86,7 +86,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_for_rank_deficient() {
 
     let a_perm = {
         let mut tmp = a.clone();
-        qr.p().permute_cols_mut(&mut tmp).unwrap();
+        qr.p().inv_permute_cols_mut(&mut tmp).unwrap();
         tmp
     };
     // check AP == QR

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -177,7 +177,7 @@ fn test_rank_determination_for_different_matrices() {
 }
 
 #[test]
-fn solve_overdetermined_system_with_exact_solution() {
+fn solve_full_rank_overdetermined_system_with() {
     let a = nalgebra::matrix![
        0f32,   2.,   1.;
        6.,   4.,   3.;
@@ -188,6 +188,24 @@ fn solve_overdetermined_system_with_exact_solution() {
 
     let b = &a * &x;
     let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
+    assert_eq!(qr.rank(), 3);
     let x_calc = qr.solve(&b).unwrap();
     assert_abs_diff_eq!(x_calc, x, epsilon = 1e-6);
+}
+
+#[test]
+fn solve_rank_deficient_overdetermined_system_with() {
+    let a = nalgebra::matrix![
+     8.,    2.,    1.;
+    14.,    4.,    3.;
+     5.,    3.,    5.;
+    29.,    9.,    8.;
+    ];
+    let x = nalgebra::vector![8., 6., 2.];
+
+    let b = &a * &x;
+    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
+    assert_eq!(qr.rank(), 2);
+    let x_calc = qr.solve(&b).unwrap();
+    assert_abs_diff_eq!(a * x_calc, a * x, epsilon = 1e-4);
 }

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -183,7 +183,7 @@ fn solve_overdetermined_system_with_exact_solution() {
        6.,   3.,   5.;
        5.,   9.,   8.;
     ];
-    let x = nalgebra::vector![5., 3., 7.];
+    let x = nalgebra::vector![8., 6., 2.];
 
     let b = &a * &x;
     let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -8,5 +8,168 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
      9.,   3.,   1.;
      8.,   4.,   9.];
 
-    let _ = super::ColPivQR::new(mat, 1e-10).expect("creating qr decomposition must not fail");
+    let _ = super::ColPivQR::new(mat, Default::default())
+        .expect("creating qr decomposition must not fail");
+}
+
+#[test]
+fn test_rank_determination_for_different_matrices() {
+    use super::{ColPivQR, rank::RankEstimationAlgo};
+    use nalgebra::{DMatrix, matrix};
+
+    // Test 1: Full rank square matrix (3x3)
+    let full_rank_square = matrix![
+        1.0, 2.0, 3.0;
+        4.0, 5.0, 6.0;
+        7.0, 8.0, 10.0  // Changed last element to avoid rank deficiency
+    ];
+    let qr = ColPivQR::new(full_rank_square, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(qr.rank(), 3, "Full rank 3x3 matrix should have rank 3");
+
+    // Test 2: Rank deficient square matrix (3x3, rank 2)
+    let rank_deficient_square = matrix![
+        1.0, 0.0, 0.0;
+        0.0, 1.0, 0.0;
+        1.0, 1.0, 0.0  // This row is row1 + row2, third column is zero
+    ];
+    let qr = ColPivQR::new(rank_deficient_square, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(qr.rank(), 2, "Rank deficient 3x3 matrix should have rank 2");
+
+    // Test 3: Overdetermined system (4x3, full column rank)
+    let overdetermined_full_rank = matrix![
+        1.0, 0.0, 1.0;
+        0.0, 1.0, 1.0;
+        1.0, 1.0, 0.0;
+        2.0, 1.0, 1.0
+    ];
+    let qr = ColPivQR::new(overdetermined_full_rank, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(
+        qr.rank(),
+        3,
+        "Overdetermined 4x3 matrix should have full column rank 3"
+    );
+
+    // Test 4: Overdetermined system with rank deficiency (4x3, rank 2)
+    let overdetermined_rank_deficient = matrix![
+        1.0, 0.0, 0.0;
+        0.0, 1.0, 0.0;
+        1.0, 0.0, 0.0;  // This row is same as row1
+        2.0, 2.0, 0.0   // This row is 2*row1 + 2*row2 = 2*row3 + 2*row2
+    ];
+    let qr = ColPivQR::new(overdetermined_rank_deficient, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(qr.rank(), 2, "Rank deficient 4x3 matrix should have rank 2");
+
+    // Test 5: Underdetermined system (3x4, full row rank)
+    let underdetermined_full_rank = matrix![
+        1.0, 0.0, 1.0, 2.0;
+        0.0, 1.0, 1.0, 3.0;
+        1.0, 1.0, 0.0, 1.0
+    ];
+    let qr = ColPivQR::new(underdetermined_full_rank, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(
+        qr.rank(),
+        3,
+        "Underdetermined 3x4 matrix should have full row rank 3"
+    );
+
+    // Test 6: Underdetermined system with rank deficiency (3x4, rank 2)
+    let underdetermined_rank_deficient = matrix![
+        1.0, 0.0, 0.0, 0.0;
+        0.0, 1.0, 0.0, 0.0;
+        1.0, 1.0, 0.0, 0.0  // This row is row1 + row2
+    ];
+    let qr = ColPivQR::new(
+        underdetermined_rank_deficient,
+        RankEstimationAlgo::default(),
+    )
+    .expect("QR decomposition should succeed");
+    assert_eq!(qr.rank(), 2, "Rank deficient 3x4 matrix should have rank 2");
+
+    // Test 7: Rank 1 matrix (3x3)
+    let rank_one = matrix![
+        1.0, 2.0, 3.0;
+        2.0, 4.0, 6.0;  // 2*row1
+        3.0, 6.0, 9.0   // 3*row1
+    ];
+    let qr = ColPivQR::new(rank_one, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    print!("qr = {:?}", qr.qr);
+    assert_eq!(qr.rank(), 1, "Rank 1 matrix should have rank 1");
+
+    // Test 8: Near-zero matrix (should have rank 0 with strict tolerance)
+    let zero = matrix![
+        0., 0., 0.;
+        0., 0., 0.;
+        0., 0., 0.
+    ];
+    let qr = ColPivQR::new(zero, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(
+        qr.rank(),
+        0,
+        "Near-zero matrix should have rank 0 with strict tolerance"
+    );
+
+    // Test 9: Dynamic matrix with different rank algorithms
+    let dynamic_mat = DMatrix::from_row_slice(
+        3,
+        3,
+        &[
+            1.0, 0.0, 0.0, // row 1
+            0.0, 1.0, 0.0, // row 2
+            2.0, 3.0, 0.0, // row 3: This row is 2*row1 + 3*row2
+        ],
+    );
+
+    // Test with fixed epsilon
+    let qr_fixed = ColPivQR::new(dynamic_mat.clone(), RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(
+        qr_fixed.rank(),
+        2,
+        "Dynamic matrix should have rank 2 with fixed eps"
+    );
+
+    // Test with scaled epsilon (default)
+    let qr_scaled =
+        ColPivQR::new(dynamic_mat, Default::default()).expect("QR decomposition should succeed");
+    assert_eq!(
+        qr_scaled.rank(),
+        2,
+        "Dynamic matrix should have rank 2 with scaled eps"
+    );
+
+    // Test 10: Identity matrix variants
+    let identity_3x3 = matrix![
+        1.0, 0.0, 0.0;
+        0.0, 1.0, 0.0;
+        0.0, 0.0, 1.0
+    ];
+    let qr = ColPivQR::new(identity_3x3, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(qr.rank(), 3, "Identity matrix should have full rank");
+
+    // Test 11: Matrix with very small but non-zero eigenvalues
+    let small_eigenvalue = matrix![
+        1.0, 0.0, 0.0;
+        0.0, 1e-5, 0.0;  // Small but above tolerance (1e-6)
+        0.0, 0.0, 1.0
+    ];
+    let qr = ColPivQR::new(small_eigenvalue, RankEstimationAlgo::default())
+        .expect("QR decomposition should succeed");
+    assert_eq!(
+        qr.rank(),
+        3,
+        "Matrix with small eigenvalues should have full rank with appropriate tolerance"
+    );
+    // Note: We use tolerance 1e-6 rather than machine epsilon because LAPACK's QR
+    // decomposition introduces small numerical perturbations that make theoretically
+    // zero diagonal elements become very small non-zero values (around 1e-6 to 1e-7).
+    // This is expected behavior in numerical linear algebra - "rank deficient" means
+    // "approximately rank deficient within tolerance" rather than exactly zero.
 }

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -10,8 +10,8 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
      9.,   3.,   1.;
      8.,   4.,   9.];
 
-    let _ =
-        ColPivQR::new(mat, Default::default()).expect("creating qr decomposition must not fail");
+    let _ = ColPivQR::with_rank_algo(mat, Default::default())
+        .expect("creating qr decomposition must not fail");
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_full_rank() {
         1.,   51.,   93.;
     ];
 
-    let qr = ColPivQR::new(a, Default::default()).unwrap();
+    let qr = ColPivQR::with_rank_algo(a, Default::default()).unwrap();
     assert_eq!(qr.rank(), 3);
     let q = qr.q();
     let r = qr.r();
@@ -70,7 +70,7 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_for_rank_deficient() {
        -130.,  58.,   94.;
 
     ];
-    let qr = ColPivQR::new(a.clone(), Default::default()).unwrap();
+    let qr = ColPivQR::with_rank_algo(a.clone(), Default::default()).unwrap();
     assert_eq!(qr.rank(), 2);
     let r = qr.r();
     let q = qr.q();
@@ -104,7 +104,7 @@ fn test_q_multiplication() {
        99.,   20.,   46.,   76.;
     ];
 
-    let qr = ColPivQR::new(a, Default::default()).unwrap();
+    let qr = ColPivQR::with_rank_algo(a, Default::default()).unwrap();
 
     // from Octave
     let q_full: Matrix<f32, _, _, _> = nalgebra::matrix![
@@ -171,7 +171,7 @@ fn test_rank_determination_for_different_matrices() {
         7.0, 8.0, 10.0
     ];
 
-    let qr = ColPivQR::new(full_rank_square, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(full_rank_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Full rank 3x3 matrix should have rank 3");
 
@@ -181,7 +181,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         1.0, 1.0, 0.0
     ];
-    let qr = ColPivQR::new(rank_deficient_square, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(rank_deficient_square, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 3x3 matrix should have rank 2");
 
@@ -192,7 +192,7 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 1.0, 0.0;
         2.0, 1.0, 1.0
     ];
-    let qr = ColPivQR::new(
+    let qr = ColPivQR::with_rank_algo(
         overdetermined_full_rank,
         RankDeterminationAlgorithm::default(),
     )
@@ -210,7 +210,7 @@ fn test_rank_determination_for_different_matrices() {
         1.0, 0.0, 0.0;  // This row is same as row1
         2.0, 2.0, 0.0   // This row is 2*row1 + 2*row2 = 2*row3 + 2*row2
     ];
-    let qr = ColPivQR::new(
+    let qr = ColPivQR::with_rank_algo(
         overdetermined_rank_deficient,
         RankDeterminationAlgorithm::default(),
     )
@@ -223,7 +223,7 @@ fn test_rank_determination_for_different_matrices() {
         2.0, 4.0, 6.0;  // 2*row1
         3.0, 6.0, 9.0   // 3*row1
     ];
-    let qr = ColPivQR::new(rank_one, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(rank_one, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     print!("qr = {:?}", qr.qr);
     assert_eq!(qr.rank(), 1, "Rank 1 matrix should have rank 1");
@@ -234,7 +234,7 @@ fn test_rank_determination_for_different_matrices() {
         0., 0., 0.;
         0., 0., 0.
     ];
-    let qr = ColPivQR::new(zero, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(zero, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -253,7 +253,7 @@ fn test_rank_determination_for_different_matrices() {
         ],
     );
 
-    let qr = ColPivQR::new(dynamic_mat.clone(), RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(dynamic_mat.clone(), RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -267,7 +267,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1.0, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQR::new(identity_3x3, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(identity_3x3, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 3, "Identity matrix should have full rank");
 
@@ -277,7 +277,7 @@ fn test_rank_determination_for_different_matrices() {
         0.0, 1e-5, 0.0;
         0.0, 0.0, 1.0
     ];
-    let qr = ColPivQR::new(small_eigenvalue, RankDeterminationAlgorithm::default())
+    let qr = ColPivQR::with_rank_algo(small_eigenvalue, RankDeterminationAlgorithm::default())
         .expect("QR decomposition should succeed");
     assert_eq!(
         qr.rank(),
@@ -297,7 +297,8 @@ fn solve_full_rank_overdetermined_system_with_single_rhs() {
     let x = nalgebra::vector![8., 6., 2.];
 
     let b = &a * &x;
-    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
+    let qr =
+        ColPivQR::with_rank_algo(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 3);
     let x_calc = qr.solve(&b).unwrap();
     assert_abs_diff_eq!(x_calc, x, epsilon = 1e-6);
@@ -314,7 +315,8 @@ fn solve_rank_deficient_overdetermined_system_with_single_rhs() {
     let x = nalgebra::vector![8., 6., 2.];
 
     let b = &a * &x;
-    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
+    let qr =
+        ColPivQR::with_rank_algo(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 2);
     let x_calc = qr.solve(&b).unwrap();
     //@note(geo-ant) for rank deficient problems we cannot expect the

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,5 +1,5 @@
 use super::ColPivQR;
-use approx::{assert_abs_diff_eq, assert_relative_eq};
+use approx::assert_abs_diff_eq;
 use na::OMatrix;
 
 #[test]
@@ -12,6 +12,40 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
 
     let _ =
         ColPivQR::new(mat, Default::default()).expect("creating qr decomposition must not fail");
+}
+
+#[test]
+fn qr_decomposition_is_logically_correct() {
+    let a: OMatrix<f32, _, _> = nalgebra::matrix!
+    [  65.,   15.,   69.;
+       99.,   44.,   63.;
+       28.,   50.,   76.;
+       99.,   45.,   39.;
+        1.,   51.,   93.;
+    ];
+
+    let qr = ColPivQR::new(a, Default::default()).unwrap();
+    assert_eq!(qr.rank(), 3);
+    let q = qr.q();
+    let r = qr.r();
+    let a_calc = {
+        let mut tmp = q * r;
+        qr.p().permute_cols_mut(&mut tmp).unwrap();
+        tmp
+    };
+
+    assert_abs_diff_eq!(a_calc, a, epsilon = 1e-6);
+
+    // let a_calc = qr.q().transpose() * qr.r();
+    // assert_eq!(qr.q(), 2. * qr.q());
+    panic!("r = {:?}", qr.r());
+
+    todo!("waaaah")
+}
+
+#[test]
+fn test_q_multiplication() {
+    todo!()
 }
 
 #[test]
@@ -162,7 +196,7 @@ fn test_rank_determination_for_different_matrices() {
 }
 
 #[test]
-fn solve_full_rank_overdetermined_system_with() {
+fn solve_full_rank_overdetermined_system_with_single_rhs() {
     let a = nalgebra::matrix![
        0f32,   2.,   1.;
        6.,   4.,   3.;
@@ -179,7 +213,7 @@ fn solve_full_rank_overdetermined_system_with() {
 }
 
 #[test]
-fn solve_rank_deficient_overdetermined_system_with() {
+fn solve_rank_deficient_overdetermined_system_with_single_rhs() {
     let a = nalgebra::matrix![
      8.,    2.,    1.;
     14.,    4.,    3.;

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -300,7 +300,7 @@ fn solve_full_rank_overdetermined_system_with_single_rhs() {
     let qr =
         ColPivQR::with_rank_algo(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 3);
-    let x_calc = qr.solve(&b).unwrap();
+    let x_calc = qr.solve(b).unwrap();
     assert_abs_diff_eq!(x_calc, x, epsilon = 1e-6);
 }
 
@@ -318,7 +318,7 @@ fn solve_rank_deficient_overdetermined_system_with_single_rhs() {
     let qr =
         ColPivQR::with_rank_algo(a, Default::default()).expect("qr decomposition must not fail");
     assert_eq!(qr.rank(), 2);
-    let x_calc = qr.solve(&b).unwrap();
+    let x_calc = qr.solve(b).unwrap();
     //@note(geo-ant) for rank deficient problems we cannot expect the
     // original vector x to be reproduced, since the solution is not unique.
     // That's why we don't compare x and x_calc for equality, but we check

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,0 +1,12 @@
+use na::OMatrix;
+
+#[test]
+fn smoketest_qr_decomposition_for_f32_matrix() {
+    let mat: OMatrix<f32, _, _> = nalgebra::matrix!
+    [0.,   8.,   1.;
+     4.,   5.,   4.;
+     9.,   3.,   1.;
+     8.,   4.,   9.];
+
+    let _ = super::ColPivQR::new(mat, 1e-10).expect("creating qr decomposition must not fail");
+}

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -157,7 +157,6 @@ fn test_q_multiplication() {
     };
 
     assert_abs_diff_eq!(q_tr_mul_b, b * q_full.transpose(), epsilon = 1e-4);
-    todo!("waaaaah")
 }
 
 #[test]
@@ -217,36 +216,6 @@ fn test_rank_determination_for_different_matrices() {
     )
     .expect("QR decomposition should succeed");
     assert_eq!(qr.rank(), 2, "Rank deficient 4x3 matrix should have rank 2");
-
-    // Underdetermined system (3x4, full row rank)
-    let underdetermined_full_rank = matrix![
-        1.0, 0.0, 1.0, 2.0;
-        0.0, 1.0, 1.0, 3.0;
-        1.0, 1.0, 0.0, 1.0
-    ];
-    let qr = ColPivQr::new(
-        underdetermined_full_rank,
-        RankDeterminationAlgorithm::default(),
-    )
-    .expect("QR decomposition should succeed");
-    assert_eq!(
-        qr.rank(),
-        3,
-        "Underdetermined 3x4 matrix should have full row rank 3"
-    );
-
-    // Underdetermined system with rank deficiency (3x4, rank 2)
-    let underdetermined_rank_deficient = matrix![
-        1.0, 0.0, 0.0, 0.0;
-        0.0, 1.0, 0.0, 0.0;
-        1.0, 1.0, 0.0, 0.0  // This row is row1 + row2
-    ];
-    let qr = ColPivQr::new(
-        underdetermined_rank_deficient,
-        RankDeterminationAlgorithm::default(),
-    )
-    .expect("QR decomposition should succeed");
-    assert_eq!(qr.rank(), 2, "Rank deficient 3x4 matrix should have rank 2");
 
     // Rank 1 matrix (3x3)
     let rank_one = matrix![

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -97,16 +97,25 @@ fn qr_decomposition_satisfies_ap_eq_qr_for_for_rank_deficient() {
 fn test_q_multiplication() {
     let a: Matrix<f32, _, _, _> = nalgebra::matrix!
     [
-       71.,   37.,   61.,   50.;
-       60.,   78.,   42.,   33.;
-       50.,   31.,   80.,   23.;
-       76.,   85.,   62.,   39.;
-       77.,   57.,   26.,   47.;
+       29.,    0.,   80.,   10.;
+       43.,   95.,   99.,   20.;
+       49.,   44.,   65.,   51.;
+       45.,   21.,   18.,   90.;
+       99.,   20.,   46.,   76.;
     ];
 
     let qr = ColPivQr::new(a, Default::default()).unwrap();
 
-    let mut b1 = nalgebra::matrix!
+    // from Octave
+    let q_full: Matrix<f32, _, _, _> = nalgebra::matrix![
+        -0.52904777,  -0.27274187,  0.74369079, -0.23345502,  0.19530256;
+        -0.65469661,  -0.26635373, -0.63457098,  0.03340311,  0.31085678;
+        -0.42985131,   0.17855078, -0.06487111, -0.16634077, -0.86687367;
+        -0.11903575,   0.75760623, -0.06473310, -0.54939070,  0.32533487;
+        -0.30420247,   0.49881860,  0.18932786,  0.78414513,  0.08895075;
+    ];
+
+    let b = nalgebra::matrix!
     [
        32.,   93.;
        40.,   92.;
@@ -115,10 +124,40 @@ fn test_q_multiplication() {
        73.,   30.;
     ];
 
-    qr.q_tr_mul_mut(&mut b1).unwrap();
-    panic!("b = {:?}", b1);
+    let q_mul_b = {
+        let mut tmp = b.clone();
+        qr.q_mul_mut(&mut tmp).unwrap();
+        tmp
+    };
 
-    todo!()
+    assert_abs_diff_eq!(q_mul_b, q_full * b, epsilon = 1e-4);
+
+    let q_tr_mul_b = {
+        let mut tmp = b.clone();
+        qr.q_tr_mul_mut(&mut tmp).unwrap();
+        tmp
+    };
+
+    assert_abs_diff_eq!(q_tr_mul_b, q_full.transpose() * b, epsilon = 1e-4);
+
+    let b = b.transpose();
+
+    let q_mul_b = {
+        let mut tmp = b.clone();
+        qr.mul_q_mut(&mut tmp).unwrap();
+        tmp
+    };
+
+    assert_abs_diff_eq!(q_mul_b, b * q_full, epsilon = 1e-4);
+
+    let q_tr_mul_b = {
+        let mut tmp = b.clone();
+        qr.mul_q_tr_mut(&mut tmp).unwrap();
+        tmp
+    };
+
+    assert_abs_diff_eq!(q_tr_mul_b, b * q_full.transpose(), epsilon = 1e-4);
+    todo!("waaaaah")
 }
 
 #[test]

--- a/nalgebra-lapack/src/colpiv_qr/test.rs
+++ b/nalgebra-lapack/src/colpiv_qr/test.rs
@@ -1,3 +1,4 @@
+use super::ColPivQR;
 use na::OMatrix;
 
 #[test]
@@ -8,8 +9,8 @@ fn smoketest_qr_decomposition_for_f32_matrix() {
      9.,   3.,   1.;
      8.,   4.,   9.];
 
-    let _ = super::ColPivQR::new(mat, Default::default())
-        .expect("creating qr decomposition must not fail");
+    let _ =
+        ColPivQR::new(mat, Default::default()).expect("creating qr decomposition must not fail");
 }
 
 #[test]
@@ -172,4 +173,20 @@ fn test_rank_determination_for_different_matrices() {
     // zero diagonal elements become very small non-zero values (around 1e-6 to 1e-7).
     // This is expected behavior in numerical linear algebra - "rank deficient" means
     // "approximately rank deficient within tolerance" rather than exactly zero.
+}
+
+#[test]
+fn solve_overdetermined_system_with_exact_solution() {
+    let a = nalgebra::matrix![
+       0f32,   2.,   1.;
+       6.,   4.,   3.;
+       6.,   3.,   5.;
+       5.,   9.,   8.;
+    ];
+    let x = nalgebra::vector![5., 3., 7.];
+
+    let b = &a * &x;
+    let qr = ColPivQR::new(a, Default::default()).expect("qr decomposition must not fail");
+    let x_calc = qr.solve(&b).unwrap();
+    assert_eq!(x_calc, x);
 }

--- a/nalgebra-lapack/src/colpiv_qr/utility.rs
+++ b/nalgebra-lapack/src/colpiv_qr/utility.rs
@@ -1,0 +1,9 @@
+use super::Side;
+impl Side {
+    pub(crate) fn into_lapack_side_character(self) -> u8 {
+        match self {
+            Side::Left => b'L',
+            Side::Right => b'R',
+        }
+    }
+}

--- a/nalgebra-lapack/src/colpiv_qr/utility.rs
+++ b/nalgebra-lapack/src/colpiv_qr/utility.rs
@@ -1,9 +1,30 @@
+use super::DiagonalKind;
 use super::Side;
+use super::TriangularStructure;
+
 impl Side {
     pub(crate) fn into_lapack_side_character(self) -> u8 {
         match self {
             Side::Left => b'L',
             Side::Right => b'R',
+        }
+    }
+}
+
+impl TriangularStructure {
+    pub(crate) fn into_lapack_uplo_character(self) -> u8 {
+        match self {
+            Self::Upper => b'U',
+            Self::Lower => b'L',
+        }
+    }
+}
+
+impl DiagonalKind {
+    pub(crate) fn into_lapack_diag_character(self) -> u8 {
+        match self {
+            DiagonalKind::Unit => b'N',
+            DiagonalKind::NonUnit => b'U',
         }
     }
 }

--- a/nalgebra-lapack/src/colpiv_qr/utility.rs
+++ b/nalgebra-lapack/src/colpiv_qr/utility.rs
@@ -23,8 +23,8 @@ impl TriangularStructure {
 impl DiagonalKind {
     pub(crate) fn into_lapack_diag_character(self) -> u8 {
         match self {
-            DiagonalKind::Unit => b'N',
-            DiagonalKind::NonUnit => b'U',
+            DiagonalKind::Unit => b'U',
+            DiagonalKind::NonUnit => b'N',
         }
     }
 }

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -96,7 +96,7 @@ mod symmetric_eigen;
 use num_complex::Complex;
 
 pub use self::cholesky::{Cholesky, CholeskyScalar};
-pub use self::colpiv_qr::{ColPivQr, Side, Transposition};
+pub use self::colpiv_qr::{ColPivQR, Side, Transposition};
 pub use self::eigen::Eigen;
 pub use self::generalized_eigenvalues::GeneralizedEigen;
 pub use self::hessenberg::Hessenberg;

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -82,6 +82,7 @@ extern crate num_traits as num;
 mod lapack_check;
 
 mod cholesky;
+/// column-pivoted QR decomposition of a rectangular (or square) matrix
 mod colpiv_qr;
 mod eigen;
 mod generalized_eigenvalues;
@@ -96,7 +97,7 @@ mod symmetric_eigen;
 use num_complex::Complex;
 
 pub use self::cholesky::{Cholesky, CholeskyScalar};
-pub use self::colpiv_qr::{ColPivQR, Side, Transposition};
+pub use self::colpiv_qr::{ColPivQR, Side, Transposition, error::Error as ColPivQrError};
 pub use self::eigen::Eigen;
 pub use self::generalized_eigenvalues::GeneralizedEigen;
 pub use self::hessenberg::Hessenberg;

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -83,7 +83,7 @@ mod lapack_check;
 
 mod cholesky;
 /// column-pivoted QR decomposition of a rectangular (or square) matrix
-mod colpiv_qr;
+pub mod colpiv_qr;
 mod eigen;
 mod generalized_eigenvalues;
 mod hessenberg;

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -96,7 +96,7 @@ mod symmetric_eigen;
 use num_complex::Complex;
 
 pub use self::cholesky::{Cholesky, CholeskyScalar};
-pub use self::colpiv_qr::{ColPivQR, Side, Transposition};
+pub use self::colpiv_qr::{ColPivQr, Side, Transposition};
 pub use self::eigen::Eigen;
 pub use self::generalized_eigenvalues::GeneralizedEigen;
 pub use self::hessenberg::Hessenberg;

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -96,6 +96,7 @@ mod symmetric_eigen;
 use num_complex::Complex;
 
 pub use self::cholesky::{Cholesky, CholeskyScalar};
+pub use self::colpiv_qr::{ColPivQR, Side, Transposition};
 pub use self::eigen::Eigen;
 pub use self::generalized_eigenvalues::GeneralizedEigen;
 pub use self::hessenberg::Hessenberg;

--- a/nalgebra-lapack/src/lib.rs
+++ b/nalgebra-lapack/src/lib.rs
@@ -82,6 +82,7 @@ extern crate num_traits as num;
 mod lapack_check;
 
 mod cholesky;
+mod colpiv_qr;
 mod eigen;
 mod generalized_eigenvalues;
 mod hessenberg;

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -1,5 +1,5 @@
 use crate::proptest::*;
-use na::{DMatrix, Dim, Dyn, Matrix, Matrix3x2, OMatrix, RawStorage};
+use na::{DMatrix, Dim, Matrix, OMatrix, RawStorage};
 use nl::ColPivQR;
 use num_traits::Zero;
 use proptest::prelude::*;

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -17,9 +17,9 @@ proptest! {
         let qtq = q.transpose()*&q;
         let eye = DMatrix::identity(qtq.nrows(),qtq.ncols());
         prop_assert!(relative_eq!(qtq, eye, epsilon = 1.0e-7));
-        // prop_assert!
         // this tests A P = Q R
-        qr.p().permute_cols_mut(&mut a).unwrap();
+        // by checking A = Q R P^-1
+        qr.p().inv_permute_cols_mut(&mut a).unwrap();
         prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7));
     }
 
@@ -36,25 +36,23 @@ proptest! {
         prop_assert!(relative_eq!(qtq, eye, epsilon = 1.0e-7));
 
         // this tests A P = Q R
-        qr.p().permute_cols_mut(&mut a).unwrap();
+        // by checking A = Q R P^-1
+        qr.p().inv_permute_cols_mut(&mut a).unwrap();
         prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7));
     }
 
     #[test]
-    fn colpiv_qr_solve_static(a in matrix5x3(), b in vector5()) {
+    fn colpiv_qr_solve_static(a in matrix5x3(), b in matrix5x2()) {
         let rank = a.rank(f64::EPSILON.sqrt());
         let qr = ColPivQR::new(a.clone()).unwrap();
         let result = qr.solve(&b);
         match result {
             Ok(x) => {
-                let req=relative_eq!(a.transpose()*a*x,a.transpose()*b,epsilon = 1e-5);
-                if !req {
-                    println!("a = {:?}",a);
-                    println!("x = {:?}",x);
-                    println!("b = {:?}",b);
-                    println!("a*x = {:?}",a*x);
-                }
-                prop_assert!(req);
+                //@note(geo-ant) We can't just test A*x = b, since that is
+                // not what the QR solution guarantees. It guarantees a minimum
+                // residual solution, which means the normal equations must
+                // hold. That means we can assert on A^T A * X = A^T *B
+                prop_assert!(relative_eq!(a.transpose()*a*x,a.transpose()*b,epsilon = 1e-5));
             },
             Err(err) => {
                 prop_assert!(rank == 0);

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -84,7 +84,7 @@ proptest! {
     fn colpiv_qr_solve_static(a in matrix5x3(), b in matrix5x2()) {
         let rank = a.rank(f64::EPSILON.sqrt());
         let qr = ColPivQR::new(a.clone()).unwrap();
-        let result = qr.solve(&b);
+        let result = qr.solve(b.clone());
         match result {
             Ok(x) => {
                 //@note(geo-ant) We can't just test A*x = b, since that is
@@ -104,7 +104,7 @@ proptest! {
     fn colpiv_qr_solve((a,b) in linear_system_dynamic()) {
         let rank = a.rank(f64::EPSILON.sqrt());
         let qr = ColPivQR::new(a.clone()).unwrap();
-        let result = qr.solve(&b);
+        let result = qr.solve(b.clone());
         match result {
             Ok(x) => {
                 //@note(geo-ant) We can't just test A*x = b, since that is

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -1,4 +1,27 @@
-#[test]
-fn proptest_stuff() {
-    todo!("add proptests here")
+use crate::proptest::*;
+use nl::ColPivQR;
+use proptest::{prop_assert, proptest};
+
+proptest! {
+    #[test]
+    fn colpiv_qr_decomposition(mut a  in square_or_overdetermined_dmatrix()) {
+        let qr = ColPivQR::new(a.clone()).unwrap();
+        let q  = qr.q();
+        let r  = qr.r();
+
+        qr.p().permute_cols_mut(&mut a).unwrap();
+
+        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7))
+    }
+
+    #[test]
+    fn colpiv_qr_decomposition_static(mut a  in matrix5x3()) {
+        let qr = ColPivQR::new(a.clone()).unwrap();
+        let q  = qr.q();
+        let r  = qr.r();
+
+        qr.p().permute_cols_mut(&mut a).unwrap();
+
+        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7))
+        }
 }

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -1,4 +1,5 @@
 use crate::proptest::*;
+use na::{DMatrix, OMatrix};
 use nl::ColPivQR;
 use proptest::{prop_assert, proptest};
 
@@ -9,9 +10,17 @@ proptest! {
         let q  = qr.q();
         let r  = qr.r();
 
+        // this tests Q^T Q = Id
+        // note that Q*Q^T is typically not the identity matrix
+        // since Q is the economy QR decomposition and
+        // this calculates orthonormal Q in R^(m x n)
+        let qtq = q.transpose()*&q;
+        let eye = DMatrix::identity(qtq.nrows(),qtq.ncols());
+        prop_assert!(relative_eq!(qtq, eye, epsilon = 1.0e-7));
+        // prop_assert!
+        // this tests A P = Q R
         qr.p().permute_cols_mut(&mut a).unwrap();
-
-        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7))
+        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7));
     }
 
     #[test]
@@ -20,8 +29,23 @@ proptest! {
         let q  = qr.q();
         let r  = qr.r();
 
-        qr.p().permute_cols_mut(&mut a).unwrap();
+        // this tests Q^T Q = Id
+        let qtq = q.transpose()*&q;
+        let (nrows, ncols) = qtq.shape_generic();
+        let eye = OMatrix::identity_generic(nrows,ncols);
+        prop_assert!(relative_eq!(qtq, eye, epsilon = 1.0e-7));
 
-        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7))
+        // this tests A P = Q R
+        qr.p().permute_cols_mut(&mut a).unwrap();
+        prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7));
     }
+
+    //@todo(geo-ant)
+    // test solve both static and dynamic
+    #[test]
+    fn colpiv_qr_solve() {
+        todo!()
+
+    }
+
 }

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -1,0 +1,4 @@
+#[test]
+fn proptest_stuff() {
+    todo!("add proptests here")
+}

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -1,7 +1,42 @@
 use crate::proptest::*;
-use na::{DMatrix, Dyn, Matrix3x2, OMatrix};
+use na::{DMatrix, Dim, Dyn, Matrix, Matrix3x2, OMatrix, RawStorage};
 use nl::ColPivQR;
+use num_traits::Zero;
 use proptest::prelude::*;
+
+fn is_upper_triangular<T, R, C, S>(mat: &Matrix<T, R, C, S>) -> bool
+where
+    T: Zero + PartialEq,
+    C: Dim,
+    R: Dim,
+    S: RawStorage<T, R, C>,
+{
+    let ncols = mat.ncols();
+    let nrows = mat.nrows();
+
+    let zero = T::zero();
+    for c in 0..ncols {
+        for r in c + 1..nrows {
+            if mat[(r, c)] != zero {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+fn square_or_overdetermined_dmatrix() -> impl Strategy<Value = DMatrix<f64>> {
+    PROPTEST_MATRIX_DIM.prop_flat_map(|rows| {
+        (1..=rows).prop_flat_map(move |cols| matrix(PROPTEST_F64, rows..=rows, cols..=cols))
+    })
+}
+
+fn linear_system_dynamic() -> impl Strategy<Value = (DMatrix<f64>, DMatrix<f64>)> {
+    square_or_overdetermined_dmatrix().prop_flat_map(|a| {
+        let b = matrix(PROPTEST_F64, a.nrows(), PROPTEST_MATRIX_DIM);
+        (Just(a), b)
+    })
+}
 
 proptest! {
     #[test]
@@ -10,8 +45,10 @@ proptest! {
         let q  = qr.q();
         let r  = qr.r();
 
+        prop_assert!(is_upper_triangular(&r));
+
         // this tests Q^T Q = Id
-        // note that Q*Q^T is typically not the identity matrix
+        // @note(geo-ant) that Q*Q^T is typically not the identity matrix
         // since Q is the economy QR decomposition and
         // this calculates orthonormal Q in R^(m x n)
         let qtq = q.transpose()*&q;
@@ -28,6 +65,8 @@ proptest! {
         let qr = ColPivQR::new(a.clone()).unwrap();
         let q  = qr.q();
         let r  = qr.r();
+
+        prop_assert!(is_upper_triangular(&r));
 
         // this tests Q^T Q = Id
         let qtq = q.transpose()*&q;
@@ -53,6 +92,26 @@ proptest! {
                 // residual solution, which means the normal equations must
                 // hold. That means we can assert on A^T A * X = A^T *B
                 prop_assert!(relative_eq!(a.transpose()*a*x,a.transpose()*b,epsilon = 1e-5));
+            },
+            Err(err) => {
+                prop_assert!(rank == 0);
+                prop_assert!(err == nl::ColPivQrError::ZeroRank);
+            },
+        }
+    }
+
+    #[test]
+    fn colpiv_qr_solve((a,b) in linear_system_dynamic()) {
+        let rank = a.rank(f64::EPSILON.sqrt());
+        let qr = ColPivQR::new(a.clone()).unwrap();
+        let result = qr.solve(&b);
+        match result {
+            Ok(x) => {
+                //@note(geo-ant) We can't just test A*x = b, since that is
+                // not what the QR solution guarantees. It guarantees a minimum
+                // residual solution, which means the normal equations must
+                // hold. That means we can assert on A^T A * X = A^T *B
+                prop_assert!(relative_eq!(a.transpose()*&a*x,a.transpose()*b,epsilon = 1e-5));
             },
             Err(err) => {
                 prop_assert!(rank == 0);

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -23,5 +23,5 @@ proptest! {
         qr.p().permute_cols_mut(&mut a).unwrap();
 
         prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7))
-        }
+    }
 }

--- a/nalgebra-lapack/tests/linalg/colpiv_qr.rs
+++ b/nalgebra-lapack/tests/linalg/colpiv_qr.rs
@@ -4,6 +4,7 @@ use nl::ColPivQR;
 use proptest::{prop_assert, proptest};
 
 proptest! {
+
     #[test]
     fn colpiv_qr_decomposition(mut a  in square_or_overdetermined_dmatrix()) {
         let qr = ColPivQR::new(a.clone()).unwrap();
@@ -39,13 +40,4 @@ proptest! {
         qr.p().permute_cols_mut(&mut a).unwrap();
         prop_assert!(relative_eq!(a, q * r, epsilon = 1.0e-7));
     }
-
-    //@todo(geo-ant)
-    // test solve both static and dynamic
-    #[test]
-    fn colpiv_qr_solve() {
-        todo!()
-
-    }
-
 }

--- a/nalgebra-lapack/tests/linalg/mod.rs
+++ b/nalgebra-lapack/tests/linalg/mod.rs
@@ -1,4 +1,5 @@
 mod cholesky;
+mod colpiv_qr;
 mod complex_eigen;
 mod generalized_eigenvalues;
 mod lu;

--- a/tests/proptest/mod.rs
+++ b/tests/proptest/mod.rs
@@ -110,12 +110,6 @@ where
     matrix(scalar_strategy, PROPTEST_MATRIX_DIM, PROPTEST_MATRIX_DIM)
 }
 
-pub fn square_or_overdetermined_dmatrix() -> impl Strategy<Value = DMatrix<f64>> {
-    PROPTEST_MATRIX_DIM.prop_flat_map(|rows| {
-        (1..=rows).prop_flat_map(move |cols| matrix(PROPTEST_F64, rows..=rows, cols..=cols))
-    })
-}
-
 // pub fn dvector_<T>(range: RangeInclusive<T>) -> impl Strategy<Value = DVector<T>>
 // where
 //     RangeInclusive<T>: Strategy<Value = T>,

--- a/tests/proptest/mod.rs
+++ b/tests/proptest/mod.rs
@@ -110,6 +110,12 @@ where
     matrix(scalar_strategy, PROPTEST_MATRIX_DIM, PROPTEST_MATRIX_DIM)
 }
 
+pub fn square_or_overdetermined_dmatrix() -> impl Strategy<Value = DMatrix<f64>> {
+    PROPTEST_MATRIX_DIM.prop_flat_map(|rows| {
+        (1..=rows).prop_flat_map(move |cols| matrix(PROPTEST_F64, rows..=rows, cols..=cols))
+    })
+}
+
 // pub fn dvector_<T>(range: RangeInclusive<T>) -> impl Strategy<Value = DVector<T>>
 // where
 //     RangeInclusive<T>: Strategy<Value = T>,


### PR DESCRIPTION
This PR adds column-pivoted QR decomposition to `nalgebra-lapack`. This is a pretty useful feature, because while the "normal" `nalgebra` crate also has column-pivoted QR, it will only solve square linear systems. The `nalgebra-lapack` implementation can be used for both square and overdetermined linear systems, which should be a useful addition.