### PR TITLE
Release v0.35.0

### DIFF
--- a/.github/workflows/nalgebra-ci-build.yml
+++ b/.github/workflows/nalgebra-ci-build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Select rustc  version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.89.0
           override: true
       - uses: actions/checkout@v4
       - name: check
@@ -77,7 +77,7 @@ jobs:
       - name: Select rustc  version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.89.0
           override: true
       - uses: actions/checkout@v4
       - name: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ starting with `nalgebra-lapack` version `0.27.0`.
 
 ### Changed
 
+- Bumped MSRV to 1.89.0.
 - Updated `simba` dependency to 0.10.
 - Updated `rand` dependency to 0.10 and `rand_distr` to 0.6.
 - Removed the `convert-glamXXX` features for all `glam` versions prior to 0.30 [#1598](https://github.com/dimforge/nalgebra/pull/1598).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 **nalgebra-lapack change log** is found [here](https://github.com/dimforge/nalgebra/blob/main/nalgebra-lapack/CHANGELOG.md)
 starting with `nalgebra-lapack` version `0.27.0`.
 
+## [0.35.0] (24 May 2026)
+
+### Added
+
+- Add the Bunch–Kaufman LDL decomposition (`LBLT`) via the new `Matrix::lblt` method [#1591](https://github.com/dimforge/nalgebra/pull/1591).
+- Add `OneNorm` and the `Matrix::one_norm` method computing the induced matrix 1-norm (maximum absolute column sum) [#1591](https://github.com/dimforge/nalgebra/pull/1591).
+- Add the `convert-glam033` feature to enable conversion from/to types from `glam` v0.33.
+
+### Changed
+
+- Updated `simba` dependency to 0.10.
+- Updated `rand` dependency to 0.10 and `rand_distr` to 0.6.
+- Removed the `convert-glamXXX` features for all `glam` versions prior to 0.30 [#1598](https://github.com/dimforge/nalgebra/pull/1598).
+- Clarified norm documentation: `EuclideanNorm` is the Frobenius norm for matrices, `LpNorm`/`UniformNorm` are entrywise, not induced matrix norms [#1591](https://github.com/dimforge/nalgebra/pull/1591).
+- `nalgebra-lapack`: updated `thiserror` to 2.0.
+
+### Fixed
+
+- Fix the `T: Sync` bound on `impl Send for ViewStorage` so view storages can be sent across threads when `T: Send` [#1581](https://github.com/dimforge/nalgebra/pull/1581).
+
 ## [0.34.2] (28 March 2026)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,14 +84,14 @@ rkyv-safe-deser = ["rkyv-serialize", "rkyv/validation"]
 [dependencies]
 nalgebra-macros = { version = "0.3.0", path = "nalgebra-macros", optional = true }
 typenum = "1.12"
-rand-package = { package = "rand", version = "0.9", optional = true, default-features = false }
+rand-package = { package = "rand", version = "0.10", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", default-features = false }
 num-rational = { version = "0.4", default-features = false }
 approx = { version = "0.5", default-features = false }
 simba = { version = "0.9", default-features = false }
 alga = { version = "0.9", default-features = false, optional = true }
-rand_distr = { version = "0.5", default-features = false, optional = true }
+rand_distr = { version = "0.6", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 # TODO: once rkyv is updated to 0.8, we could consider removing the `allow(unsafe_op_in_unsafe_fn)`.
@@ -113,14 +113,14 @@ encase = { version = "0.12", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-rand_xorshift = "0.4"
-rand_isaac = "0.4"
+rand_xorshift = "0.5"
+rand_isaac = "0.5"
 criterion = { version = "0.7", features = ["html_reports"] }
 nalgebra = { path = ".", features = ["debug", "compare", "rand", "macros"] }
 
 # For matrix comparison macro
 matrixcompare = "0.3.0"
-itertools = "0.13"
+itertools = "0.14"
 
 # For macro testing
 trybuild = "1.0.90"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", default-features = false }
 num-rational = { version = "0.4", default-features = false }
 approx = { version = "0.5", default-features = false }
-simba = { version = "0.9", default-features = false }
+simba = { version = "0.10", default-features = false }
 alga = { version = "0.9", default-features = false, optional = true }
 rand_distr = { version = "0.6", default-features = false, optional = true }
 matrixmultiply = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ encase = { version = "0.12", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 rand_xorshift = "0.5"
-rand_isaac = "0.5"
 criterion = { version = "0.7", features = ["html_reports"] }
 nalgebra = { path = ".", features = ["debug", "compare", "rand", "macros"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ std = [
     "glam030?/std",
     "glam031?/std",
     "glam032?/std",
+    "glam033?/std",
 ]
 sparse = []
 debug = ["approx/num-complex", "rand"]
@@ -45,6 +46,7 @@ libm = [
     "glam030?/libm",
     "glam031?/libm",
     "glam032?/libm",
+    "glam033?/libm",
 ]
 libm-force = ["simba/libm_force"]
 macros = ["nalgebra-macros"]
@@ -55,6 +57,7 @@ convert-bytemuck = ["bytemuck", "num-complex/bytemuck"]
 convert-glam030 = ["glam030"]
 convert-glam031 = ["glam031"]
 convert-glam032 = ["glam032"]
+convert-glam033 = ["glam033"]
 
 # Serialization
 ## To use serde in a #[no-std] environment, enable the
@@ -103,6 +106,7 @@ proptest = { version = "1", optional = true, default-features = false, features 
 glam030 = { package = "glam", version = "0.30", optional = true, default-features = false }
 glam031 = { package = "glam", version = "0.31", optional = true, default-features = false }
 glam032 = { package = "glam", version = "0.32", optional = true, default-features = false }
+glam033 = { package = "glam", version = "0.33", optional = true, default-features = false, features = ["f64", "i32", "u32"] }
 rayon = { version = "1.6", optional = true }
 defmt = { version = "1.0.1", optional = true }
 encase = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "mathematics", "wasm", "no-std"]
 keywords = ["linear", "algebra", "matrix", "vector", "math"]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 exclude = ["/ci/*", "/.travis.yml", "/Makefile"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nalgebra"
-version = "0.34.2"
+version = "0.35.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "General-purpose linear algebra library with transformations and statically-sized or dynamically-sized matrices."

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -11,7 +11,7 @@ macro_rules! bench_binop(
             use rand::SeedableRng;
             use rand::RngExt;
 
-            let mut rng = IsaacRng::seed_from_u64(0);
+            let mut rng = XorShiftRng::seed_from_u64(0);
 
             bh.bench_function(stringify!($name), |bh| bh.iter_batched(
                 || (rng.random::<$t1>(), rng.random::<$t2>()),
@@ -30,7 +30,7 @@ macro_rules! bench_binop_ref(
             use rand::SeedableRng;
             use rand::RngExt;
 
-            let mut rng = IsaacRng::seed_from_u64(0);
+            let mut rng = XorShiftRng::seed_from_u64(0);
 
             bh.bench_function(stringify!($name), |bh| bh.iter_batched_ref(
                 || (rng.random::<$t1>(), rng.random::<$t2>()),
@@ -55,7 +55,7 @@ macro_rules! bench_binop_single_1st(
             use rand::RngExt;
             use std::hint::black_box;
 
-            let mut rng = IsaacRng::seed_from_u64(0);
+            let mut rng = XorShiftRng::seed_from_u64(0);
 
             let first = black_box(rng.random::<$t1>());
 
@@ -77,7 +77,7 @@ macro_rules! bench_binop_single_1st_ref(
             use rand::RngExt;
             use std::hint::black_box;
 
-            let mut rng = IsaacRng::seed_from_u64(0);
+            let mut rng = XorShiftRng::seed_from_u64(0);
 
             let first = black_box(rng.random::<$t1>());
 
@@ -98,7 +98,7 @@ macro_rules! bench_unop(
             use rand::SeedableRng;
             use rand::RngExt;
 
-            let mut rng = IsaacRng::seed_from_u64(0);
+            let mut rng = XorShiftRng::seed_from_u64(0);
 
             bh.bench_function(stringify!($name), |bh| bh.iter_batched_ref(
                 || rng.random::<$t>(),

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -9,6 +9,7 @@ macro_rules! bench_binop(
     ($name: ident, $t1: ty, $t2: ty, $binop: ident) => {
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
+            use rand::RngExt;
 
             let mut rng = IsaacRng::seed_from_u64(0);
 
@@ -27,6 +28,7 @@ macro_rules! bench_binop_ref(
     ($name: ident, $t1: ty, $t2: ty, $binop: ident) => {
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
+            use rand::RngExt;
 
             let mut rng = IsaacRng::seed_from_u64(0);
 
@@ -50,6 +52,7 @@ macro_rules! bench_binop_single_1st(
     ($name: ident, $t1: ty, $t2: ty, $binop: ident) => {
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
+            use rand::RngExt;
             use std::hint::black_box;
 
             let mut rng = IsaacRng::seed_from_u64(0);
@@ -71,6 +74,7 @@ macro_rules! bench_binop_single_1st_ref(
     ($name: ident, $t1: ty, $t2: ty, $binop: ident) => {
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
+            use rand::RngExt;
             use std::hint::black_box;
 
             let mut rng = IsaacRng::seed_from_u64(0);
@@ -92,6 +96,7 @@ macro_rules! bench_unop(
     ($name: ident, $t: ty, $unop: ident) => {
         fn $name(bh: &mut criterion::Criterion) {
             use rand::SeedableRng;
+            use rand::RngExt;
 
             let mut rng = IsaacRng::seed_from_u64(0);
 

--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -1,6 +1,5 @@
 use na::{DMatrix, DVector, Matrix2, Matrix3, Matrix4, OMatrix, U10, Vector2, Vector3, Vector4};
-use rand::Rng;
-use rand_isaac::IsaacRng;
+use rand_xorshift::XorShiftRng;
 use std::hint::black_box;
 use std::ops::{Add, Div, Mul, Sub};
 

--- a/benches/core/vector.rs
+++ b/benches/core/vector.rs
@@ -1,5 +1,5 @@
 use na::{DVector, SVector, Vector2, Vector3, Vector4};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand_isaac::IsaacRng;
 
 use std::ops::{Add, Div, Mul, Sub};

--- a/benches/core/vector.rs
+++ b/benches/core/vector.rs
@@ -1,6 +1,6 @@
 use na::{DVector, SVector, Vector2, Vector3, Vector4};
-use rand::{Rng, RngExt};
-use rand_isaac::IsaacRng;
+use rand::RngExt;
+use rand_xorshift::XorShiftRng;
 
 use std::ops::{Add, Div, Mul, Sub};
 
@@ -51,7 +51,7 @@ bench_binop_ref!(vec10000_dot_f32, SVector<f32, 10000>, SVector<f32, 10000>, dot
 fn vec10000_axpy_f64(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     bh.bench_function("vec10000_axpy_f64", |bh| {
         bh.iter_batched(
@@ -74,7 +74,7 @@ fn vec10000_axpy_f64(bh: &mut criterion::Criterion) {
 fn vec10000_axpy_beta_f64(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     bh.bench_function("vec10000_axpy_beta_f64", |bh| {
         bh.iter_batched(
@@ -98,7 +98,7 @@ fn vec10000_axpy_beta_f64(bh: &mut criterion::Criterion) {
 fn vec10000_axpy_f64_slice(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     bh.bench_function("vec10000_axpy_f64_slice", |bh| {
         bh.iter_batched(
@@ -123,7 +123,7 @@ fn vec10000_axpy_f64_slice(bh: &mut criterion::Criterion) {
 fn vec10000_axpy_f64_static(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     // NOTE: for some reasons, it is much faster if the argument are boxed (Box::new(OVector...)).
     bh.bench_function("vec10000_axpy_f64_static", |bh| {
@@ -147,7 +147,7 @@ fn vec10000_axpy_f64_static(bh: &mut criterion::Criterion) {
 fn vec10000_axpy_f32(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     bh.bench_function("vec10000_axpy_f32", |bh| {
         bh.iter_batched(
@@ -170,7 +170,7 @@ fn vec10000_axpy_f32(bh: &mut criterion::Criterion) {
 fn vec10000_axpy_beta_f32(bh: &mut criterion::Criterion) {
     use rand::SeedableRng;
 
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
 
     bh.bench_function("vec10000_axpy_beta_f32", |bh| {
         bh.iter_batched(

--- a/benches/geometry/quaternion.rs
+++ b/benches/geometry/quaternion.rs
@@ -1,6 +1,5 @@
 use na::{Quaternion, UnitQuaternion, Vector3};
-use rand::Rng;
-use rand_isaac::IsaacRng;
+use rand_xorshift::XorShiftRng;
 use std::ops::{Add, Div, Mul, Sub};
 
 #[path = "../common/macros.rs"]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,9 +7,9 @@ extern crate rand_package as rand;
 extern crate criterion;
 
 use na::{DMatrix, SMatrix, Scalar};
+use rand::RngExt;
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, RngExt};
-use rand_isaac::IsaacRng;
+use rand_xorshift::XorShiftRng;
 
 pub mod core;
 pub mod geometry;
@@ -22,14 +22,14 @@ where
     StandardUniform: Distribution<T>,
 {
     use rand::SeedableRng;
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
     SMatrix::from_fn(|_, _| rng.random())
 }
 
 #[allow(dead_code)]
 fn reproducible_dmatrix(nrows: usize, ncols: usize) -> DMatrix<f64> {
     use rand::SeedableRng;
-    let mut rng = IsaacRng::seed_from_u64(0);
+    let mut rng = XorShiftRng::seed_from_u64(0);
     DMatrix::<f64>::from_fn(nrows, ncols, |_, _| rng.random())
 }
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,8 +7,8 @@ extern crate rand_package as rand;
 extern crate criterion;
 
 use na::{DMatrix, SMatrix, Scalar};
-use rand::{Rng, RngExt};
 use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
 use rand_isaac::IsaacRng;
 
 pub mod core;

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,7 +7,7 @@ extern crate rand_package as rand;
 extern crate criterion;
 
 use na::{DMatrix, SMatrix, Scalar};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand::distr::{Distribution, StandardUniform};
 use rand_isaac::IsaacRng;
 

--- a/examples/cargo/Cargo.toml
+++ b/examples/cargo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["You"]
 
 [dependencies]
-nalgebra = "0.34.0"
+nalgebra = "0.35.0"
 
 [[bin]]
 name = "example"

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -29,5 +29,5 @@ convert-bytemuck = ["nalgebra/bytemuck"]
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
-simba = { version = "0.9", default-features = false }
+simba = { version = "0.10", default-features = false }
 nalgebra = { path = "..", version = "0.34", default-features = false }

--- a/nalgebra-glm/Cargo.toml
+++ b/nalgebra-glm/Cargo.toml
@@ -30,4 +30,4 @@ convert-bytemuck = ["nalgebra/bytemuck"]
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 simba = { version = "0.10", default-features = false }
-nalgebra = { path = "..", version = "0.34", default-features = false }
+nalgebra = { path = "..", version = "0.35", default-features = false }

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -34,7 +34,7 @@ lapack-mkl-dynamic-par = ["lapack-src/intel-mkl-dynamic-parallel", "blas-src/int
 lapack-custom = []
 
 [dependencies]
-nalgebra = { version = "0.34", path = ".." }
+nalgebra = { version = "0.35", path = ".." }
 num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }
 simba = "0.10"
@@ -46,7 +46,7 @@ blas-src = { version = "0.14", optional = true, default-features = false}
 thiserror = "2.0"
 
 [dev-dependencies]
-nalgebra = { version = "0.34", features = ["arbitrary", "rand"], path = ".." }
+nalgebra = { version = "0.35", features = ["arbitrary", "rand"], path = ".." }
 proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = "1"
 approx = "0.5"

--- a/nalgebra-lapack/Cargo.toml
+++ b/nalgebra-lapack/Cargo.toml
@@ -37,13 +37,13 @@ lapack-custom = []
 nalgebra = { version = "0.34", path = ".." }
 num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }
-simba = "0.9"
+simba = "0.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
 lapack = { version = "0.20", default-features = false }
 blas = { version = "0.23", default-features = false }
 lapack-src = { version = "0.13", optional = true }
 blas-src = { version = "0.14", optional = true, default-features = false}
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 nalgebra = { version = "0.34", features = ["arbitrary", "rand"], path = ".." }

--- a/nalgebra-macros/Cargo.toml
+++ b/nalgebra-macros/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-nalgebra = { version = "0.34", path = ".." }
+nalgebra = { version = "0.35", path = ".." }

--- a/nalgebra-macros/src/matrix_vector_impl.rs
+++ b/nalgebra-macros/src/matrix_vector_impl.rs
@@ -88,7 +88,7 @@ impl Parse for Matrix {
             } else {
                 ncols = Some(row.len());
             }
-            data.extend(row.into_iter());
+            data.extend(row);
             nrows += 1;
 
             // We've just read a row, so if there are more tokens, there must be a semi-colon,

--- a/nalgebra-sparse/Cargo.toml
+++ b/nalgebra-sparse/Cargo.toml
@@ -24,7 +24,7 @@ io = ["pest", "pest_derive"]
 slow-tests = []
 
 [dependencies]
-nalgebra = { version = "0.34", path = "../" }
+nalgebra = { version = "0.35", path = "../" }
 num-traits = { version = "0.2", default-features = false }
 proptest = { version = "1.0", optional = true }
 matrixcompare-core = { version = "0.1.0", optional = true }
@@ -35,7 +35,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 [dev-dependencies]
 itertools = "0.13"
 matrixcompare = { version = "0.3.0", features = ["proptest-support"] }
-nalgebra = { version = "0.34", path = "../", features = ["compare"] }
+nalgebra = { version = "0.35", path = "../", features = ["compare"] }
 tempfile = "3.3"
 serde_json = "1.0"
 

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -9,7 +9,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::{Bounded, One, Zero};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/base/helper.rs
+++ b/src/base/helper.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -5,7 +5,7 @@
 use quickcheck::{Arbitrary, Gen};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 #[cfg(feature = "serde-serialize-no-std")]

--- a/src/geometry/perspective.rs
+++ b/src/geometry/perspective.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/point_construction.rs
+++ b/src/geometry/point_construction.rs
@@ -4,7 +4,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::{Bounded, One, Zero};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -7,7 +7,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, OpenClosed01, StandardUniform, Uniform, uniform::SampleUniform},
 };
 

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -7,7 +7,7 @@ use num::Zero;
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, OpenClosed01, StandardUniform, Uniform, uniform::SampleUniform},
 };
 

--- a/src/geometry/scale_construction.rs
+++ b/src/geometry/scale_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/similarity_construction.rs
+++ b/src/geometry/similarity_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::One;
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/translation_construction.rs
+++ b/src/geometry/translation_construction.rs
@@ -6,7 +6,7 @@ use quickcheck::{Arbitrary, Gen};
 use num::{One, Zero};
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "rand-no-std")]
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform},
 };
 

--- a/src/third_party/glam/mod.rs
+++ b/src/third_party/glam/mod.rs
@@ -4,3 +4,5 @@ mod v030;
 mod v031;
 #[cfg(feature = "glam032")]
 mod v032;
+#[cfg(feature = "glam033")]
+mod v033;

--- a/src/third_party/glam/v033/mod.rs
+++ b/src/third_party/glam/v033/mod.rs
@@ -1,0 +1,18 @@
+#[path = "../common/glam_isometry.rs"]
+mod glam_isometry;
+#[path = "../common/glam_matrix.rs"]
+mod glam_matrix;
+#[path = "../common/glam_point.rs"]
+mod glam_point;
+#[path = "../common/glam_quaternion.rs"]
+mod glam_quaternion;
+#[path = "../common/glam_rotation.rs"]
+mod glam_rotation;
+#[path = "../common/glam_similarity.rs"]
+mod glam_similarity;
+#[path = "../common/glam_translation.rs"]
+mod glam_translation;
+#[path = "../common/glam_unit_complex.rs"]
+mod glam_unit_complex;
+
+pub(self) use glam033 as glam;

--- a/tests/core/helper.rs
+++ b/tests/core/helper.rs
@@ -4,7 +4,7 @@
 use na::RealField;
 use num_complex::Complex;
 use quickcheck::{Arbitrary, Gen};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand::distr::{Distribution, StandardUniform};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/tests/core/helper.rs
+++ b/tests/core/helper.rs
@@ -4,8 +4,8 @@
 use na::RealField;
 use num_complex::Complex;
 use quickcheck::{Arbitrary, Gen};
-use rand::{Rng, RngExt};
 use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RandComplex<T>(pub Complex<T>);

--- a/tests/linalg/lblt.rs
+++ b/tests/linalg/lblt.rs
@@ -4,7 +4,7 @@ use na::{
     OVector, RealField, allocator::Allocator,
 };
 use num_traits::FromPrimitive;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, StandardNormal};
 
 fn decomposition_error<T, N>(matrix: &OMatrix<T, N, N>, lblt: &LBLT<T, N>) -> T::RealField


### PR DESCRIPTION

## [0.35.0] (24 May 2026)

### Added

- Add the Bunch–Kaufman LDL decomposition (`LBLT`) via the new `Matrix::lblt` method [#1591](https://github.com/dimforge/nalgebra/pull/1591).
- Add `OneNorm` and the `Matrix::one_norm` method computing the induced matrix 1-norm (maximum absolute column sum) [#1591](https://github.com/dimforge/nalgebra/pull/1591).
- Add the `convert-glam033` feature to enable conversion from/to types from `glam` v0.33.

### Changed

- Updated `simba` dependency to 0.10.
- Updated `rand` dependency to 0.10 and `rand_distr` to 0.6.
- Removed the `convert-glamXXX` features for all `glam` versions prior to 0.30 [#1598](https://github.com/dimforge/nalgebra/pull/1598).
- Clarified norm documentation: `EuclideanNorm` is the Frobenius norm for matrices, `LpNorm`/`UniformNorm` are entrywise, not induced matrix norms [#1591](https://github.com/dimforge/nalgebra/pull/1591).
- `nalgebra-lapack`: updated `thiserror` to 2.0.

### Fixed

- Fix the `T: Sync` bound on `impl Send for ViewStorage` so view storages can be sent across threads when `T: Send` [#1581](https://github.com/dimforge/nalgebra/pull/1581).
