### PR TITLE
fix: Cholesky::new returns None non-positive-definite complex matrices

### DIFF
--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -235,10 +235,14 @@ where
             }
 
             let sqrt_denom = |v: T| {
-                if v.is_zero() {
+                let re = v.clone().real();
+                let im = v.imaginary();
+
+                if re <= T::RealField::zero() || !im.is_zero() {
                     return None;
                 }
-                v.try_sqrt()
+
+                re.try_sqrt().map(T::from_real)
             };
 
             let diag = unsafe { matrix.get_unchecked((j, j)).clone() };

--- a/src/linalg/cholesky.rs
+++ b/src/linalg/cholesky.rs
@@ -235,10 +235,14 @@ where
             }
 
             let sqrt_denom = |v: T| {
-                let re = v.clone().real();
-                let im = v.imaginary();
+                // The diagonal pivots of a Hermitian positive-definite matrix
+                // are real and strictly positive. For complex scalars `try_sqrt`
+                // always succeeds, so we explicitly take the real part (the
+                // imaginary part is a roundoff artifact) and require it to be
+                // positive — otherwise the matrix is not positive-definite.
+                let re = v.real();
 
-                if re <= T::RealField::zero() || !im.is_zero() {
+                if re <= T::RealField::zero() {
                     return None;
                 }
 

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -178,3 +178,28 @@ macro_rules! gen_tests(
 
 gen_tests!(complex, RandComplex<f64>);
 gen_tests!(f64, RandScalar<f64>);
+
+#[test]
+fn cholesky_non_pd_complex_returns_none() {
+    // Regression test for https://github.com/dimforge/nalgebra/issues/1536.
+    // A non-positive-definite matrix with Complex<f64> entries must return None,
+    // just as it does for f64 entries. The diagonal pivot elements during
+    // Cholesky factorization must be real and strictly positive; for complex
+    // types, try_sqrt always succeeds, so positivity must be checked explicitly.
+    use na::DMatrix;
+    use num_complex::Complex;
+
+    // This 2x2 negative-definite matrix is not positive definite.
+    let m = DMatrix::from_row_slice(2, 2, &[
+        Complex::new(-4.0_f64, 0.0), Complex::new(0.0, 0.0),
+        Complex::new(0.0, 0.0),      Complex::new(-4.0_f64, 0.0),
+    ]);
+    assert!(na::Cholesky::new(m).is_none());
+
+    // A matrix with a non-real diagonal pivot is also not positive definite.
+    let m2 = DMatrix::from_row_slice(2, 2, &[
+        Complex::new(0.0_f64, 1.0), Complex::new(0.0, 0.0),
+        Complex::new(0.0, 0.0),     Complex::new(1.0_f64, 0.0),
+    ]);
+    assert!(na::Cholesky::new(m2).is_none());
+}

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -190,16 +190,29 @@ fn cholesky_non_pd_complex_returns_none() {
     use num_complex::Complex;
 
     // This 2x2 negative-definite matrix is not positive definite.
-    let m = DMatrix::from_row_slice(2, 2, &[
-        Complex::new(-4.0_f64, 0.0), Complex::new(0.0, 0.0),
-        Complex::new(0.0, 0.0),      Complex::new(-4.0_f64, 0.0),
-    ]);
+    let m = DMatrix::from_row_slice(
+        2,
+        2,
+        &[
+            Complex::new(-4.0_f64, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(-4.0_f64, 0.0),
+        ],
+    );
     assert!(na::Cholesky::new(m).is_none());
 
-    // A matrix with a non-real diagonal pivot is also not positive definite.
-    let m2 = DMatrix::from_row_slice(2, 2, &[
-        Complex::new(0.0_f64, 1.0), Complex::new(0.0, 0.0),
-        Complex::new(0.0, 0.0),     Complex::new(1.0_f64, 0.0),
-    ]);
+    // A matrix whose diagonal pivot has a non-positive real part (here a purely
+    // imaginary entry, real part 0) is also not positive definite.
+    let m2 = DMatrix::from_row_slice(
+        2,
+        2,
+        &[
+            Complex::new(0.0_f64, 1.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(0.0, 0.0),
+            Complex::new(1.0_f64, 0.0),
+        ],
+    );
     assert!(na::Cholesky::new(m2).is_none());
 }


### PR DESCRIPTION
For complex types,  always succeeds (every complex number has a square root), so non-PD matrices were silently producing garbage results. Fix by calling  on the real part of each diagonal pivot instead — matching the behaviour already correct for .

Fixes #1536