### PR TITLE
docs(nalgebra-sparse): clarify required features for front-page example

### DIFF
--- a/nalgebra-sparse/src/lib.rs
+++ b/nalgebra-sparse/src/lib.rs
@@ -77,6 +77,16 @@
 //!
 //! # Example: COO -> CSR -> matrix-vector product
 //!
+//! The example below uses the `matrixcompare` crate to compare sparse and dense matrices. Enable
+//! the `compare` feature for both `nalgebra-sparse` and `nalgebra`:
+//!
+//! ```toml
+//! [dependencies]
+//! nalgebra-sparse = { version = "0.12", features = ["compare"] }
+//! nalgebra = { version = "0.35", features = ["compare"] }
+//! matrixcompare = "0.3"
+//! ```
+//!
 //! ```
 //! use nalgebra_sparse::{coo::CooMatrix, csr::CsrMatrix};
 //! use nalgebra::{DMatrix, DVector};


### PR DESCRIPTION
The front-page example in `nalgebra-sparse` uses `matrixcompare` to assert that the sparse and dense matrices agree, but the surrounding documentation did not mention the `compare` feature on `nalgebra` and `nalgebra-sparse` that this example needs. Without those features, new users copy-pasting the example will hit unresolved imports, which has been a source of confusion.

This change adds a short note and a `Cargo.toml` snippet above the example in `nalgebra-sparse/src/lib.rs` so readers can see exactly which dependencies and features to enable.

Resolves #1214

### Changes
- Added a paragraph to the front-page example in `nalgebra-sparse/src/lib.rs` explaining that the `compare` feature is required on both `nalgebra-sparse` and `nalgebra`.
- Added a `Cargo.toml` snippet showing the required dependencies and feature flags for the example to compile.