### PR TITLE
fix failing test `coo-with-duplicates-samples-all-admissible-outputs

### DIFF
--- a/nalgebra-sparse/tests/unit_tests/proptest.rs
+++ b/nalgebra-sparse/tests/unit_tests/proptest.rs
@@ -108,7 +108,7 @@ mod slow {
 
         // This number needs to be high enough so that we with high probability sample
         // all possible cases
-        let num_generated_matrices = 500000;
+        let num_generated_matrices = 750000;
 
         let values = -1..=1;
         let rows = 0..=2;


### PR DESCRIPTION
Increasing the number of generated matrices seems to reliably hit the rare cases (at least on my machine(TM)). That means there shouldn't be a logic error in the implementation under test, though maybe there are ways to make it more efficient.