### PR TITLE
Use `wrapping_add()` for ptr addition in `Iterator::next()`

### DIFF
--- a/src/base/iter.rs
+++ b/src/base/iter.rs
@@ -100,7 +100,7 @@ macro_rules! iterator {
                         // so this is not observable.
                         if self.size != 0 {
                             let stride = self.strides.0.value();
-                            self.ptr = self.ptr.add(stride);
+                            self.ptr = self.ptr.wrapping_add(stride);
                         }
 
                         Some(old)


### PR DESCRIPTION
When iterating over a view of a row major matrix and finishing a column during iteration it is possible for the pointer to be incremented outside the allocation when determining the current column has been finished. This is fine because the pointer never is actually reading from outside the allocation, the `inner_end` value used to track we've finished the column will match on the next call to `next()` and never actually attempt to read from outside the allocation for the matrix. However, this increment step is done using `add()` instead of `wrapping_add()` and per the `wrapping_add()` documentation [1] `wrapping_add()` should be used in situations where the pointer can be incremented outside the allocation. While using `add()` in these situations is immediately undefined behavior. This will also trigger miri failures when testing code that is building a `MatrixView` to a row major array and then iterating over it. This commit changes the use of pointer `add()` to `wrapping_add()` in the `Iterator::next()` method to fix this issue.

[1] https://doc.rust-lang.org/std/primitive.pointer.html#method.wrapping_add