### PR TITLE
fix clippy warnings for manual implementations of is_multiple_of()

### DIFF
--- a/src/base/vec_storage.rs
+++ b/src/base/vec_storage.rs
@@ -473,7 +473,7 @@ impl<T, R: Dim> Extend<T> for VecStorage<T, R, Dyn> {
         self.data.extend(iter);
         self.ncols = Dyn(self.data.len() / self.nrows.value());
         assert!(
-            self.data.len() % self.nrows.value() == 0,
+            self.data.len().is_multiple_of(self.nrows.value()),
             "The number of elements produced by the given iterator was not a multiple of the number of rows."
         );
     }

--- a/src/linalg/permutation_sequence.rs
+++ b/src/linalg/permutation_sequence.rs
@@ -156,7 +156,7 @@ where
     #[inline]
     #[must_use]
     pub fn determinant<T: One + ClosedNeg>(&self) -> T {
-        if self.len % 2 == 0 {
+        if self.len.is_multiple_of(2) {
             T::one()
         } else {
             -T::one()

--- a/src/linalg/pow.rs
+++ b/src/linalg/pow.rs
@@ -26,7 +26,7 @@ where
             let mut x = self.clone_owned();
             let mut workspace = self.clone_owned();
 
-            if exp % 2 == 0 {
+            if exp.is_multiple_of(2) {
                 self.fill_with_identity();
             } else {
                 // Avoid an useless multiplication by the identity


### PR DESCRIPTION
cargo clippy warns on the common pattern `a % b == 0`, which returns true if `a` is a multiple of `b`. Rust unsigned integers have an `is_multiple_of` method, which makes the intent slightly clearer.