### PR TITLE
Add note about quaternion conversion

### DIFF
--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1076,7 +1076,7 @@ where
 
     /// The underlying quaternion.
     ///
-    /// Same as `self.as_ref()`.
+    /// Same as `self.as_ref()`. For conversion by value see [`Unit::into_inner`].
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
Was baffled for a moment how to convert UnitQuaternion into normal Quaternion, so added link for it in the docs.