### PR TITLE
Fix grammar to accept numbers without leading zeros, e.g. ".45"

### DIFF
--- a/src/io/matrix_market.pest
+++ b/src/io/matrix_market.pest
@@ -12,5 +12,5 @@ Document = {
     (NEWLINE ~ Entry?)*
 }
 Dimension = @{ ASCII_DIGIT+ }
-Value = @{ ("+" | "-")? ~ NUMBER+ ~ ("." ~ NUMBER+)? ~ ("e" ~ ("+" | "-")? ~ NUMBER+)? }
+Value = @{ ("+" | "-")? ~ (NUMBER+ ~ ("." ~ NUMBER*)? | "." ~ NUMBER+) ~ (("e" | "E") ~ ("+" | "-")? ~ NUMBER+)? }
 Entry = { Dimension ~ Dimension ~ Value }


### PR DESCRIPTION
Many matrices of the matrix market are being parsed incorrectly because of the missing leading zero.

Example:  <https://sparse.tamu.edu/Grund/b1_ss>

```
%%MatrixMarket matrix coordinate real general
%-------------------------------------------------------------------------------
% UF Sparse Matrix Collection, Tim Davis
% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss
% name: Grund/b1_ss
% [Unsymmetric Matrix b1_ss, F. Grund, Dec 1994.]
% id: 449
% date: 1997
% author: F. Grund
% ed: F. Grund
% fields: title A b name id date author ed kind
% kind: chemical process simulation problem
%-------------------------------------------------------------------------------
7 7 15
5 1 -.03599942
6 1 -.0176371
7 1 -.007721779
1 2 1
2 2 -1
1 3 1
3 3 -1
1 4 1
4 4 -1
2 5 .45
5 5 1
3 6 .1
6 6 1
4 7 .45
7 7 1
```

And the .45 and the .1 are not being read.

Note that ../../nalgebra-sparse/src/io/matrix_market.pest is correct.

Also: `".45".parse::<f64>()` works.`