### PR TITLE
feat(geometry): add face_towards to 2D isometries

### DIFF
--- a/src/geometry/isometry.rs
+++ b/src/geometry/isometry.rs
@@ -42,7 +42,7 @@ use rkyv::bytecheck;
 /// this page.
 ///
 /// # Construction
-/// * [From a 2D vector and/or an angle <span style="float:right;">`new`, `translation`, `rotation`…</span>](#construction-from-a-2d-vector-andor-a-rotation-angle)
+/// * [From a 2D vector and/or an angle <span style="float:right;">`new`, `translation`, `rotation`, `face_towards`…</span>](#construction-from-a-2d-vector-andor-a-rotation-angle)
 /// * [From a 3D vector and/or an axis-angle <span style="float:right;">`new`, `translation`, `rotation`…</span>](#construction-from-a-3d-vector-andor-an-axis-angle)
 /// * [From a 3D eye position and target point <span style="float:right;">`look_at`, `look_at_lh`, `face_towards`…</span>](#construction-from-a-3d-eye-position-and-target-point)
 /// * [From the translation and rotation parts <span style="float:right;">`from_parts`…</span>](#from-the-translation-and-rotation-parts)

--- a/src/geometry/isometry_construction.rs
+++ b/src/geometry/isometry_construction.rs
@@ -17,8 +17,8 @@ use crate::base::{Vector2, Vector3};
 
 use crate::{
     AbstractRotation, Isometry, Isometry2, Isometry3, IsometryMatrix2, IsometryMatrix3, Point,
-    Point3, Rotation, Rotation3, Scalar, Translation, Translation2, Translation3, UnitComplex,
-    UnitQuaternion,
+    Point2, Point3, Rotation, Rotation3, Scalar, Translation, Translation2, Translation3,
+    UnitComplex, UnitQuaternion,
 };
 
 impl<T: SimdRealField, R: AbstractRotation<T, D>, const D: usize> Default for Isometry<T, R, D>
@@ -155,6 +155,44 @@ where
         Self::new(Vector2::zeros(), angle)
     }
 
+    /// Creates an isometry that corresponds to the local frame of an observer standing at the
+    /// point `eye` and looking toward `target`.
+    ///
+    /// It maps the `x` axis to the view direction `target - eye` and the origin to the `eye`.
+    ///
+    /// # Arguments
+    ///   * eye - The observer position.
+    ///   * target - The target position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # use nalgebra::{IsometryMatrix2, Point2, Vector2};
+    /// let eye = Point2::new(1.0, 2.0);
+    /// let target = Point2::new(2.0, 2.0);
+    ///
+    /// let iso = IsometryMatrix2::face_towards(&eye, &target);
+    /// assert_eq!(iso * Point2::origin(), eye);
+    /// assert_relative_eq!(iso * Vector2::x(), Vector2::x());
+    /// ```
+    #[inline]
+    pub fn face_towards(eye: &Point2<T>, target: &Point2<T>) -> Self {
+        let dir = target - eye;
+        let angle = dir.y.clone().simd_atan2(dir.x.clone());
+
+        Self::from_parts(
+            Translation::from(eye.coords.clone()),
+            Rotation::<T, 2>::new(angle),
+        )
+    }
+
+    /// Deprecated: Use [`IsometryMatrix2::face_towards`] instead.
+    #[deprecated(note = "renamed to `face_towards`")]
+    pub fn new_observer_frame(eye: &Point2<T>, target: &Point2<T>) -> Self {
+        Self::face_towards(eye, target)
+    }
+
     /// Cast the components of `self` to another type.
     ///
     /// # Example
@@ -207,6 +245,44 @@ where
     #[inline]
     pub fn rotation(angle: T) -> Self {
         Self::new(Vector2::zeros(), angle)
+    }
+
+    /// Creates an isometry that corresponds to the local frame of an observer standing at the
+    /// point `eye` and looking toward `target`.
+    ///
+    /// It maps the `x` axis to the view direction `target - eye` and the origin to the `eye`.
+    ///
+    /// # Arguments
+    ///   * eye - The observer position.
+    ///   * target - The target position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// # use nalgebra::{Isometry2, Point2, Vector2};
+    /// let eye = Point2::new(1.0, 2.0);
+    /// let target = Point2::new(2.0, 2.0);
+    ///
+    /// let iso = Isometry2::face_towards(&eye, &target);
+    /// assert_eq!(iso * Point2::origin(), eye);
+    /// assert_relative_eq!(iso * Vector2::x(), Vector2::x());
+    /// ```
+    #[inline]
+    pub fn face_towards(eye: &Point2<T>, target: &Point2<T>) -> Self {
+        let dir = target - eye;
+        let angle = dir.y.clone().simd_atan2(dir.x.clone());
+
+        Self::from_parts(
+            Translation::from(eye.coords.clone()),
+            UnitComplex::from_angle(angle),
+        )
+    }
+
+    /// Deprecated: Use [`Isometry2::face_towards`] instead.
+    #[deprecated(note = "renamed to `face_towards`")]
+    pub fn new_observer_frame(eye: &Point2<T>, target: &Point2<T>) -> Self {
+        Self::face_towards(eye, target)
     }
 
     /// Cast the components of `self` to another type.

--- a/tests/geometry/isometry.rs
+++ b/tests/geometry/isometry.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "proptest-support")]
 #![allow(non_snake_case)]
 
-use na::{Isometry3, Point3, Vector3};
+use na::{Isometry2, Isometry3, IsometryMatrix2, Point2, Point3, Vector2, Vector3};
 
 use crate::proptest::*;
-use proptest::{prop_assert, prop_assert_eq, proptest};
+use proptest::{prop_assert, prop_assert_eq, prop_assume, proptest};
 
 proptest!(
     #[test]
@@ -44,6 +44,40 @@ proptest!(
             && relative_eq!(
                 observer * Vector3::z(),
                 (target - eye).normalize(),
+                epsilon = 1.0e-7
+            ))
+    }
+
+    #[test]
+    fn observer_frame_2(eye in point2(), target in point2()) {
+        let dir = target - eye;
+        prop_assume!(dir.norm_squared() > 1.0e-14);
+
+        let observer = Isometry2::face_towards(&eye, &target);
+        let matrix_observer = IsometryMatrix2::face_towards(&eye, &target);
+        let origin = Point2::origin();
+        let direction = dir.normalize();
+
+        #[allow(deprecated)]
+        {
+            prop_assert!(relative_eq!(
+                Isometry2::new_observer_frame(&eye, &target),
+                observer,
+                epsilon = 1.0e-7
+            ));
+            prop_assert!(relative_eq!(
+                IsometryMatrix2::new_observer_frame(&eye, &target),
+                matrix_observer,
+                epsilon = 1.0e-7
+            ));
+        }
+
+        prop_assert!(relative_eq!(observer * origin, eye, epsilon = 1.0e-7)
+            && relative_eq!(observer * Vector2::x(), direction, epsilon = 1.0e-7)
+            && relative_eq!(matrix_observer * origin, eye, epsilon = 1.0e-7)
+            && relative_eq!(
+                matrix_observer * Vector2::x(),
+                direction,
                 epsilon = 1.0e-7
             ))
     }


### PR DESCRIPTION
This adds a `face_towards` constructor for 2D isometries (`Isometry2` and `IsometryMatrix2`) that mirrors the existing 3D behavior. The new method builds an isometry from an `eye` point and a `target` point, mapping the local `x` axis to the view direction and the origin to `eye`, which is useful for orienting objects toward a target in 2D.

A deprecated `new_observer_frame` alias is also provided on the 2D types for consistency with the 3D naming, and the rustdoc section in `isometry.rs` is updated to list the new constructor.

Resolves #492

### Changes
- Add `Isometry2::face_towards` and `IsometryMatrix2::face_towards` in `src/geometry/isometry_construction.rs`, computing the rotation from `atan2(dy, dx)` between `eye` and `target`.
- Add deprecated `new_observer_frame` aliases on both 2D isometry types, delegating to `face_towards`.
- Update the 2D construction section in the `Isometry` rustdoc to mention `face_towards`.
- Add a proptest in `tests/geometry/isometry.rs` covering both 2D types, verifying that the origin maps to `eye` and the `x` axis maps to the normalized view direction.