### PR TITLE
Fix #1579: QR::solve handles overdetermined (least-squares) systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 **nalgebra-lapack change log** is found [here](https://github.com/dimforge/nalgebra/blob/main/nalgebra-lapack/CHANGELOG.md)
 starting with `nalgebra-lapack` version `0.27.0`.
 
+## Unreleased
+
+### Changed
+
+- `QR::solve` and `QR::solve_mut` now solve overdetermined systems in the least-squares sense (minimizing `‖Ax - b‖₂`) instead of panicking on non-square matrices. `QR::solve` now returns a matrix with as many rows as the system has columns [#1579](https://github.com/dimforge/nalgebra/issues/1579).
+
 ## [0.35.0] (24 May 2026)
 
 ### Added

--- a/src/linalg/qr.rs
+++ b/src/linalg/qr.rs
@@ -171,40 +171,60 @@ where
     }
 }
 
-impl<T: ComplexField, D: DimMin<D, Output = D>> QR<T, D, D>
+impl<T: ComplexField, R: DimMin<C>, C: Dim> QR<T, R, C>
 where
-    DefaultAllocator: Allocator<D, D> + Allocator<D>,
+    DefaultAllocator: Allocator<R, C> + Allocator<R> + Allocator<DimMinimum<R, C>>,
 {
     /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
     ///
-    /// Returns `None` if `self` is not invertible.
+    /// If the system is overdetermined (i.e. the decomposed matrix has more rows than
+    /// columns), the least-squares solution minimizing `‖self * x - b‖` is returned. The
+    /// returned matrix has as many rows as the decomposed matrix has columns.
+    ///
+    /// This assumes the matrix has full column rank: the unpivoted QR factorization cannot
+    /// reliably solve rank-deficient or numerically ill-conditioned least-squares problems —
+    /// use `ColPivQR` or `SVD` for those. Returns `None` if a zero pivot is encountered.
+    /// Panics if the system is underdetermined (i.e. it has fewer rows than columns).
     #[must_use = "Did you mean to use solve_mut()?"]
     pub fn solve<R2: Dim, C2: Dim, S2>(
         &self,
         b: &Matrix<T, R2, C2, S2>,
-    ) -> Option<OMatrix<T, R2, C2>>
+    ) -> Option<OMatrix<T, C, C2>>
     where
         S2: Storage<T, R2, C2>,
-        ShapeConstraint: SameNumberOfRows<R2, D>,
-        DefaultAllocator: Allocator<R2, C2>,
+        ShapeConstraint: SameNumberOfRows<R2, R>,
+        DefaultAllocator: Allocator<R2, C2> + Allocator<C, C2>,
     {
         let mut res = b.clone_owned();
 
         if self.solve_mut(&mut res) {
-            Some(res)
+            // For an overdetermined system the solution lies in the first `ncols` rows.
+            let ncols = self.qr.shape_generic().1;
+            Some(res.rows_generic(0, ncols).into_owned())
         } else {
             None
         }
     }
 
-    /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined.
+    /// Solves the linear system `self * x = b`, where `x` is the unknown to be determined,
+    /// overwriting `b`.
     ///
-    /// If the decomposed matrix is not invertible, this returns `false` and its input `b` is
-    /// overwritten with garbage.
+    /// If the system is overdetermined (i.e. the decomposed matrix has more rows than
+    /// columns), the least-squares solution minimizing `‖self * x - b‖` is computed and
+    /// written into the first `ncols` rows of `b`. The remaining `nrows - ncols` rows are
+    /// left holding the tail of `Qᵀ * b`; for each right-hand side (column of `b`), the
+    /// Euclidean norm of that tail equals its least-squares residual `‖self * x - b‖`.
+    /// `b` must have as many rows as the decomposed matrix.
+    ///
+    /// This assumes the matrix has full column rank: the unpivoted QR factorization cannot
+    /// reliably solve rank-deficient or numerically ill-conditioned least-squares problems —
+    /// use `ColPivQR` or `SVD` for those. If a zero pivot is encountered this returns `false`
+    /// and `b` is overwritten with garbage. Panics if the system is underdetermined (i.e. it
+    /// has fewer rows than columns).
     pub fn solve_mut<R2: Dim, C2: Dim, S2>(&self, b: &mut Matrix<T, R2, C2, S2>) -> bool
     where
         S2: StorageMut<T, R2, C2>,
-        ShapeConstraint: SameNumberOfRows<R2, D>,
+        ShapeConstraint: SameNumberOfRows<R2, R>,
     {
         assert_eq!(
             self.qr.nrows(),
@@ -212,8 +232,9 @@ where
             "QR solve matrix dimension mismatch."
         );
         assert!(
-            self.qr.is_square(),
-            "QR solve: unable to solve a non-square system."
+            self.qr.nrows() >= self.qr.ncols(),
+            "QR solve: the system must be square or overdetermined \
+             (it cannot have fewer rows than columns)."
         );
 
         self.q_tr_mul(b);
@@ -227,9 +248,11 @@ where
     ) -> bool
     where
         S2: StorageMut<T, R2, C2>,
-        ShapeConstraint: SameNumberOfRows<R2, D>,
+        ShapeConstraint: SameNumberOfRows<R2, R>,
     {
-        let dim = self.qr.nrows();
+        // For an overdetermined system only the first `min(nrows, ncols)` rows form the
+        // upper-triangular system; the remaining rows hold the least-squares residual.
+        let dim = self.diag.len();
 
         for k in 0..b.ncols() {
             let mut b = b.column_mut(k);
@@ -254,7 +277,12 @@ where
 
         true
     }
+}
 
+impl<T: ComplexField, D: DimMin<D, Output = D>> QR<T, D, D>
+where
+    DefaultAllocator: Allocator<D, D> + Allocator<D>,
+{
     /// Computes the inverse of the decomposed matrix.
     ///
     /// Returns `None` if the decomposed matrix is not invertible.

--- a/tests/linalg/qr.rs
+++ b/tests/linalg/qr.rs
@@ -3,7 +3,7 @@
 macro_rules! gen_tests(
     ($module: ident, $scalar: expr, $scalar_type: ty) => {
         mod $module {
-            use na::{DMatrix, DVector, Matrix4x3, Vector4};
+            use na::{DMatrix, DVector, Matrix4x3, Matrix5x2, Vector4, Vector5};
             use std::cmp;
             #[allow(unused_imports)]
             use crate::core::helper::{RandScalar, RandComplex};
@@ -81,6 +81,48 @@ macro_rules! gen_tests(
                          prop_assert!(relative_eq!(m * sol1, b1, epsilon = 1.0e-6));
                          prop_assert!(relative_eq!(m * sol2, b2, epsilon = 1.0e-6));
                      }
+                }
+
+                #[test]
+                fn qr_solve_overdetermined(d1 in PROPTEST_MATRIX_DIM, d2 in PROPTEST_MATRIX_DIM, nb in PROPTEST_MATRIX_DIM) {
+                    // Build an overdetermined (or square) system: nrows >= ncols.
+                    let nrows = cmp::min(cmp::max(d1, d2), 10);
+                    let ncols = cmp::min(cmp::min(d1, d2), nrows);
+                    let nb    = cmp::min(nb, 10);
+
+                    let m  = DMatrix::<$scalar_type>::new_random(nrows, ncols).map(|e| e.0);
+                    let qr = m.clone().qr();
+                    let b  = DMatrix::<$scalar_type>::new_random(nrows, nb).map(|e| e.0);
+
+                    // QR gives the least-squares solution, so we cannot assert `m * x == b`.
+                    // Instead we check the normal equations `Aᴴ A x == Aᴴ b` that define it.
+                    if let Some(x) = qr.solve(&b) {
+                        prop_assert!(relative_eq!(
+                            m.adjoint() * &m * &x, m.adjoint() * &b,
+                            epsilon = 1.0e-5, max_relative = 1.0e-5
+                        ));
+                    }
+                }
+
+                #[test]
+                fn qr_solve_overdetermined_static(m in matrix5x3_($scalar)) {
+                    let qr = m.qr();
+                    let b1 = Vector5::<$scalar_type>::new_random().map(|e| e.0);
+                    let b2 = Matrix5x2::<$scalar_type>::new_random().map(|e| e.0);
+
+                    // Overdetermined 5x3: verify the least-squares normal equations.
+                    if let Some(sol1) = qr.solve(&b1) {
+                        prop_assert!(relative_eq!(
+                            m.adjoint() * m * sol1, m.adjoint() * b1,
+                            epsilon = 1.0e-5, max_relative = 1.0e-5
+                        ));
+                    }
+                    if let Some(sol2) = qr.solve(&b2) {
+                        prop_assert!(relative_eq!(
+                            m.adjoint() * m * sol2, m.adjoint() * b2,
+                            epsilon = 1.0e-5, max_relative = 1.0e-5
+                        ));
+                    }
                 }
 
                 #[test]


### PR DESCRIPTION
## Summary

Closes #1579.

`QR::solve` / `solve_mut` previously asserted `is_square()` and panicked on any
non-square matrix. They now solve overdetermined (`m ≥ n`) systems in the
**least-squares** sense (minimizing ‖Ax − b‖₂), consistent with `SVD::solve`,
`nalgebra-lapack`'s `QR::solve`, and Julia/Octave's `A \ b`.

The decomposition already supported non-square matrices; only the solve was
restricted. The algorithm is the standard thin-QR least squares: apply `Qᵀ` to `b`
in place (Householder), keep the first `n` rows, back-substitute `R₁ x = (Qᵀb)[..n]`.

## Changes

- Moved `solve` / `solve_mut` / `solve_upper_triangular_mut` into the general
  `impl<T, R: DimMin<C>, C: Dim>` block; `try_inverse` / `is_invertible` stay square-only.
- `solve_mut`: `is_square()` assertion → `nrows ≥ ncols` (underdetermined still panics).
  The solution lands in the first `ncols` rows of `b`; the trailing rows hold `Qᵀb`'s
  tail, whose per-column norm is the least-squares residual.
- `solve`: now returns an `ncols`-row matrix (`OMatrix<T, C, C2>`); source-compatible
  for square systems.
- Documented the full-column-rank assumption (use `ColPivQR` / `SVD` for rank-deficient cases).

## Tests

Added proptests (f64 + complex, dynamic + static 5×3) verifying the least-squares
normal equations `Aᴴ A x = Aᴴ b`:

    cargo test --features "arbitrary,debug,compare,rand,macros,proptest-support" qr

## Notes

- `ColPivQR::solve` has the same square-only limitation; left for a focused follow-up
  (needs care with the column-pivot permutation).
- Per discussion in the issue, the least-squares residual is recoverable from
  `solve_mut`'s output, so no separate `(solution, residual)` method was added.

Note: I did this with the help of Claude. If this is against your rules or the PR is garbage, maybe it can still serve as template for the issue.